### PR TITLE
Don't do coverage for vendor/bundle

### DIFF
--- a/lib/simplecov/adapters.rb
+++ b/lib/simplecov/adapters.rb
@@ -40,6 +40,9 @@ SimpleCov.adapters.define 'rails' do
   add_filter '/features/'
   add_filter '/spec/'
   add_filter '/config/'
+  add_filter '/db/'
+  add_filter '/autotest/'
+  add_filter '/vendor/bundle/'
   
   add_group 'Controllers', 'app/controllers'
   add_group 'Models', 'app/models'


### PR DESCRIPTION
Add in the filter for vendor/bundle as we don't need to test the gems.
