### PR TITLE
Make ResultMerger safe in parallel environment

### DIFF
--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -13,7 +13,11 @@ module SimpleCov::ResultMerger
     # Loads the cached resultset from YAML and returns it as a Hash
     def resultset
       if stored_data
-        SimpleCov::JSON.parse(stored_data)
+        begin
+          SimpleCov::JSON.parse(stored_data)
+        rescue
+          {}
+        end
       else
         {}
       end


### PR DESCRIPTION
With current implementation, sometimes two processes write to the same JSON file, and collapse it.
My fix avoids this problem, and loads JSON with error check.
