### PR TITLE
fix issue #204 by escape special characters in root path such as '(', ')'

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -4,7 +4,7 @@ require 'simplecov-html'
 SimpleCov.profiles.define 'root_filter' do
   # Exclude all files outside of simplecov root
   add_filter do |src|
-    !(src.filename =~ /^#{SimpleCov.root}/)
+    !(src.filename =~ /^#{Regexp.escape(SimpleCov.root)}/)
   end
 end
 


### PR DESCRIPTION
This change is to fix issue #204 to use Regexp.escape to resolve regexp special characters like '('. 
