### PR TITLE
Fix for defining groups based on a custom filter class.

### DIFF
--- a/features/rspec_groups_using_filter_class.feature
+++ b/features/rspec_groups_using_filter_class.feature
@@ -1,0 +1,40 @@
+@rspec
+Feature: Grouping on RSpec using a custom filter class
+
+  Next to passing a block or a string to define a group, you can also pass
+  a filter class. The filter class inherits from SimpleCov::Filter and 
+  must implement the matches? method, which is used to determine whether 
+  or not a file should be added to the group. 
+
+  Scenario:
+    Given SimpleCov for RSpec is configured with:
+      """
+      require 'simplecov'
+      class CoverageFilter < SimpleCov::Filter
+        def matches?(source_file)
+          source_file.covered_percent < filter_argument
+        end
+      end
+      SimpleCov.start do
+        add_group 'By filter class', CoverageFilter.new(90)
+        add_group 'By string', 'project/meta_magic'
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rspec spec`
+    Then I should see the groups:
+      | name             | coverage | files |
+      | All Files        | 90.74%   | 6     |
+      | By filter class  | 78.26%   | 2     |
+      | By string        | 100.0%   | 1     |
+      | Ungrouped        | 100.0%   | 3     |
+
+    And I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project/framework_specific.rb | 75.0 %   | 
+      | lib/faked_project/some_class.rb         | 80.0 %   |
+      | lib/faked_project.rb                    | 100.0 %  |
+      | lib/faked_project/meta_magic.rb         | 100.0 %  |
+      | spec/meta_magic_spec.rb                 | 100.0 %  |
+      | spec/some_class_spec.rb                 | 100.0 %  |
+

--- a/features/test_unit_groups_using_filter_class.feature
+++ b/features/test_unit_groups_using_filter_class.feature
@@ -1,0 +1,40 @@
+@test_unit
+Feature: Grouping on Test/Unit using a custom filter class
+
+  Next to passing a block or a string to define a group, you can also pass
+  a filter class. The filter class inherits from SimpleCov::Filter and 
+  must implement the matches? method, which is used to determine whether 
+  or not a file should be added to the group. 
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      class CoverageFilter < SimpleCov::Filter
+        def matches?(source_file)
+          source_file.covered_percent < filter_argument
+        end
+      end
+      SimpleCov.start do
+        add_group 'By filter class', CoverageFilter.new(90)
+        add_group 'By string', 'project/meta_magic'
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+    Then I should see the groups:
+      | name             | coverage | files |
+      | All Files        | 91.38%   | 6     |
+      | By filter class  | 78.26%   | 2     |
+      | By string        | 100.0%   | 1     |
+      | Ungrouped        | 100.0%   | 3     |
+
+    And I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project/framework_specific.rb | 75.0 %   | 
+      | lib/faked_project/some_class.rb         | 80.0 %   |
+      | lib/faked_project.rb                    | 100.0 %  |
+      | lib/faked_project/meta_magic.rb         | 100.0 %  |
+      | test/meta_magic_test.rb                 | 100.0 %  |
+      | test/some_class_test.rb                 | 100.0 %  |
+

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -60,7 +60,7 @@ module SimpleCov
     def filtered(files)
       result = files.clone
       filters.each do |filter|
-        result = result.select {|source_file| filter.passes?(source_file) }
+        result = result.reject {|source_file| filter.matches?(source_file) }
       end
       SimpleCov::FileList.new result
     end
@@ -72,7 +72,7 @@ module SimpleCov
       grouped = {}
       grouped_files = []
       groups.each do |name, filter|
-        grouped[name] = SimpleCov::FileList.new(files.select {|source_file| !filter.passes?(source_file)})
+        grouped[name] = SimpleCov::FileList.new(files.select {|source_file| filter.matches?(source_file)})
         grouped_files += grouped[name]
       end
       if groups.length > 0 and (other_files = files.reject {|source_file| grouped_files.include?(source_file)}).length > 0

--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -16,7 +16,7 @@ module SimpleCov
       @filter_argument = filter_argument
     end
 
-    def passes?(source_file)
+    def matches?(source_file)
       raise "The base filter class is not intended for direct use"
     end
   end
@@ -24,16 +24,16 @@ module SimpleCov
   class StringFilter < SimpleCov::Filter
     # Returns true when the given source file's filename matches the
     # string configured when initializing this Filter with StringFilter.new('somestring)
-    def passes?(source_file)
-      !(source_file.filename =~ /#{filter_argument}/)
+    def matches?(source_file)
+      (source_file.filename =~ /#{filter_argument}/)
     end
   end
 
   class BlockFilter < SimpleCov::Filter
     # Returns true if the block given when initializing this filter with BlockFilter.new {|src_file| ... }
     # returns true for the given source file.
-    def passes?(source_file)
-      !filter_argument.call(source_file)
+    def matches?(source_file)
+      filter_argument.call(source_file)
     end
   end
 end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -7,32 +7,32 @@ class TestFilters < Test::Unit::TestCase
         @source_file = SimpleCov::SourceFile.new(source_fixture('sample.rb'), [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
       end
 
-      should "pass a new SimpleCov::StringFilter 'foobar'" do
-        assert SimpleCov::StringFilter.new('foobar').passes?(@source_file)
+      should "not match a new SimpleCov::StringFilter 'foobar'" do
+        assert !SimpleCov::StringFilter.new('foobar').matches?(@source_file)
       end
 
-      should "pass a new SimpleCov::StringFilter 'some/path'" do
-        assert SimpleCov::StringFilter.new('some/path').passes?(@source_file)
+      should "not match a new SimpleCov::StringFilter 'some/path'" do
+        assert !SimpleCov::StringFilter.new('some/path').matches?(@source_file)
       end
 
-      should "not pass a new SimpleCov::StringFilter 'test/fixtures'" do
-        assert !SimpleCov::StringFilter.new('test/fixtures').passes?(@source_file)
+      should "match a new SimpleCov::StringFilter 'test/fixtures'" do
+        assert SimpleCov::StringFilter.new('test/fixtures').matches?(@source_file)
       end
 
-      should "not pass a new SimpleCov::StringFilter 'test/fixtures/sample.rb'" do
-        assert !SimpleCov::StringFilter.new('test/fixtures/sample.rb').passes?(@source_file)
+      should "match a new SimpleCov::StringFilter 'test/fixtures/sample.rb'" do
+        assert SimpleCov::StringFilter.new('test/fixtures/sample.rb').matches?(@source_file)
       end
 
-      should "not pass a new SimpleCov::StringFilter 'sample.rb'" do
-        assert !SimpleCov::StringFilter.new('sample.rb').passes?(@source_file)
+      should "match a new SimpleCov::StringFilter 'sample.rb'" do
+        assert SimpleCov::StringFilter.new('sample.rb').matches?(@source_file)
       end
 
-      should "pass a new SimpleCov::BlockFilter that is not applicable" do
-        assert SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'foo.rb'}).passes?(@source_file)
+      should "not match a new SimpleCov::BlockFilter that is not applicable" do
+        assert !SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'foo.rb'}).matches?(@source_file)
       end
 
-      should "not pass a new SimpleCov::BlockFilter that is applicable" do
-        assert !SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'sample.rb'}).passes?(@source_file)
+      should "match a new SimpleCov::BlockFilter that is applicable" do
+        assert SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'sample.rb'}).matches?(@source_file)
       end
     end
 


### PR DESCRIPTION
### Problem

The following **LineFilter** example is mentioned in the documentation of SimpleCov. I tried this out and configured SimpleCov as follows:

```
class LineFilter &lt; SimpleCov::Filter
  def passes?(source_file)
    source_file.lines.count < filter_argument
  end
end

SimpleCov.start 'rails' do
  add_group "Short files", LineFilter.new(5)
end
```

Instead of showing me the files that have less then 5 lines, the tab 'Short files' contains all files that are greater than or equal to 5 lines. 
### Fixes

The initial fix was removing the negation from the `grouped` method in `lib/simplecov.rb`. This led to some underlying problems in the **SimpleCov::Filter** classes.

I renamed the `passes?` method to `matches?` and also removed the negation that was present. The comments in the **StringFilter** and **LineFilter** class now match the code :)  The changes made in `test/test_filters.rb` are trivial changes because of the removed negation.

I also had to change the `filtered` method in `lib/simplecov.rb`. This method now removes (or reject) all files that match the filter. This is functionally still the same. 

I added a specific feature for testing the custom filter class (no existing one was present). 
