### PR TITLE
Clean up command guessing regexes and put spec before cucumber

### DIFF
--- a/features/config_command_name.feature
+++ b/features/config_command_name.feature
@@ -31,3 +31,15 @@ Feature: Custom names for individual test suites
       | Dreck macht Speck |
       | I'm in UR Unitz   |
 
+  Scenario: RSpec auto detection with spec/features
+    Given SimpleCov for RSpec is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start
+      """
+    And a file named "spec/features/foobar_spec.rb" with:
+      """
+      """
+    When I open the coverage report generated with `bundle exec rspec spec`
+    Then the report should be based upon:
+      | RSpec |

--- a/lib/simplecov/command_guesser.rb
+++ b/lib/simplecov/command_guesser.rb
@@ -18,16 +18,16 @@ module SimpleCov::CommandGuesser
     
     def from_command_line_options
       case original_run_command
-        when /#{'test/functional/'}/, /#{'test/{.*?functional.*?}/'}/
+        when /test\/functional\//, /test\/{.*?functional.*?}\//
           "Functional Tests"
-        when /#{'test/integration/'}/
+        when /test\/integration\//
           "Integration Tests"
-        when /#{'test/'}/
+        when /test\//
           "Unit Tests"
-        when /cucumber/, /features/
-          "Cucumber Features"
         when /spec/
           "RSpec"
+        when /cucumber/, /features/
+          "Cucumber Features"
         else
           nil
       end


### PR DESCRIPTION
This allows for Capybara 2.0 RSpec DSL to be detected correctly
