### PR TITLE
Update to SimpleCov gemspec

### DIFF
--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "cucumber", "~> 1.0.0"
   s.add_development_dependency "rake", "<= 0.9.0" # This is required since 0.9.1 breaks compatibility with Ruby 1.8.6...
   s.add_development_dependency "rspec", ">= 2.6.0"
-  s.add_development_dependency "shoulda", "2.10.3"
+  s.add_development_dependency "shoulda", "~> 2.10.3"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Hello Christoph,
I was was receiving the following error when trying to install SimpleCov 0.5.0:

Invalid gemspec in [/Users/jspradlin/.rvm/gems/ruby-1.9.2-p180@jonesy/specifications/simplecov-0.5.0.gemspec]: Illformed requirement ["#Syck::DefaultKey:0x00000109f9e4f8 2.10.3"]

I updated the simplecov.gemspec file to install shoulda as a development dependency using the following syntax:  

s.add_development_dependency "shoulda", "~> 2.10.3"

instead of

s.add_development_dependency "shoulda", "2.10.3"

After making this change I was able to install simplecov 0.5.0 without any problems.  I ran all of the test and everything still passes.

Thanks,
Justin

My environment is

Ruby 1.9.2-p180
Gem: 1.8.10
Rails 3.1
Mac OSX
