### PR TITLE
Clearer Framework/Library Agnosticism

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -26,8 +26,8 @@ Then, add the following to your Rails test/test_helper.rb (right at the top, lin
 
 Now, when running rake test you'll get a coverage/ folder inside your app's root where you can browse your code coverage.
 
-If you're making a Rails application, SimpleCov comes with a built-in adaptor (see below) for it which will give you handy
-tabs in the output webpage for your Comtrollers, Views, Models, etc. To use it the first two lines of your test_helper should
+If you're making a Rails application, SimpleCov comes with a built-in adapter (see below) for it which will give you handy
+tabs in the output webpage for your Controllers, Views, Models, etc. To use it, the first two lines of your test_helper should
 be like this:
 
   require 'simplecov'


### PR DESCRIPTION
This is a pull-request for [something that came up on Twitter](http://atreply.net/reply_chain?id=http://twitter.com/benhamill/statuses/35911500937826304). When I first saw the README, I got the impression that SimpleCov was Rails-centric. I feel like rewording the "Basic Usage" section a bit would avoid that kind of impression. See what you think of this wording.
