### PR TITLE
Remove default addition of 'vendor/plugins' group when using 'rails' adapter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.7.0...master))
 -------------------
 
+  * Remove default addition of 'vendor/plugins' group when using 'rails' adapter.
   * [FEATURE] Adds support for Rails 4 command guessing.
 
 v0.7.1, 2012-10-12 ([changes](https://github.com/colszowka/simplecov/compare/v0.7.0...v0.7.1))

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ is being set in the SimpleCov::Filter initialize method and thus is set to 5 in 
 ## Groups
 
 You can separate your source files into groups. For example, in a rails app, you'll want to have separate listings for
-Models, Controllers, Helpers, Libs and Plugins. Group definition works similar to Filters (and indeed also accepts custom
+Models, Controllers, Helpers, and Libs. Group definition works similar to Filters (and indeed also accepts custom
 filter classes), but source files end up in a group when the filter passes (returns true), as opposed to filtering results,
 which exclude files from results when the filter results in a true value.
 
@@ -406,7 +406,6 @@ SimpleCov.adapters.define 'rails' do
   add_group 'Models', 'app/models'
   add_group 'Helpers', 'app/helpers'
   add_group 'Libraries', 'lib'
-  add_group 'Plugins', 'vendor/plugins'
 end
 ```
 

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -27,7 +27,6 @@ SimpleCov.adapters.define 'rails' do
   add_group 'Mailers', 'app/mailers'
   add_group 'Helpers', 'app/helpers'
   add_group 'Libraries', 'lib'
-  add_group 'Plugins', 'vendor/plugins'
 end
 
 # Default configuration


### PR DESCRIPTION
With Rails doing away with plugins, seems like the rails adapter shouldn't be creating a special group for them anymore....
