### PR TITLE
Return coverage calculations on all files or on a requested subset

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,11 +9,7 @@ SimpleCov.coverage_dir('tmp/coverage')
 
 class Test::Unit::TestCase
   def source_fixture(filename)
-    File.expand_path relative_source_fixture(filename)
-  end
-
-  def relative_source_fixture(filename)
-    File.join(File.dirname(__FILE__), 'fixtures', filename)
+    File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', filename))
   end
 
   # Keep 1.8-rubies from complaining about missing tests in each file that covers only 1.9 functionality

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -65,34 +65,23 @@ class TestResult < Test::Unit::TestCase
         end
       end
 
-      context "with a non-empty file whitelist" do
+      context "with a file whitelist" do
         setup do
           original_result = {source_fixture('sample.rb') => [nil, 0, 1, 0, nil, nil, 0, 0, nil, nil],
             source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
             source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
           @result = SimpleCov::Result.new(original_result)
-          @result.file_whitelist = [relative_source_fixture("app/models/user.rb"),
-            relative_source_fixture("app/controllers/sample_controller.rb")]
+          @result.file_whitelist = @result.files[0..1]
         end
 
         should "have 80% coverage" do
           assert_equal 100.0*8/10, @result.covered_percent
         end
 
-        context "that has been initialized by a hash" do
-          setup do @result.file_whitelist = {
-            relative_source_fixture("sample.rb") => true }
-          end
-
-          should "have 20% coverage" do
-            assert_equal 100.0*1/5, @result.covered_percent
-          end
-        end
-
         context "that has been reset" do
-          setup { @result.reset_file_whitelist! }
+          setup { @result.reset_file_whitelist }
 
-          should "have 60% coverage" do
+          should "have 60% coverage because all files are included again" do
             assert_equal 100.0*9/15, @result.covered_percent
           end
         end


### PR DESCRIPTION
I added a file_whitelist concept to the Result class so that you can get coverage calculations only on certain files when desired. When not set, it returns coverage on all (non-filtered) files like before. I added tests and verified that the existing ones still pass.

Next I'll submit a pull request on simplecov-html to take advantage of this new code.
