### PR TITLE
Prevent divisions by zero

### DIFF
--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -44,6 +44,7 @@ module SimpleCov
 
     # The multiple of coverage for this result
     def covered_strength
+      return 0 if total_lines.zero?
       return @covered_strength if @covered_strength
       m = 0
       @files.each do |file|

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -109,7 +109,9 @@ module SimpleCov
     # The coverage for this file in percent. 0 if the file has no relevant lines
     def covered_percent
       return 100.0 if lines.length == 0 or lines.length == never_lines.count
-      (covered_lines.count) * 100 / (lines.count - never_lines.count - skipped_lines.count).to_f
+      relevant_lines = lines.count - never_lines.count - skipped_lines.count
+      return 0 if relevant_lines == 0
+      (covered_lines.count) * 100 / relevant_lines.to_f
     end
 
     def covered_strength
@@ -119,6 +121,7 @@ module SimpleCov
         lines_strength += c.coverage if c.coverage
       end
       effective_lines_count = (lines.count - never_lines.count - skipped_lines.count).to_f
+      return 0 if effective_lines_count == 0
       strength = lines_strength / effective_lines_count
       round_float(strength, 1)
     end


### PR DESCRIPTION
There are a few cases where divisions by zero were possible.
When the happens the HTML reporter fails like this:

```
/home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/source_file.rb:171:in `round': NaN (FloatDomainError)
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/source_file.rb:171:in `round_float'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/source_file.rb:123:in `covered_strength'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/file_list.rb:42:in `block in covered_strength'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/file_list.rb:42:in `map'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/file_list.rb:42:in `covered_strength'
    from (erb):7:in `formatted_file_list'
    from /home/golly/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/erb.rb:838:in `eval'
    from /home/golly/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/erb.rb:838:in `result'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/gems/simplecov-html-0.5.3/lib/simplecov-html.rb:53:in `formatted_file_list'
    from (erb):30:in `block in format'
    from /home/golly/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/erb.rb:838:in `eval'
    from /home/golly/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/erb.rb:838:in `result'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/gems/simplecov-html-0.5.3/lib/simplecov-html.rb:19:in `block in format'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/gems/simplecov-html-0.5.3/lib/simplecov-html.rb:18:in `open'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/gems/simplecov-html-0.5.3/lib/simplecov-html.rb:18:in `format'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/result.rb:90:in `format!'
    from /home/golly/projects/ruby_ext/.simplecov:32:in `block in <top (required)>'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/defaults.rb:51:in `call'
    from /home/golly/.rvm/gems/ruby-1.9.3-p125/bundler/gems/simplecov-8b3a937fe213/lib/simplecov/defaults.rb:51:in `block in <top (required)>'
```

Considered writing test cases for this but decided it's not worth it.
All existing tests pass with this fix.
