### PR TITLE
Fix command name detecting for capybara 2.0

### DIFF
--- a/features/config_command_name.feature
+++ b/features/config_command_name.feature
@@ -31,3 +31,15 @@ Feature: Custom names for individual test suites
       | Dreck macht Speck |
       | I'm in UR Unitz   |
 
+  Scenario: RSpec auto detection with spec/features
+    Given SimpleCov for RSpec is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start
+      """
+    And a file named "spec/features/foobar_spec.rb" with:
+      """
+      """
+    When I open the coverage report generated with `bundle exec rspec spec`
+    Then the report should be based upon:
+      | RSpec |

--- a/lib/simplecov/command_guesser.rb
+++ b/lib/simplecov/command_guesser.rb
@@ -11,11 +11,22 @@ module SimpleCov::CommandGuesser
     attr_accessor :original_run_command
     
     def guess
-      from_command_line_options || from_defined_constants
+      from_program_name || from_command_line_options || from_defined_constants
     end
     
     private
     
+    def from_program_name
+      case $PROGRAM_NAME
+        when /\/rspec$/
+          "RSpec"
+        when /\/cucumber$/
+          "Cucumber Features"
+        else
+          nil
+      end
+    end
+
     def from_command_line_options
       case original_run_command
         when /#{'test/functional/'}/, /#{'test/{.*?functional.*?}/'}/


### PR DESCRIPTION
With files named spec/features/foobar_spec.rb simplecov detected the
command as Cucumber Features. Now it looks at $PROGRAM_NAME first and
makes the proper guess for RSpec.
