### PR TITLE
Conform to multijson 1.3.1: MultiJson.decode is now MultiJson.load

### DIFF
--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -15,7 +15,7 @@ module SimpleCov::ResultMerger
     # Loads the cached resultset from YAML and returns it as a Hash
     def resultset
       if stored_data
-        MultiJson.decode(stored_data)
+        MultiJson.load(stored_data)
       else
         {}
       end


### PR DESCRIPTION
i updated to the latest multijson and saw this deprecation message:

```
.../simplecov-0.6.1/lib/simplecov/result_merger.rb:18:in `resultset': [DEPRECATION] MultiJson.decode is deprecated and will be removed in the next major version. Use MultiJson.load instead.
```

so made the change
