### PR TITLE
Treat source files as UTF-8 to avoid encoding errors

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -77,7 +77,8 @@ module SimpleCov
     alias_method :source, :src
 
     def initialize(filename, coverage)
-      @filename, @coverage, @src = filename, coverage, File.readlines(filename)
+      @filename, @coverage = filename, coverage
+      File.open(filename, "r:UTF-8") {|f| @src = f.readlines }
     end
 
     # Returns all source lines for this file as instances of SimpleCov::SourceFile::Line,

--- a/test/fixtures/utf-8.rb
+++ b/test/fixtures/utf-8.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+
+puts '135°C'

--- a/test/test_source_file.rb
+++ b/test/test_source_file.rb
@@ -71,5 +71,16 @@ class TestSourceFile < Test::Unit::TestCase
         assert_match /^Warning: coverage data provided/, captured_output
       end
     end
+
+    context "Encoding" do
+      should "handle utf-8 encoded source files" do
+        source_file = SimpleCov::SourceFile.new(source_fixture('utf-8.rb'), [nil, nil, 1])
+
+        assert_nothing_raised do
+          source_file.process_skipped_lines!
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Avoid errors like this:
gems/simplecov-0.5.4/lib/simplecov/source_file.rb:158:in `block in process_skipped_lines!': invalid byte sequence in US-ASCII (ArgumentError)

A fixture file is included which contains a degree symbol. The line containing the symbol currently causes the above exception.
