### PR TITLE
Update .travis.yml to test with Rubinius 1.9 mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 1.9.3
   - ruby-head
   - ree
-  - rbx-18mode
+  - rbx-19mode
   - jruby-18mode
 matrix:
   allow_failures:


### PR DESCRIPTION
Test with Rubinius in 1.9 mode. There is no Coverage module
in Ruby 1.8.
