### PR TITLE
Makes SimpleCov resilient to inclusion of mathn library. (Re: #140)

### DIFF
--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -39,6 +39,6 @@ class SimpleCov::FileList < Array
   # Computes the strength (hits / line) based upon lines covered and lines missed
   def covered_strength
     return 0 if empty? or lines_of_code == 0
-    map {|f| f.covered_strength }.inject(&:+) / size
+    map {|f| f.covered_strength }.inject(&:+).to_f / size
   end
 end

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -114,7 +114,7 @@ module SimpleCov
       if relevant_lines == 0
         0
       else
-        (covered_lines.count) * 100 / relevant_lines.to_f
+        (covered_lines.count) * 100.0 / relevant_lines.to_f
       end
     end
 


### PR DESCRIPTION
Made sure SourceFile.covered_percent and FileList.covered_strength won't return Rationals even when 'mathn' has been included.

With the latest builds of MRI 1.9.3, it seems that dividing an Integer by a Float will return a Rational when 'mathn' is included, and calling .round() on a Rational currently causes a segfault.

Even though Rational.round shouldn't be segfaulting, it seems worthwhile to ensure that Simplecov returns a float for these methods with or without 'mathn' being present.

I understand if you would rather just wait for the core team to fix Rational.round, but this seemed like a simple enough fix to merit consideration.
