### PR TITLE
Upgrade to Capybara 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 before_install:
   - echo "yes" | gem uninstall json
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 script:
   - bundle
   - rake appraisal:install

--- a/features/config_project_name.feature
+++ b/features/config_project_name.feature
@@ -14,7 +14,7 @@ Feature:
       """
 
     When I open the coverage report generated with `bundle exec rake test`
-    Then I should see "Code coverage for Project"
+    Then I should see "Code coverage for Project" within "title"
 
   Scenario: Custom name
     Given SimpleCov for Test/Unit is configured with:
@@ -24,4 +24,4 @@ Feature:
       """
 
     When I open the coverage report generated with `bundle exec rake test`
-    Then I should see "Code coverage for Superfancy 2.0"
+    Then I should see "Code coverage for Superfancy 2.0" within "title"

--- a/features/step_definitions/html_steps.rb
+++ b/features/step_definitions/html_steps.rb
@@ -35,7 +35,7 @@ Then /^I should see the source files:$/ do |table|
   expected_files.length.should == available_source_files.count
 
   # Find all filenames and their coverage present in coverage report
-  files = available_source_files.map {|f| {"name" => f.find('h3').text, "coverage" => f.find('.header span').text} }
+  files = available_source_files.map {|f| {"name" => f.find('h3').text, "coverage" => f.find('h4 > span').text} }
 
   files.sort_by {|hsh| hsh["name"] }.should == expected_files.sort_by {|hsh| hsh["name"] }
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,12 +7,19 @@ require 'bundler'
 Bundler.setup
 require 'aruba/cucumber'
 require 'capybara/cucumber'
+require 'capybara/webkit'
 
 # Fake rack app for capybara that just returns the latest coverage report from aruba temp project dir
-Capybara.app = lambda {|env|
+Capybara.app = lambda { |env|
+  request_path = env['REQUEST_PATH'] || '/'
+  request_path = '/index.html' if request_path == '/'
+
   [200, {'Content-Type' => 'text/html'},
-    [File.read(File.join(File.dirname(__FILE__), '../../tmp/aruba/project', 'coverage/index.html'))]]
+    [File.read(File.join(File.dirname(__FILE__), '../../tmp/aruba/project/coverage', request_path))]]
 }
+
+# https://github.com/thoughtbot/capybara-webkit
+Capybara.default_driver = Capybara.javascript_driver = :webkit
 
 Before do
   @aruba_timeout_seconds = 20

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'simplecov-html', '~> 0.7.1'
 
   gem.add_development_dependency 'aruba'
-  gem.add_development_dependency 'capybara', '~> 1.0'
+  gem.add_development_dependency 'capybara', '~> 2.0'
+  gem.add_development_dependency 'capybara-webkit'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'cucumber', '>= 1.1.4'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Hi,

Those cukes failing with Capybara 2 were bothering me. The main issue was that Capybara 2 doesn't look for text in hidden DOM elements anymore (which makes sense!) so we now need to use a JS-enabled driver. I went ahead and picked [capybara-webkit](https://github.com/thoughtbot/capybara-webkit). [Poltergeist](https://github.com/jonleighton/poltergeist) is cool too because truly headless thanks to PhantomJS but it requires Ruby 1.9.2+. You might want to use [another one](https://github.com/jnicklas/capybara#drivers). I also tweaked a bit the fake Rack app to serve other resources such as JS files. 

There's probably a minor overhead (although I can't see any difference locally) running cukes with JS but I thought it'd be more relevant for integration tests.

Also references 239db29e.
