### PR TITLE
allow :nocov: to be used inline

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -168,7 +168,7 @@ module SimpleCov
     def process_skipped_lines!
       skipping = false
       lines.each do |line|
-        if line.src =~ /^([\s]*)#([\s]*)(\:#{SimpleCov.nocov_token}\:)/
+        if line.src =~ /#([\s]*)(\:#{SimpleCov.nocov_token}\:)\s*$/
           skipping = !skipping
         else
           line.skipped! if skipping


### PR DESCRIPTION
The main reason for this patch is to allow code like:

``` ruby
def whocares # :nocov:
  # blah.. 
end # :nocov:
```

By allowing nocov to appear inline, it won't show up in docs. Alternatively, you can use only the closing tag inline if you still want it in docs but want a somewhat tidier appearance in source.
