### PR TITLE
Add support for local and instance vars to SimpleCov DSL

### DIFF
--- a/features/config_styles.feature
+++ b/features/config_styles.feature
@@ -24,6 +24,34 @@ Feature:
     Then I should see "4 files in total."
     And I should see "using Config Test Runner" within "#footer"
 
+  Scenario: Inside start block, using instance var from outside
+    Given a file named ".simplecov" with:
+      """
+      @filter = 'test'
+      SimpleCov.start do
+        add_filter @filter
+        command_name 'Config Test Runner'
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+    Then I should see "4 files in total."
+    And I should see "using Config Test Runner" within "#footer"
+
+  Scenario: Inside start block, using local var from outside
+    Given a file named ".simplecov" with:
+      """
+      filter = 'test'
+      SimpleCov.start do
+        add_filter filter
+        command_name 'Config Test Runner'
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+    Then I should see "4 files in total."
+    And I should see "using Config Test Runner" within "#footer"
+
   Scenario: Explicitly before start block
     Given a file named ".simplecov" with:
       """

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'docile'
 #
 # Bundles the configuration options used for SimpleCov. All methods
 # defined here are usable from SimpleCov directly. Please check out
@@ -118,7 +119,7 @@ module SimpleCov::Configuration
   #
   def configure(&block)
     return false unless SimpleCov.usable?
-    instance_exec(&block)
+    Docile.dsl_eval(self, &block)
   end
 
   #

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'multi_json'
   gem.add_dependency 'simplecov-html', '~> 0.7.1'
+  gem.add_dependency 'docile', '~> 1.1.0'
 
   gem.add_development_dependency 'appraisal', '~> 0.5.1'
   gem.add_development_dependency 'rake', '~> 10.0.3'


### PR DESCRIPTION
This commit replaces the naked instance_exec call with a
call to Docile#dsl_eval, which abstracts away the complexities
of referring to outside variables in Ruby DSLs.
