### PR TITLE
handle source files which are subsequently deleted

### DIFF
--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -21,7 +21,9 @@ module SimpleCov
     # coverage data)
     def initialize(original_result)
       @original_result = original_result.freeze
-      @files = original_result.map {|filename, coverage| SimpleCov::SourceFile.new(filename, coverage)}.sort_by(&:filename)
+      @files = original_result.map {|filename, coverage|
+        SimpleCov::SourceFile.new(filename, coverage) if File.file?(filename)
+      }.compact.sort_by(&:filename)
       filter!
     end
   

--- a/test/fixtures/deleted_source_sample.rb
+++ b/test/fixtures/deleted_source_sample.rb
@@ -1,0 +1,15 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
+require 'lib/simplecov'
+SimpleCov.start
+
+dir = File.expand_path(File.dirname(__FILE__))
+file = File.join(dir, "generated_buddha.rb")
+code = %{
+  def kill_the_buddha(z)
+    z**z
+  end
+}
+File.open(file, "w") { |f| f.print code }
+load file
+File.unlink file
+raise unless kill_the_buddha(3) == 27

--- a/test/test_deleted_source.rb
+++ b/test/test_deleted_source.rb
@@ -1,0 +1,14 @@
+require 'helper'
+
+class TestDeletedSource < Test::Unit::TestCase
+  on_ruby '1.8', '1.9' do
+    context "A source file which is subsequently deleted" do
+      should "not cause an error" do
+        Dir.chdir(File.join(File.dirname(__FILE__), 'fixtures')) do
+          `ruby deleted_source_sample.rb`
+          assert_equal 0, $?.exitstatus
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Without the change to result.rb the test will produce:

lib/simplecov/source_file.rb:56:in `readlines': No such file or directory - /path/to/generated_buddha.rb (Errno::ENOENT)
