### PR TITLE
allow global configuration with ~/.simplecov

### DIFF
--- a/features/config_styles.feature
+++ b/features/config_styles.feature
@@ -91,3 +91,19 @@ Feature:
     Then I should see "4 files in total."
     And I should see "using Config Test Runner" within "#footer"
 
+  Scenario: Global config and local config
+    Given a file named "~/.simplecov" with:
+      """
+      SimpleCov.configure do
+        add_filter 'test'
+      end
+      """
+    And a file named ".simplecov" with:
+      """
+      SimpleCov.command_name 'Config Test Runner'
+      SimpleCov.start
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+    Then I should see "4 files in total."
+    And I should see "using Config Test Runner" within "#footer"

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -82,5 +82,8 @@ at_exit do
 end
 
 # Autoload config from .simplecov if present
+global_config_path = File.join(File.expand_path("~"), '.simplecov')
+load global_config_path if File.exist?(global_config_path)
+
 config_path = File.join(SimpleCov.root, '.simplecov')
 load config_path if File.exist?(config_path)


### PR DESCRIPTION
I posted a [message to the mailing list](https://groups.google.com/d/topic/simplecov/Y2oZRGwyXRg/discussion) about this, then realized it was a simple change to implement. Essentially the change loads `~/.simplecov` prior to a local `.simplecov` allowing global configurations to be set.

I took at stab at writing a test but am having difficulty with the appraisal gem (I believe for the same reason as mentioned in the mailing list post). Looking forward to feedback.
