### PR TITLE
Refactor on_ruby helper to handle Ruby 2.0

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -2,11 +2,8 @@
 # Code coverage for ruby 1.9. Please check out README for a full introduction.
 #
 module SimpleCov
-  # Indicates invalid coverage data
-  class CoverageDataError < StandardError; end;
-
   class << self
-    attr_accessor :running#, :result # TODO: Remove result?
+    attr_accessor :running
 
     #
     # Sets up SimpleCov to run against your project.
@@ -27,11 +24,6 @@ module SimpleCov
     #
     def start(adapter=nil, &block)
       if SimpleCov.usable?
-        unless defined? Coverage
-          require 'coverage'
-          require 'simplecov/jruby16_fix'
-        end
-
         load_adapter(adapter) if adapter
         configure(&block) if block_given?
         @result = nil
@@ -104,11 +96,19 @@ module SimpleCov
     end
 
     #
-    # Checks whether we're on a proper version of ruby (1.9+) and returns false if this is not the case,
-    # also printing an appropriate warning
+    # Checks whether we're on a proper version of Ruby (likely 1.9+) which
+    # provides coverage support
     #
     def usable?
-      "1.9".respond_to?(:encoding)
+      return @usable unless @usable.nil?
+
+      @usable = begin
+        require 'coverage'
+        require 'simplecov/jruby16_fix'
+        true
+      rescue LoadError
+        false
+      end
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,7 +13,6 @@ class Test::Unit::TestCase
   # Keep 1.8-rubies from complaining about missing tests in each file that covers only 1.9 functionality
   def default_test
   end
-
 end
 
 require 'shoulda_macros'

--- a/test/shoulda_macros.rb
+++ b/test/shoulda_macros.rb
@@ -1,14 +1,4 @@
 module ShouldaMacros
-  #
-  # Simple block helper for running certain tests only on specific ruby versions.
-  # The given strings will be regexp-matched against RUBY_VERSION
-  #
-  def on_ruby(*ruby_versions)
-    context "On Ruby #{RUBY_VERSION}" do
-      yield
-    end if ruby_versions.any? {|v| RUBY_VERSION =~ /#{v}/ }
-  end
-
   def should_be(boolean_flag)
     should "be #{boolean_flag}" do
       assert_equal true, subject.send(boolean_flag)

--- a/test/test_1_8_fallbacks.rb
+++ b/test/test_1_8_fallbacks.rb
@@ -7,27 +7,25 @@ require 'helper'
 # be called in a test/spec-helper simplecov config block
 #
 class Test18FallBacks < Test::Unit::TestCase
-  on_ruby '1.8' do
-    should "return false when calling SimpleCov.start" do
-      assert_equal false, SimpleCov.start
-    end
+  should "return false when calling SimpleCov.start" do
+    assert_equal false, SimpleCov.start
+  end
 
-    should "return false when calling SimpleCov.start with a block" do
-      assert_equal false, SimpleCov.start { raise "Shouldn't reach this!?" }
-    end
+  should "return false when calling SimpleCov.start with a block" do
+    assert_equal false, SimpleCov.start { raise "Shouldn't reach this!?" }
+  end
 
-    should "return false when calling SimpleCov.configure with a block" do
-      assert_equal false, SimpleCov.configure { raise "Shouldn't reach this!?" }
-    end
+  should "return false when calling SimpleCov.configure with a block" do
+    assert_equal false, SimpleCov.configure { raise "Shouldn't reach this!?" }
+  end
 
-    should "allow to define an adapter" do
-      begin
-        SimpleCov.adapters.define 'testadapter' do
-          add_filter '/config/'
-        end
-      rescue => err
-        assert false, "Adapter definition should have been fine, but raised #{err}"
+  should "allow to define an adapter" do
+    begin
+      SimpleCov.adapters.define 'testadapter' do
+        add_filter '/config/'
       end
+    rescue => err
+      assert false, "Adapter definition should have been fine, but raised #{err}"
     end
   end
-end
+end if RUBY_VERSION.start_with? '1.8'

--- a/test/test_command_guesser.rb
+++ b/test/test_command_guesser.rb
@@ -1,21 +1,19 @@
 require 'helper'
 
 class TestCommandGuesser < Test::Unit::TestCase
-  on_ruby '1.9' do
-    def self.should_guess_command_name(expectation, *argv)
-      argv.each do |args|
-        should "return '#{expectation}' for '#{args}'" do
-          SimpleCov::CommandGuesser.original_run_command = args
-          assert_equal expectation, SimpleCov::CommandGuesser.guess
-        end
+  def self.should_guess_command_name(expectation, *argv)
+    argv.each do |args|
+      should "return '#{expectation}' for '#{args}'" do
+        SimpleCov::CommandGuesser.original_run_command = args
+        assert_equal expectation, SimpleCov::CommandGuesser.guess
       end
     end
-
-    should_guess_command_name "Unit Tests", '/some/path/test/units/foo_bar_test.rb', 'test/units/foo.rb', 'test/foo.rb', 'test/{models,helpers,unit}/**/*_test.rb'
-    should_guess_command_name "Functional Tests", '/some/path/test/functional/foo_bar_controller_test.rb', 'test/{controllers,mailers,functional}/**/*_test.rb'
-    should_guess_command_name "Integration Tests", '/some/path/test/integration/foo_bar_controller_test.rb', 'test/integration/**/*_test.rb'
-    should_guess_command_name "Cucumber Features", 'features', 'cucumber', 'cucumber features'
-    should_guess_command_name "RSpec", '/some/path/spec/foo.rb'
-    should_guess_command_name "Unit Tests", 'some_arbitrary_command with arguments' # Because Test::Unit const is defined!
   end
-end
+
+  should_guess_command_name "Unit Tests", '/some/path/test/units/foo_bar_test.rb', 'test/units/foo.rb', 'test/foo.rb', 'test/{models,helpers,unit}/**/*_test.rb'
+  should_guess_command_name "Functional Tests", '/some/path/test/functional/foo_bar_controller_test.rb', 'test/{controllers,mailers,functional}/**/*_test.rb'
+  should_guess_command_name "Integration Tests", '/some/path/test/integration/foo_bar_controller_test.rb', 'test/integration/**/*_test.rb'
+  should_guess_command_name "Cucumber Features", 'features', 'cucumber', 'cucumber features'
+  should_guess_command_name "RSpec", '/some/path/spec/foo.rb'
+  should_guess_command_name "Unit Tests", 'some_arbitrary_command with arguments' # Because Test::Unit const is defined!
+end if SimpleCov.usable?

--- a/test/test_deleted_source.rb
+++ b/test/test_deleted_source.rb
@@ -3,13 +3,11 @@ require 'helper'
 # Test to verify correct handling of deleted files,
 # see issue #9 on github
 class TestDeletedSource < Test::Unit::TestCase
-  on_ruby '1.8', '1.9' do
-    context "A source file which is subsequently deleted" do
-      should "not cause an error" do
-        Dir.chdir(File.join(File.dirname(__FILE__), 'fixtures')) do
-          `ruby deleted_source_sample.rb`
-          assert_equal 0, $?.exitstatus
-        end
+  context "A source file which is subsequently deleted" do
+    should "not cause an error" do
+      Dir.chdir(File.join(File.dirname(__FILE__), 'fixtures')) do
+        `ruby deleted_source_sample.rb`
+        assert_equal 0, $?.exitstatus
       end
     end
   end

--- a/test/test_file_list.rb
+++ b/test/test_file_list.rb
@@ -1,24 +1,22 @@
 require 'helper'
 
 class TestFileList < Test::Unit::TestCase
-  on_ruby "1.9" do
-    context "With a file list from a result" do
-      setup do
-        original_result = {source_fixture('sample.rb') => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-            source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-            source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
-        @file_list = SimpleCov::Result.new(original_result).files
-      end
+  context "With a file list from a result" do
+    setup do
+      original_result = {source_fixture('sample.rb') => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
+          source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+          source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
+      @file_list = SimpleCov::Result.new(original_result).files
+    end
 
-      should("have 13 covered_lines") { assert_equal 13, @file_list.covered_lines }
-      should("have 2 missed_lines")   { assert_equal 2, @file_list.missed_lines }
-      should("have 18 never_lines")   { assert_equal 18, @file_list.never_lines }
-      should("have 15 lines_of_code") { assert_equal 15, @file_list.lines_of_code }
-      should("have 3 skipped_lines")  { assert_equal 3, @file_list.skipped_lines }
+    should("have 13 covered_lines") { assert_equal 13, @file_list.covered_lines }
+    should("have 2 missed_lines")   { assert_equal 2, @file_list.missed_lines }
+    should("have 18 never_lines")   { assert_equal 18, @file_list.never_lines }
+    should("have 15 lines_of_code") { assert_equal 15, @file_list.lines_of_code }
+    should("have 3 skipped_lines")  { assert_equal 3, @file_list.skipped_lines }
 
-      should "have correct covered_percent" do
-        assert_equal 100.0*13/15, @file_list.covered_percent
-      end
+    should "have correct covered_percent" do
+      assert_equal 100.0*13/15, @file_list.covered_percent
     end
   end
-end
+end if SimpleCov.usable?

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1,80 +1,78 @@
 require 'helper'
 
 class TestFilters < Test::Unit::TestCase
-  on_ruby '1.9' do
-    context "A source file initialized with some coverage data" do
-      setup do
-        @source_file = SimpleCov::SourceFile.new(source_fixture('sample.rb'), [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
-      end
-
-      should "not match a new SimpleCov::StringFilter 'foobar'" do
-        assert !SimpleCov::StringFilter.new('foobar').matches?(@source_file)
-      end
-
-      should "not match a new SimpleCov::StringFilter 'some/path'" do
-        assert !SimpleCov::StringFilter.new('some/path').matches?(@source_file)
-      end
-
-      should "match a new SimpleCov::StringFilter 'test/fixtures'" do
-        assert SimpleCov::StringFilter.new('test/fixtures').matches?(@source_file)
-      end
-
-      should "match a new SimpleCov::StringFilter 'test/fixtures/sample.rb'" do
-        assert SimpleCov::StringFilter.new('test/fixtures/sample.rb').matches?(@source_file)
-      end
-
-      should "match a new SimpleCov::StringFilter 'sample.rb'" do
-        assert SimpleCov::StringFilter.new('sample.rb').matches?(@source_file)
-      end
-
-      should "not match a new SimpleCov::BlockFilter that is not applicable" do
-        assert !SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'foo.rb'}).matches?(@source_file)
-      end
-
-      should "match a new SimpleCov::BlockFilter that is applicable" do
-        assert SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'sample.rb'}).matches?(@source_file)
-      end
+  context "A source file initialized with some coverage data" do
+    setup do
+      @source_file = SimpleCov::SourceFile.new(source_fixture('sample.rb'), [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
     end
 
-    context "with no filters set up and a basic source file in an array" do
-      setup do
-        SimpleCov.filters = []
-        @files = [SimpleCov::SourceFile.new(source_fixture('sample.rb'), [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])]
-      end
+    should "not match a new SimpleCov::StringFilter 'foobar'" do
+      assert !SimpleCov::StringFilter.new('foobar').matches?(@source_file)
+    end
 
-      should "return 0 items after executing SimpleCov.filtered on files when using a 'sample' string filter" do
-        SimpleCov.add_filter "sample"
-        assert_equal 0, SimpleCov.filtered(@files).count
-      end
+    should "not match a new SimpleCov::StringFilter 'some/path'" do
+      assert !SimpleCov::StringFilter.new('some/path').matches?(@source_file)
+    end
 
-      should "return 0 items after executing SimpleCov.filtered on files when using a 'test/fixtures/' string filter" do
-        SimpleCov.add_filter "test/fixtures"
-        assert_equal 0, SimpleCov.filtered(@files).count
-      end
+    should "match a new SimpleCov::StringFilter 'test/fixtures'" do
+      assert SimpleCov::StringFilter.new('test/fixtures').matches?(@source_file)
+    end
 
-      should "return 1 item after executing SimpleCov.filtered on files when using a 'fooo' string filter" do
-        SimpleCov.add_filter "fooo"
-        assert_equal 1, SimpleCov.filtered(@files).count
-      end
+    should "match a new SimpleCov::StringFilter 'test/fixtures/sample.rb'" do
+      assert SimpleCov::StringFilter.new('test/fixtures/sample.rb').matches?(@source_file)
+    end
 
-      should "return 0 items after executing SimpleCov.filtered on files when using a block filter that returns true" do
-        SimpleCov.add_filter do |src_file|
-          true
-        end
-        assert_equal 0, SimpleCov.filtered(@files).count
-      end
+    should "match a new SimpleCov::StringFilter 'sample.rb'" do
+      assert SimpleCov::StringFilter.new('sample.rb').matches?(@source_file)
+    end
 
-      should "return 1 item after executing SimpleCov.filtered on files when using an always-false block filter" do
-        SimpleCov.add_filter do |src_file|
-          false
-        end
-        assert_equal 1, SimpleCov.filtered(@files).count
-      end
+    should "not match a new SimpleCov::BlockFilter that is not applicable" do
+      assert !SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'foo.rb'}).matches?(@source_file)
+    end
 
-      should "return a FileList after filtering" do
-        SimpleCov.add_filter "fooo"
-        assert_equal SimpleCov::FileList, SimpleCov.filtered(@files).class
-      end
+    should "match a new SimpleCov::BlockFilter that is applicable" do
+      assert SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'sample.rb'}).matches?(@source_file)
     end
   end
-end
+
+  context "with no filters set up and a basic source file in an array" do
+    setup do
+      SimpleCov.filters = []
+      @files = [SimpleCov::SourceFile.new(source_fixture('sample.rb'), [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])]
+    end
+
+    should "return 0 items after executing SimpleCov.filtered on files when using a 'sample' string filter" do
+      SimpleCov.add_filter "sample"
+      assert_equal 0, SimpleCov.filtered(@files).count
+    end
+
+    should "return 0 items after executing SimpleCov.filtered on files when using a 'test/fixtures/' string filter" do
+      SimpleCov.add_filter "test/fixtures"
+      assert_equal 0, SimpleCov.filtered(@files).count
+    end
+
+    should "return 1 item after executing SimpleCov.filtered on files when using a 'fooo' string filter" do
+      SimpleCov.add_filter "fooo"
+      assert_equal 1, SimpleCov.filtered(@files).count
+    end
+
+    should "return 0 items after executing SimpleCov.filtered on files when using a block filter that returns true" do
+      SimpleCov.add_filter do |src_file|
+        true
+      end
+      assert_equal 0, SimpleCov.filtered(@files).count
+    end
+
+    should "return 1 item after executing SimpleCov.filtered on files when using an always-false block filter" do
+      SimpleCov.add_filter do |src_file|
+        false
+      end
+      assert_equal 1, SimpleCov.filtered(@files).count
+    end
+
+    should "return a FileList after filtering" do
+      SimpleCov.add_filter "fooo"
+      assert_equal SimpleCov::FileList, SimpleCov.filtered(@files).class
+    end
+  end
+end if SimpleCov.usable?

--- a/test/test_merge_helpers.rb
+++ b/test/test_merge_helpers.rb
@@ -1,107 +1,105 @@
 require 'helper'
 
 class TestMergeHelpers < Test::Unit::TestCase
-  on_ruby '1.9' do
-    context "With two faked coverage resultsets" do
+  context "With two faked coverage resultsets" do
+    setup do
+      SimpleCov.use_merging true
+      @resultset1 = {source_fixture('sample.rb') => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
+          source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+          source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+          source_fixture('resultset1.rb') => [1, 1, 1, 1]}
+
+      @resultset2 = {source_fixture('sample.rb') => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil],
+          source_fixture('app/models/user.rb') => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
+          source_fixture('app/controllers/sample_controller.rb') => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil],
+          source_fixture('resultset2.rb') => [nil, 1, 1, nil]}
+    end
+
+    context "a merge" do
       setup do
-        SimpleCov.use_merging true
-        @resultset1 = {source_fixture('sample.rb') => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-            source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-            source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-            source_fixture('resultset1.rb') => [1, 1, 1, 1]}
-
-        @resultset2 = {source_fixture('sample.rb') => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil],
-            source_fixture('app/models/user.rb') => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
-            source_fixture('app/controllers/sample_controller.rb') => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil],
-            source_fixture('resultset2.rb') => [nil, 1, 1, nil]}
+        assert @merged = @resultset1.merge_resultset(@resultset2)
       end
 
-      context "a merge" do
-        setup do
-          assert @merged = @resultset1.merge_resultset(@resultset2)
-        end
-
-        should "have proper results for sample.rb" do
-          assert_equal [1, 1, 2, 2, nil, nil, 2, 2, nil, nil], @merged[source_fixture('sample.rb')]
-        end
-
-        should "have proper results for user.rb" do
-          assert_equal [nil, 2, 6, 2, nil, nil, 2, 0, nil, nil], @merged[source_fixture('app/models/user.rb')]
-        end
-
-        should "have proper results for sample_controller.rb" do
-          assert_equal [nil, 4, 2, 1, nil, nil, 2, 0, nil, nil], @merged[source_fixture('app/controllers/sample_controller.rb')]
-        end
-
-        should "have proper results for resultset1.rb" do
-          assert_equal [1, 1, 1, 1], @merged[source_fixture('resultset1.rb')]
-        end
-
-        should "have proper results for resultset2.rb" do
-          assert_equal [nil, 1, 1, nil], @merged[source_fixture('resultset2.rb')]
-        end
+      should "have proper results for sample.rb" do
+        assert_equal [1, 1, 2, 2, nil, nil, 2, 2, nil, nil], @merged[source_fixture('sample.rb')]
       end
 
-      # See Github issue #6
-      should "return an empty hash when the resultset cache file is empty" do
-        File.open(SimpleCov::ResultMerger.resultset_path, "w+") {|f| f.puts ""}
-        assert_equal Hash.new, SimpleCov::ResultMerger.resultset
+      should "have proper results for user.rb" do
+        assert_equal [nil, 2, 6, 2, nil, nil, 2, 0, nil, nil], @merged[source_fixture('app/models/user.rb')]
       end
 
-      # See Github issue #6
-      should "return an empty hash when the resultset cache file is not present" do
+      should "have proper results for sample_controller.rb" do
+        assert_equal [nil, 4, 2, 1, nil, nil, 2, 0, nil, nil], @merged[source_fixture('app/controllers/sample_controller.rb')]
+      end
+
+      should "have proper results for resultset1.rb" do
+        assert_equal [1, 1, 1, 1], @merged[source_fixture('resultset1.rb')]
+      end
+
+      should "have proper results for resultset2.rb" do
+        assert_equal [nil, 1, 1, nil], @merged[source_fixture('resultset2.rb')]
+      end
+    end
+
+    # See Github issue #6
+    should "return an empty hash when the resultset cache file is empty" do
+      File.open(SimpleCov::ResultMerger.resultset_path, "w+") {|f| f.puts ""}
+      assert_equal Hash.new, SimpleCov::ResultMerger.resultset
+    end
+
+    # See Github issue #6
+    should "return an empty hash when the resultset cache file is not present" do
+      system "rm #{SimpleCov::ResultMerger.resultset_path}" if File.exist?(SimpleCov::ResultMerger.resultset_path)
+      assert_equal Hash.new, SimpleCov::ResultMerger.resultset
+    end
+
+    context "and results generated from those" do
+      setup do
         system "rm #{SimpleCov::ResultMerger.resultset_path}" if File.exist?(SimpleCov::ResultMerger.resultset_path)
-        assert_equal Hash.new, SimpleCov::ResultMerger.resultset
+        @result1 = SimpleCov::Result.new(@resultset1)
+        @result1.command_name = "result1"
+        @result2 = SimpleCov::Result.new(@resultset2)
+        @result2.command_name = "result2"
       end
 
-      context "and results generated from those" do
+      context "with stored results" do
         setup do
-          system "rm #{SimpleCov::ResultMerger.resultset_path}" if File.exist?(SimpleCov::ResultMerger.resultset_path)
-          @result1 = SimpleCov::Result.new(@resultset1)
-          @result1.command_name = "result1"
-          @result2 = SimpleCov::Result.new(@resultset2)
-          @result2.command_name = "result2"
+          assert SimpleCov::ResultMerger.store_result(@result1)
+          assert SimpleCov::ResultMerger.store_result(@result2)
         end
 
-        context "with stored results" do
+        should "have stored data in resultset_path yaml file" do
+          assert File.readlines(SimpleCov::ResultMerger.resultset_path).length > 50
+        end
+
+        should "return a hash containing keys ['result1' and 'result2'] for resultset" do
+          assert_equal ['result1', 'result2'], SimpleCov::ResultMerger.resultset.keys.sort
+        end
+
+        should "return proper values for merged_result" do
+          assert_equal [nil, 2, 6, 2, nil, nil, 2, 0, nil, nil], SimpleCov::ResultMerger.merged_result.source_files.find {|s| s.filename =~ /user/}.lines.map(&:coverage)
+        end
+
+        context "with second result way above the merge_timeout" do
           setup do
-            assert SimpleCov::ResultMerger.store_result(@result1)
+            @result2.created_at = Time.now - 172800 # two days ago
             assert SimpleCov::ResultMerger.store_result(@result2)
           end
 
-          should "have stored data in resultset_path yaml file" do
-            assert File.readlines(SimpleCov::ResultMerger.resultset_path).length > 50
-          end
-
-          should "return a hash containing keys ['result1' and 'result2'] for resultset" do
-            assert_equal ['result1', 'result2'], SimpleCov::ResultMerger.resultset.keys.sort
-          end
-
-          should "return proper values for merged_result" do
-            assert_equal [nil, 2, 6, 2, nil, nil, 2, 0, nil, nil], SimpleCov::ResultMerger.merged_result.source_files.find {|s| s.filename =~ /user/}.lines.map(&:coverage)
-          end
-
-          context "with second result way above the merge_timeout" do
-            setup do
-              @result2.created_at = Time.now - 172800 # two days ago
-              assert SimpleCov::ResultMerger.store_result(@result2)
-            end
-
-            should "have only one result in SimpleCov::ResultMerger.results" do
-              assert_equal 1, SimpleCov::ResultMerger.results.length
-            end
-          end
-
-          context "with merging disabled" do
-            setup { SimpleCov.use_merging false }
-
-            should "return nil for SimpleCov.result" do
-              assert_nil SimpleCov.result
-            end
+          should "have only one result in SimpleCov::ResultMerger.results" do
+            assert_equal 1, SimpleCov::ResultMerger.results.length
           end
         end
 
+        context "with merging disabled" do
+          setup { SimpleCov.use_merging false }
+
+          should "return nil for SimpleCov.result" do
+            assert_nil SimpleCov.result
+          end
+        end
       end
+
     end
   end
-end
+end if SimpleCov.usable?

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -1,162 +1,160 @@
 require 'helper'
 
 class TestResult < Test::Unit::TestCase
-  on_ruby "1.9" do
-    context "With a (mocked) Coverage.result" do
-      setup do
-        SimpleCov.filters = []
-        SimpleCov.groups = {}
-        SimpleCov.formatter = nil
-        @original_result = {source_fixture('sample.rb') => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-            source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-            source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
+  context "With a (mocked) Coverage.result" do
+    setup do
+      SimpleCov.filters = []
+      SimpleCov.groups = {}
+      SimpleCov.formatter = nil
+      @original_result = {source_fixture('sample.rb') => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
+          source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+          source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
+    end
+
+    context "a simple cov result initialized from that" do
+      setup { @result = SimpleCov::Result.new(@original_result) }
+
+      should "have 3 filenames" do
+        assert_equal 3, @result.filenames.count
       end
 
-      context "a simple cov result initialized from that" do
-        setup { @result = SimpleCov::Result.new(@original_result) }
-
-        should "have 3 filenames" do
-          assert_equal 3, @result.filenames.count
-        end
-
-        should "have 3 source files" do
-          assert_equal 3, @result.source_files.count
-          assert @result.source_files.all? {|s| s.instance_of?(SimpleCov::SourceFile)}, "Not all instances are of SimpleCov::SourceFile type"
-        end
-
-        should "return an instance of SimpleCov::FileList for source_files and files" do
-          assert_equal SimpleCov::FileList, @result.source_files.class
-          assert_equal SimpleCov::FileList, @result.files.class
-        end
-
-        should "have files equal to source_files" do
-          assert_equal @result.files, @result.source_files
-        end
-
-        should "have accurate covered percent" do
-          # in our fixture, there are 13 covered line (result in 1) in all 15 relevant line (result in non-nil)
-          assert_equal 100.0*13/15, @result.covered_percent
-        end
-
-        context "dumped with to_hash" do
-          setup { @hash = @result.to_hash }
-          should("be a hash") { assert_equal Hash, @hash.class }
-
-          context "loaded back with from_yaml" do
-            setup { @dumped_result = SimpleCov::Result.from_hash(@hash) }
-
-            should "have 3 source files" do
-              assert_equal @result.source_files.count, @dumped_result.source_files.count
-            end
-
-            should "have the same covered_percent" do
-              assert_equal @result.covered_percent, @dumped_result.covered_percent
-            end
-
-            should "have the same timestamp" do
-              assert_equal @result.created_at.to_i, @dumped_result.created_at.to_i
-            end
-
-            should "have the same command_name" do
-              assert_equal @result.command_name, @dumped_result.command_name
-            end
-
-            should "have the same original_result" do
-              assert_equal @result.original_result, @dumped_result.original_result
-            end
-          end
-        end
+      should "have 3 source files" do
+        assert_equal 3, @result.source_files.count
+        assert @result.source_files.all? {|s| s.instance_of?(SimpleCov::SourceFile)}, "Not all instances are of SimpleCov::SourceFile type"
       end
 
-      context "with some filters set up" do
-        setup do
-          SimpleCov.add_filter 'sample.rb'
-        end
-
-        should "have 2 files in a new simple cov result" do
-          assert_equal 2, SimpleCov::Result.new(@original_result).source_files.length
-        end
-
-        should "have 80 covered percent" do
-          assert_equal 80, SimpleCov::Result.new(@original_result).covered_percent
-        end
+      should "return an instance of SimpleCov::FileList for source_files and files" do
+        assert_equal SimpleCov::FileList, @result.source_files.class
+        assert_equal SimpleCov::FileList, @result.files.class
       end
 
-      context "with groups set up for all files" do
-        setup do
-          SimpleCov.add_group 'Models', 'app/models'
-          SimpleCov.add_group 'Controllers', 'app/controllers'
-          SimpleCov.add_group 'Other' do |src_file|
-            File.basename(src_file.filename) == 'sample.rb'
-          end
-          @result = SimpleCov::Result.new(@original_result)
-        end
-
-        should "have 3 groups" do
-          assert_equal 3, @result.groups.length
-        end
-
-        should "have user.rb in 'Models' group" do
-          assert_equal 'user.rb', File.basename(@result.groups['Models'].first.filename)
-        end
-
-        should "have sample_controller.rb in 'Controllers' group" do
-          assert_equal 'sample_controller.rb', File.basename(@result.groups['Controllers'].first.filename)
-        end
-
-        context "and simple formatter being used" do
-          setup {SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter}
-
-          should "return a formatted string with result.format!" do
-            assert_equal String, @result.format!.class
-          end
-        end
-
-        context "and multi formatter being used" do
-          setup do
-            SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-              SimpleCov::Formatter::SimpleFormatter,
-              SimpleCov::Formatter::SimpleFormatter,
-            ]
-          end
-
-          should "return an array containing formatted string with result.format!" do
-            formated = @result.format!
-            assert_equal 2, formated.count
-            assert_equal String, formated.first.class
-          end
-        end
+      should "have files equal to source_files" do
+        assert_equal @result.files, @result.source_files
       end
 
-      context "with groups set up that do not match all files" do
-        setup do
-          SimpleCov.configure do
-            add_group 'Models', 'app/models'
-            add_group 'Controllers', 'app/controllers'
+      should "have accurate covered percent" do
+        # in our fixture, there are 13 covered line (result in 1) in all 15 relevant line (result in non-nil)
+        assert_equal 100.0*13/15, @result.covered_percent
+      end
+
+      context "dumped with to_hash" do
+        setup { @hash = @result.to_hash }
+        should("be a hash") { assert_equal Hash, @hash.class }
+
+        context "loaded back with from_yaml" do
+          setup { @dumped_result = SimpleCov::Result.from_hash(@hash) }
+
+          should "have 3 source files" do
+            assert_equal @result.source_files.count, @dumped_result.source_files.count
           end
-          @result = SimpleCov::Result.new(@original_result)
-        end
 
-        should "have 3 groups" do
-          assert_equal 3, @result.groups.length
-        end
-
-        should "have 1 item per group" do
-          @result.groups.each do |name, files|
-            assert_equal 1, files.length, "Group #{name} should have 1 file"
+          should "have the same covered_percent" do
+            assert_equal @result.covered_percent, @dumped_result.covered_percent
           end
-        end
 
-        should "have sample.rb in 'Ungrouped' group" do
-          assert_equal 'sample.rb', File.basename(@result.groups['Ungrouped'].first.filename)
-        end
+          should "have the same timestamp" do
+            assert_equal @result.created_at.to_i, @dumped_result.created_at.to_i
+          end
 
-        should "return all groups as instances of SimpleCov::FileList" do
-          @result.groups.each do |name, files|
-            assert_equal SimpleCov::FileList, files.class
+          should "have the same command_name" do
+            assert_equal @result.command_name, @dumped_result.command_name
+          end
+
+          should "have the same original_result" do
+            assert_equal @result.original_result, @dumped_result.original_result
           end
         end
       end
     end
+
+    context "with some filters set up" do
+      setup do
+        SimpleCov.add_filter 'sample.rb'
+      end
+
+      should "have 2 files in a new simple cov result" do
+        assert_equal 2, SimpleCov::Result.new(@original_result).source_files.length
+      end
+
+      should "have 80 covered percent" do
+        assert_equal 80, SimpleCov::Result.new(@original_result).covered_percent
+      end
+    end
+
+    context "with groups set up for all files" do
+      setup do
+        SimpleCov.add_group 'Models', 'app/models'
+        SimpleCov.add_group 'Controllers', 'app/controllers'
+        SimpleCov.add_group 'Other' do |src_file|
+          File.basename(src_file.filename) == 'sample.rb'
+        end
+        @result = SimpleCov::Result.new(@original_result)
+      end
+
+      should "have 3 groups" do
+        assert_equal 3, @result.groups.length
+      end
+
+      should "have user.rb in 'Models' group" do
+        assert_equal 'user.rb', File.basename(@result.groups['Models'].first.filename)
+      end
+
+      should "have sample_controller.rb in 'Controllers' group" do
+        assert_equal 'sample_controller.rb', File.basename(@result.groups['Controllers'].first.filename)
+      end
+
+      context "and simple formatter being used" do
+        setup {SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter}
+
+        should "return a formatted string with result.format!" do
+          assert_equal String, @result.format!.class
+        end
+      end
+
+      context "and multi formatter being used" do
+        setup do
+          SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+            SimpleCov::Formatter::SimpleFormatter,
+            SimpleCov::Formatter::SimpleFormatter,
+          ]
+        end
+
+        should "return an array containing formatted string with result.format!" do
+          formated = @result.format!
+          assert_equal 2, formated.count
+          assert_equal String, formated.first.class
+        end
+      end
+    end
+
+    context "with groups set up that do not match all files" do
+      setup do
+        SimpleCov.configure do
+          add_group 'Models', 'app/models'
+          add_group 'Controllers', 'app/controllers'
+        end
+        @result = SimpleCov::Result.new(@original_result)
+      end
+
+      should "have 3 groups" do
+        assert_equal 3, @result.groups.length
+      end
+
+      should "have 1 item per group" do
+        @result.groups.each do |name, files|
+          assert_equal 1, files.length, "Group #{name} should have 1 file"
+        end
+      end
+
+      should "have sample.rb in 'Ungrouped' group" do
+        assert_equal 'sample.rb', File.basename(@result.groups['Ungrouped'].first.filename)
+      end
+
+      should "return all groups as instances of SimpleCov::FileList" do
+        @result.groups.each do |name, files|
+          assert_equal SimpleCov::FileList, files.class
+        end
+      end
+    end
   end
-end
+end if SimpleCov.usable?

--- a/test/test_return_codes.rb
+++ b/test/test_return_codes.rb
@@ -3,37 +3,35 @@ require 'helper'
 # Make sure that exit codes of tests are propagated properly when using
 # simplecov. See github issue #5
 class TestReturnCodes < Test::Unit::TestCase
-  on_ruby '1.8', '1.9' do
-    context "Inside fixtures/frameworks" do
-      setup do
-        @current_dir = Dir.getwd
-        Dir.chdir(File.join(File.dirname(__FILE__), 'fixtures', 'frameworks'))
-        FileUtils.rm_rf('./coverage')
-      end
+  context "Inside fixtures/frameworks" do
+    setup do
+      @current_dir = Dir.getwd
+      Dir.chdir(File.join(File.dirname(__FILE__), 'fixtures', 'frameworks'))
+      FileUtils.rm_rf('./coverage')
+    end
 
-      should "have return code 0 when running testunit_good.rb" do
-        `ruby testunit_good.rb`
-        assert_equal 0, $?.exitstatus
-      end
+    should "have return code 0 when running testunit_good.rb" do
+      `ruby testunit_good.rb`
+      assert_equal 0, $?.exitstatus
+    end
 
-      should "have return code 0 when running rspec_good.rb" do
-        `rspec rspec_good.rb`
-        assert_equal 0, $?.exitstatus
-      end
+    should "have return code 0 when running rspec_good.rb" do
+      `rspec rspec_good.rb`
+      assert_equal 0, $?.exitstatus
+    end
 
-      should "have non-0 return code when running testunit_bad.rb" do
-        `ruby testunit_bad.rb`
-        assert_not_equal 0, $?.exitstatus
-      end
+    should "have non-0 return code when running testunit_bad.rb" do
+      `ruby testunit_bad.rb`
+      assert_not_equal 0, $?.exitstatus
+    end
 
-      should "have return code 1 when running rspec_bad.rb" do
-        `rspec rspec_bad.rb`
-        assert_not_equal 0, $?.exitstatus
-      end
+    should "have return code 1 when running rspec_bad.rb" do
+      `rspec rspec_bad.rb`
+      assert_not_equal 0, $?.exitstatus
+    end
 
-      teardown do
-        Dir.chdir(@current_dir)
-      end
+    teardown do
+      Dir.chdir(@current_dir)
     end
   end
 end

--- a/test/test_source_file.rb
+++ b/test/test_source_file.rb
@@ -1,95 +1,92 @@
 require 'helper'
 
 class TestSourceFile < Test::Unit::TestCase
-  on_ruby '1.9' do
-    COVERAGE_FOR_SAMPLE_RB = [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil]
-    context "A source file initialized with some coverage data" do
-      setup do
-        @source_file = SimpleCov::SourceFile.new(source_fixture('sample.rb'), COVERAGE_FOR_SAMPLE_RB)
-      end
-
-      should "have a filename" do
-        assert @source_file.filename
-      end
-
-      should "have source equal to src" do
-        assert_equal @source_file.source, @source_file.src
-      end
-
-      should "have source_lines equal to lines" do
-        assert_equal @source_file.source_lines, @source_file.lines
-      end
-
-      should "have 16 source lines" do
-        assert_equal 16, @source_file.lines.count
-      end
-
-      should "have all source lines of type SimpleCov::SourceFile::Line" do
-        assert @source_file.lines.all? {|l| l.instance_of?(SimpleCov::SourceFile::Line)}
-      end
-
-      should "have 'class Foo' as line(2).source" do
-        assert_equal "class Foo\n", @source_file.line(2).source
-      end
-
-      should "return lines number 2, 3, 4, 7 for covered_lines" do
-        assert_equal [2, 3, 4, 7], @source_file.covered_lines.map(&:line)
-      end
-
-      should "return lines number 8 for missed_lines" do
-        assert_equal [8], @source_file.missed_lines.map(&:line)
-      end
-
-      should "return lines number 1, 5, 6, 9, 10, 11, 15, 16 for never_lines" do
-        assert_equal [1, 5, 6, 9, 10, 11, 15, 16], @source_file.never_lines.map(&:line)
-      end
-
-      should "return line numbers 12, 13, 14 for skipped_lines" do
-        assert_equal [12, 13, 14], @source_file.skipped_lines.map(&:line)
-      end
-
-      should "have 80% covered_percent" do
-        assert_equal 80.0, @source_file.covered_percent
-      end
+  COVERAGE_FOR_SAMPLE_RB = [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil]
+  context "A source file initialized with some coverage data" do
+    setup do
+      @source_file = SimpleCov::SourceFile.new(source_fixture('sample.rb'), COVERAGE_FOR_SAMPLE_RB)
     end
 
-    context "Simulating potential Ruby 1.9 defect -- see Issue #56" do
-      setup do
-        @source_file = SimpleCov::SourceFile.new(source_fixture('sample.rb'), COVERAGE_FOR_SAMPLE_RB + [nil])
-      end
-
-      should "have 16 source lines regardless of extra data in coverage array" do
-        # Do not litter test output with known warning
-        capture_stderr { assert_equal 16, @source_file.lines.count }
-      end
-
-      should "print a warning to stderr if coverage array contains more data than lines in the file" do
-        captured_output = capture_stderr do
-          @source_file.lines
-        end
-
-        assert_match(/^Warning: coverage data provided/, captured_output)
-      end
+    should "have a filename" do
+      assert @source_file.filename
     end
 
-    context "Encoding" do
-      should "handle utf-8 encoded source files" do
-        source_file = SimpleCov::SourceFile.new(source_fixture('utf-8.rb'), [nil, nil, 1])
-
-        assert_nothing_raised do
-          source_file.process_skipped_lines!
-        end
-      end
-
-      should "handle iso-8859 encoded source files" do
-        source_file = SimpleCov::SourceFile.new(source_fixture('iso-8859.rb'), [nil, nil, 1])
-
-        assert_nothing_raised do
-          source_file.process_skipped_lines!
-        end
-      end
+    should "have source equal to src" do
+      assert_equal @source_file.source, @source_file.src
     end
 
+    should "have source_lines equal to lines" do
+      assert_equal @source_file.source_lines, @source_file.lines
+    end
+
+    should "have 16 source lines" do
+      assert_equal 16, @source_file.lines.count
+    end
+
+    should "have all source lines of type SimpleCov::SourceFile::Line" do
+      assert @source_file.lines.all? {|l| l.instance_of?(SimpleCov::SourceFile::Line)}
+    end
+
+    should "have 'class Foo' as line(2).source" do
+      assert_equal "class Foo\n", @source_file.line(2).source
+    end
+
+    should "return lines number 2, 3, 4, 7 for covered_lines" do
+      assert_equal [2, 3, 4, 7], @source_file.covered_lines.map(&:line)
+    end
+
+    should "return lines number 8 for missed_lines" do
+      assert_equal [8], @source_file.missed_lines.map(&:line)
+    end
+
+    should "return lines number 1, 5, 6, 9, 10, 11, 15, 16 for never_lines" do
+      assert_equal [1, 5, 6, 9, 10, 11, 15, 16], @source_file.never_lines.map(&:line)
+    end
+
+    should "return line numbers 12, 13, 14 for skipped_lines" do
+      assert_equal [12, 13, 14], @source_file.skipped_lines.map(&:line)
+    end
+
+    should "have 80% covered_percent" do
+      assert_equal 80.0, @source_file.covered_percent
+    end
   end
-end
+
+  context "Simulating potential Ruby 1.9 defect -- see Issue #56" do
+    setup do
+      @source_file = SimpleCov::SourceFile.new(source_fixture('sample.rb'), COVERAGE_FOR_SAMPLE_RB + [nil])
+    end
+
+    should "have 16 source lines regardless of extra data in coverage array" do
+      # Do not litter test output with known warning
+      capture_stderr { assert_equal 16, @source_file.lines.count }
+    end
+
+    should "print a warning to stderr if coverage array contains more data than lines in the file" do
+      captured_output = capture_stderr do
+        @source_file.lines
+      end
+
+      assert_match(/^Warning: coverage data provided/, captured_output)
+    end
+  end
+
+  context "Encoding" do
+    should "handle utf-8 encoded source files" do
+      source_file = SimpleCov::SourceFile.new(source_fixture('utf-8.rb'), [nil, nil, 1])
+
+      assert_nothing_raised do
+        source_file.process_skipped_lines!
+      end
+    end
+
+    should "handle iso-8859 encoded source files" do
+      source_file = SimpleCov::SourceFile.new(source_fixture('iso-8859.rb'), [nil, nil, 1])
+
+      assert_nothing_raised do
+        source_file.process_skipped_lines!
+      end
+    end
+  end
+end if SimpleCov.usable?
 

--- a/test/test_source_file_line.rb
+++ b/test/test_source_file_line.rb
@@ -1,110 +1,106 @@
 require 'helper'
 
 class TestSourceFileLine < Test::Unit::TestCase
+  context "A source line" do
+    setup do
+      @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, 3)
+    end
+    subject { @line }
 
-
-  on_ruby '1.9' do
-    context "A source line" do
-      setup do
-        @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, 3)
-      end
-      subject { @line }
-
-      should 'return "# the ruby source" as src' do
-        assert_equal '# the ruby source', @line.src
-      end
-
-      should 'return the same for source as for src' do
-        assert_equal @line.src, @line.source
-      end
-
-      should 'have line number 5' do
-        assert_equal 5, @line.line_number
-      end
-
-      should 'have equal line_number, line and number' do
-        assert_equal @line.line_number, @line.line
-        assert_equal @line.line_number, @line.number
-      end
-
-      context "flagged as skipped!" do
-        setup { @line.skipped! }
-
-        should_not_be :covered?
-        should_be :skipped?
-        should_not_be :missed?
-        should_not_be :never?
-        should_have :status, 'skipped'
-      end
+    should 'return "# the ruby source" as src' do
+      assert_equal '# the ruby source', @line.src
     end
 
-    context "A source line with coverage" do
-      setup do
-        @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, 3)
-      end
-      subject { @line }
-
-      should "have coverage of 3" do
-        assert_equal 3, @line.coverage
-      end
-
-      should_be :covered?
-      should_not_be :skipped?
-      should_not_be :missed?
-      should_not_be :never?
-      should_have :status, 'covered'
+    should 'return the same for source as for src' do
+      assert_equal @line.src, @line.source
     end
 
-    context "A source line without coverage" do
-      setup do
-        @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, 0)
-      end
-      subject { @line }
+    should 'have line number 5' do
+      assert_equal 5, @line.line_number
+    end
 
-      should "have coverage of 0" do
-        assert_equal 0, @line.coverage
-      end
+    should 'have equal line_number, line and number' do
+      assert_equal @line.line_number, @line.line
+      assert_equal @line.line_number, @line.number
+    end
+
+    context "flagged as skipped!" do
+      setup { @line.skipped! }
 
       should_not_be :covered?
-      should_not_be :skipped?
-      should_be :missed?
-      should_not_be :never?
-      should_have :status, 'missed'
-    end
-
-    context "A source line with no code" do
-      setup do
-        @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, nil)
-      end
-      subject { @line }
-
-      should "have nil coverage" do
-        assert_nil @line.coverage
-      end
-
-      should_not_be :covered?
-      should_not_be :skipped?
+      should_be :skipped?
       should_not_be :missed?
-      should_be :never?
-      should_have :status, 'never'
-    end
-
-    should "raise ArgumentError when initialized with invalid src" do
-      assert_raise ArgumentError do
-        SimpleCov::SourceFile::Line.new(:symbol, 5, 3)
-      end
-    end
-
-    should "raise ArgumentError when initialized with invalid line_number" do
-      assert_raise ArgumentError do
-        SimpleCov::SourceFile::Line.new("some source", "five", 3)
-      end
-    end
-
-    should "raise ArgumentError when initialized with invalid coverage" do
-      assert_raise ArgumentError do
-        SimpleCov::SourceFile::Line.new("some source", 5, "three")
-      end
+      should_not_be :never?
+      should_have :status, 'skipped'
     end
   end
-end
+
+  context "A source line with coverage" do
+    setup do
+      @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, 3)
+    end
+    subject { @line }
+
+    should "have coverage of 3" do
+      assert_equal 3, @line.coverage
+    end
+
+    should_be :covered?
+    should_not_be :skipped?
+    should_not_be :missed?
+    should_not_be :never?
+    should_have :status, 'covered'
+  end
+
+  context "A source line without coverage" do
+    setup do
+      @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, 0)
+    end
+    subject { @line }
+
+    should "have coverage of 0" do
+      assert_equal 0, @line.coverage
+    end
+
+    should_not_be :covered?
+    should_not_be :skipped?
+    should_be :missed?
+    should_not_be :never?
+    should_have :status, 'missed'
+  end
+
+  context "A source line with no code" do
+    setup do
+      @line = SimpleCov::SourceFile::Line.new('# the ruby source', 5, nil)
+    end
+    subject { @line }
+
+    should "have nil coverage" do
+      assert_nil @line.coverage
+    end
+
+    should_not_be :covered?
+    should_not_be :skipped?
+    should_not_be :missed?
+    should_be :never?
+    should_have :status, 'never'
+  end
+
+  should "raise ArgumentError when initialized with invalid src" do
+    assert_raise ArgumentError do
+      SimpleCov::SourceFile::Line.new(:symbol, 5, 3)
+    end
+  end
+
+  should "raise ArgumentError when initialized with invalid line_number" do
+    assert_raise ArgumentError do
+      SimpleCov::SourceFile::Line.new("some source", "five", 3)
+    end
+  end
+
+  should "raise ArgumentError when initialized with invalid coverage" do
+    assert_raise ArgumentError do
+      SimpleCov::SourceFile::Line.new("some source", 5, "three")
+    end
+  end
+end if SimpleCov.usable?


### PR DESCRIPTION
While working on [fixing the build](https://github.com/infertux/simplecov/tree/fix_build), I came across the [on_ruby](https://github.com/colszowka/simplecov/blob/master/test/shoulda_macros.rb#L6-L10) helper. It seems a bit brittle since it doesn't run all tests for Ruby 2.0 assuming it is under 1.8.
Here's a quick refactoring to handle Ruby 2.0, please let me know if that makes sense so I could try to fix the build for 2.0.
I'm a bit confused about lines like `on_ruby '1.8', '1.9' do` - what version did you intend to exclude here? Thanks!
