### PR TITLE
automagic `rake simplecov` task for Rails 3

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -119,3 +119,6 @@ require 'simplecov/version'
 
 # Load default config
 require 'simplecov/defaults'
+
+# Load Rails integration
+require 'simplecov/railtie' if defined? Rails

--- a/lib/simplecov/railtie.rb
+++ b/lib/simplecov/railtie.rb
@@ -1,0 +1,7 @@
+module SimpleCov
+  class Railtie < ::Rails::Railtie
+    rake_tasks do
+      load 'simplecov/railties/tasks.rake'
+    end
+  end
+end

--- a/lib/simplecov/railties/tasks.rake
+++ b/lib/simplecov/railties/tasks.rake
@@ -1,0 +1,11 @@
+require 'rake/testtask'
+Rake::TestTask.new do |t|
+  t.name = 'simplecov'
+  t.loader = :direct # uses require() which skips PWD in Ruby 1.9
+  t.libs.push 'test', 'spec', Dir.pwd
+  t.test_files = FileList['{test,spec}/**/*_{test,spec}.rb']
+  t.ruby_opts.push '-r', 'simplecov', '-e', 'SimpleCov.start(:rails)'.inspect
+end
+
+require 'rake/clean'
+CLOBBER.include 'coverage'


### PR DESCRIPTION
This commit defines a Railtie that automatically defines a "simplecov"
Rake task that runs the Rails app's entire test suite under SimpleCov.

The user simply needs to add the following snippet to their Gemfile:

``` ruby
group :development, :test do
  gem 'simplecov'
end
```

And everything else is taken care of automagically by Rails 3! :sparkles:
