### PR TITLE
Don't misuse `Appraisal::File` instead of `::File`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "http://rubygems.org"
 gemspec
 
 # Uncomment this to use local copy of simplecov-html in development when checked out
-# gem 'simplecov-html', :path => File.dirname(__FILE__) + '/../simplecov-html'
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'


### PR DESCRIPTION
If you uncomment the [last line](https://github.com/colszowka/simplecov/blob/master/Gemfile#L5) in the `Gemfile` to hack around with a local copy of _simplecov-html_, `rake` runs into [this error](https://github.com/thoughtbot/appraisal/issues/39).

This minor patch avoids to misuse `Appraisal::File` instead of `::File`.
