### PR TITLE
Add support for command guessing in Rails 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.7.0...master))
 -------------------
 
+  * [FEATURE] Adds support for Rails 4 command guessing.
+
 v0.7.1, 2012-10-12 ([changes](https://github.com/colszowka/simplecov/compare/v0.7.0...v0.7.1))
 -------------------
 

--- a/lib/simplecov/command_guesser.rb
+++ b/lib/simplecov/command_guesser.rb
@@ -18,7 +18,7 @@ module SimpleCov::CommandGuesser
     
     def from_command_line_options
       case original_run_command
-        when /#{'test/functional/'}/
+        when /#{'test/functional/'}/, /#{'test/{.*?functional.*?}/'}/
           "Functional Tests"
         when /#{'test/integration/'}/
           "Integration Tests"

--- a/test/test_command_guesser.rb
+++ b/test/test_command_guesser.rb
@@ -11,9 +11,9 @@ class TestCommandGuesser < Test::Unit::TestCase
       end
     end
 
-    should_guess_command_name "Unit Tests", '/some/path/test/units/foo_bar_test.rb', 'test/units/foo.rb', 'test/foo.rb'
-    should_guess_command_name "Functional Tests", '/some/path/test/functional/foo_bar_controller_test.rb'
-    should_guess_command_name "Integration Tests", '/some/path/test/integration/foo_bar_controller_test.rb'
+    should_guess_command_name "Unit Tests", '/some/path/test/units/foo_bar_test.rb', 'test/units/foo.rb', 'test/foo.rb', 'test/{models,helpers,unit}/**/*_test.rb'
+    should_guess_command_name "Functional Tests", '/some/path/test/functional/foo_bar_controller_test.rb', 'test/{controllers,mailers,functional}/**/*_test.rb'
+    should_guess_command_name "Integration Tests", '/some/path/test/integration/foo_bar_controller_test.rb', 'test/integration/**/*_test.rb'
     should_guess_command_name "Cucumber Features", 'features', 'cucumber', 'cucumber features'
     should_guess_command_name "RSpec", '/some/path/spec/foo.rb'
     should_guess_command_name "Unit Tests", 'some_arbitrary_command with arguments' # Because Test::Unit const is defined!


### PR DESCRIPTION
Rails 4 issues the command

```
rake_test_loader.rb test/{controllers,mailers,functional}/**/*_test.rb
```

to run functional tests.

This adds a second clause to the case statement to properly guess that these are functional tests. I also added tests for each of the basic kinds of tests Rails 4 runs (integration/unit/functional).

I left the regex a little flexible in case the ordering of the "controllers,mailers,functional" part changes. It should still be plenty specific enough.

Thank you for a fantastic library.
