### PR TITLE
Add a refuse_coverage_drop configuration option

### DIFF
--- a/features/refuse_coverage_drop.feature
+++ b/features/refuse_coverage_drop.feature
@@ -1,0 +1,35 @@
+@test_unit @config
+Feature:
+
+  Exit code should be non-zero if the overall coverage decreases.
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        refuse_coverage_drop
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should be 0
+    And a file named "coverage/.last_run.json" should exist
+
+    Given a file named "lib/faked_project/missed.rb" with:
+      """
+      class UncoveredSourceCode
+        def foo
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should contain "Coverage has dropped by 3.31% since the last time (maximum allowed: 0.00%)."
+    And a file named "coverage/.last_run.json" should exist
+

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -192,6 +192,14 @@ module SimpleCov::Configuration
   end
 
   #
+  # Refuses any coverage drop. That is, coverage is only allowed to increase.
+  # SimpleCov will return non-zero if the coverage decreases.
+  #
+  def refuse_coverage_drop
+    maximum_coverage_drop 0
+  end
+
+  #
   # Add a filter to the processing chain.
   # There are three ways to define a filter:
   #


### PR DESCRIPTION
Just a really simple implementation of `refuse_coverage_drop` option as proposed in https://github.com/colszowka/simplecov/issues/11#issuecomment-7720023.
