### PR TITLE
Support for minimal coverage and maximal coverage drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,17 @@ You can define what simplecov should do when your test suite finishes by customi
 
 Above is the default behaviour. Do whatever you like instead!
 
+### Minimum coverage
+
+You can define the minimum coverage percentage expected. SimpleCov will return non-zero if unmet.
+
+    SimpleCov.minimum_coverage = 90
+
+### Maximum coverage drop
+
+You can define the maximum coverage drop percentage at once. SimpleCov will return non-zero if exceeded.
+
+    SimpleCov.maximum_coverage_drop = 5
 
 ## Using your own formatter
 

--- a/features/maximum_coverage_drop.feature
+++ b/features/maximum_coverage_drop.feature
@@ -1,0 +1,36 @@
+@test_unit @config
+Feature:
+
+  Exit code should be non-zero if the overall coverage decreases by more than
+  the maximum_coverage_drop threshold.
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        maximum_coverage_drop 2
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should be 0
+    And a file named "coverage/.last_run.json" should exist
+
+    Given a file named "lib/faked_project/missed.rb" with:
+      """
+      class UncoveredSourceCode
+        def foo
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should contain "Coverage has dropped by 3.31% since the last time (maximum allowed: 2.00%)."
+    And a file named "coverage/.last_run.json" should exist
+

--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -1,0 +1,32 @@
+@test_unit @config
+Feature:
+
+  Exit code should be non-zero if the overall coverage is below the
+  minimum_coverage threshold.
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        minimum_coverage 90
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should contain "Coverage (88.10%) is below the expected minimum coverage (90.00%)."
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should be 0
+

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -55,6 +55,14 @@ module SimpleCov
     end
 
     #
+    # Returns nil if the result has not been computed
+    # Otherwise, returns the result
+    #
+    def result?
+      defined? @result and @result
+    end
+
+    #
     # Applies the configured filters to the given array of SimpleCov::SourceFile items
     #
     def filtered(files)
@@ -105,12 +113,15 @@ end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__)))
 require 'simplecov/configuration'
 SimpleCov.send :extend, SimpleCov::Configuration
+require 'simplecov/exit_codes'
+require 'simplecov/json'
 require 'simplecov/adapters'
 require 'simplecov/source_file'
 require 'simplecov/file_list'
 require 'simplecov/result'
 require 'simplecov/filter'
 require 'simplecov/formatter'
+require 'simplecov/last_run'
 require 'simplecov/merge_helpers'
 require 'simplecov/result_merger'
 require 'simplecov/command_guesser'

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -170,6 +170,28 @@ module SimpleCov::Configuration
   end
 
   #
+  # Defines the minimum overall coverage required for the testsuite to pass.
+  # SimpleCov will return non-zero if the current coverage is below this threshold.
+  #
+  # Default is 0% (disabled)
+  #
+  def minimum_coverage(coverage=nil)
+    @minimum_coverage = coverage if coverage.kind_of?(Fixnum)
+    @minimum_coverage ||= 0
+  end
+
+  #
+  # Defines the maximum coverage drop at once allowed for the testsuite to pass.
+  # SimpleCov will return non-zero if the coverage decreases by more than this threshold.
+  #
+  # Default is 100% (disabled)
+  #
+  def maximum_coverage_drop(coverage_drop=nil)
+    @maximum_coverage_drop = coverage_drop if coverage_drop.kind_of?(Fixnum)
+    @maximum_coverage_drop ||= 100
+  end
+
+  #
   # Add a filter to the processing chain.
   # There are three ways to define a filter:
   #

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -46,9 +46,36 @@ at_exit do
     #if it was a SystemExit, use the accompanying status
     #otherwise set a non-zero status representing termination by some other exception
     #(see github issue 41)
-    @exit_status = $!.is_a?(SystemExit) ? $!.status : 1
+    @exit_status = $!.is_a?(SystemExit) ? $!.status : SimpleCov::ExitCodes::EXCEPTION
   end
+
   SimpleCov.at_exit.call
+
+  if SimpleCov.result? # Result has been computed
+    if @exit_status.to_i == 0 # No other errors
+      @exit_status = if SimpleCov.result.covered_percent < SimpleCov.minimum_coverage
+        $stderr.puts "Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%)." % \
+                     [SimpleCov.result.covered_percent, SimpleCov.minimum_coverage]
+
+        SimpleCov::ExitCodes::MINIMUM_COVERAGE
+
+      elsif (last_run = SimpleCov::LastRun.read)
+        diff = last_run['result']['covered_percent'] - SimpleCov.result.covered_percent
+        if diff > SimpleCov.maximum_coverage_drop
+          $stderr.puts "Coverage has dropped by %.2f%% since the last time (maximum allowed: %.2f%%)." % \
+                       [diff, SimpleCov.maximum_coverage_drop]
+
+          SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
+        end
+      end
+    end
+
+    metrics = {
+      :result => { :covered_percent => SimpleCov.result.covered_percent }
+    }
+    SimpleCov::LastRun.write(metrics)
+  end
+
   exit @exit_status if @exit_status # Force exit with stored status (see github issue #5)
 end
 

--- a/lib/simplecov/exit_codes.rb
+++ b/lib/simplecov/exit_codes.rb
@@ -1,0 +1,5 @@
+module SimpleCov::ExitCodes
+  EXCEPTION = 1
+  MINIMUM_COVERAGE = 2
+  MAXIMUM_COVERAGE_DROP = 3
+end

--- a/lib/simplecov/json.rb
+++ b/lib/simplecov/json.rb
@@ -1,0 +1,27 @@
+require 'multi_json'
+
+module SimpleCov::JSON
+  class << self
+    def parse(json)
+      # Detect and use available MultiJson API - it changed in v1.3
+      if MultiJson.respond_to?(:adapter)
+        MultiJson.load(json)
+      else
+        MultiJson.decode(json)
+      end
+    end
+
+    def dump(string)
+      if defined? ::JSON
+        ::JSON.pretty_generate(string)
+      else
+        # Detect and use available MultiJson API - it changed in v1.3
+        if MultiJson.respond_to?(:adapter)
+          MultiJson.dump(string)
+        else
+          MultiJson.encode(string)
+        end
+      end
+    end
+  end
+end

--- a/lib/simplecov/last_run.rb
+++ b/lib/simplecov/last_run.rb
@@ -1,0 +1,20 @@
+module SimpleCov::LastRun
+  class << self
+    def last_run_path
+      File.join(SimpleCov.coverage_path, '.last_run.json')
+    end
+
+    def read
+      return nil unless File.exist?(last_run_path)
+
+      SimpleCov::JSON.parse(File.read(last_run_path))
+    end
+
+    def write(json)
+      File.open(last_run_path, "w+") do |f|
+        f.puts SimpleCov::JSON.dump(json)
+      end
+    end
+  end
+end
+

--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -1,5 +1,3 @@
-require 'multi_json'
-
 #
 # Singleton that is responsible for caching, loading and merging
 # SimpleCov::Results into a single result for coverage analysis based
@@ -15,12 +13,7 @@ module SimpleCov::ResultMerger
     # Loads the cached resultset from YAML and returns it as a Hash
     def resultset
       if stored_data
-        # Detect and use available MultiJson API - it changed in v1.3
-        if MultiJson.respond_to?(:adapter)
-          MultiJson.load(stored_data)
-        else
-          MultiJson.decode(stored_data)
-        end
+        SimpleCov::JSON.parse(stored_data)
       else
         {}
       end
@@ -73,16 +66,7 @@ module SimpleCov::ResultMerger
       command_name, data = result.to_hash.first
       new_set[command_name] = data
       File.open(resultset_path, "w+") do |f|
-        if defined? ::JSON
-          f.puts JSON.pretty_generate(new_set)
-        else
-          # Detect and use available MultiJson API - it changed in v1.3
-          if MultiJson.respond_to?(:adapter)
-            f.puts MultiJson.dump(new_set)
-          else
-            f.puts MultiJson.encode(new_set)
-          end
-        end
+        f.puts SimpleCov::JSON.dump(new_set)
       end
       true
     end


### PR DESCRIPTION
Here is a proposal to implement two new features:
- return non-zero if the coverage is below a defined threshold (`min_coverage`)
- return non-zero if the coverage has dropped by more than a defined threshold since the last build (`max_coverage_difference`)

Please let me know if you're happy with this so I would add some explanations in the README.

Also, I extracted the JSON handling to a separate file to avoid code duplication between `result_merger.rb` and `last_run.rb`.

Thanks for this neat Gem :).
