### PR TITLE
Workaround failing travis-ci by uninstalling json.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - echo "yes" | gem uninstall json
 script:
   - bundle
   - rake appraisal:install


### PR DESCRIPTION
The travis-ci status was failing. According to the travis-ci folks, the workaround for the error you were getting in jobs like http://travis-ci.org/#!/colszowka/simplecov/jobs/1464724 was to remove the `json` gem before installing: https://github.com/travis-ci/travis-ci/issues/568 . With this change, all tests pass on all platforms: http://travis-ci.org/#!/igal/simplecov
