### PR TITLE
Compatability with BINARY internal encoding

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -79,7 +79,7 @@ module SimpleCov
 
     def initialize(filename, coverage)
       @filename, @coverage = filename, coverage
-      File.open(filename, "r:UTF-8") {|f| @src = f.readlines }
+      File.open(filename, "r:UTF-8:UTF-8") {|f| @src = f.readlines }
     end
 
     # Returns all source lines for this file as instances of SimpleCov::SourceFile::Line,

--- a/test/test_source_file.rb
+++ b/test/test_source_file.rb
@@ -88,6 +88,20 @@ class TestSourceFile < Test::Unit::TestCase
           source_file.process_skipped_lines!
         end
       end
+
+      should "handle utf-8 encoded source files when the default_internal encoding is binary" do
+        original_internal_encoding = Encoding.default_internal
+        Encoding.default_internal = "BINARY"
+        begin
+          source_file = SimpleCov::SourceFile.new(source_fixture('utf-8.rb'), [nil, nil, 1])
+        ensure
+          Encoding.default_internal = original_internal_encoding
+        end
+
+        assert_nothing_raised do
+          source_file.process_skipped_lines!
+        end
+      end
     end
 
   end


### PR DESCRIPTION
- Specify the default_internal encoding as UTF-8 when reading source
  files. This fixes Issue #127.

This issue was recommended by obieq here: https://github.com/colszowka/simplecov/issues/127#issuecomment-10436774
