### PR TITLE
Add SimpleCov-Badge to list of formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,11 @@ A formatter for Simplecov that emits a Vim script to mark up code files with cov
 
 A formatter that prints the coverage of the file under test when you run a single test file.
 
+#### [simplecov-badge](https://github.com/matthew342/simplecov-badge)
+*by Matt Hale*
+
+A formatter that generates a coverage badge for use in your project's readme using ImageMagick.
+
 ## Ruby version compatibility
 
 [![Build Status](https://secure.travis-ci.org/colszowka/simplecov.png)](http://travis-ci.org/colszowka/simplecov)


### PR DESCRIPTION
I wrote a simple formatter that produces a coverage badge - it's great for small private repos that want to make coverage more visible but don't want to pay for a hosted service like Coveralls.  Requires ImageMagick.
