### PR TITLE
Allow the build to fail with ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ rvm:
   - ree
   - rbx-18mode
   - jruby-18mode
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 notifications:
   email:
     on_success: always


### PR DESCRIPTION
This will turn Travis badge back to green allowing the build for `ruby-head` to fail.
I guess there is little point in failing the whole CI for this.
