### PR TITLE
#16 Uncovered source files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.7.1...master))
 -------------------
-
+  * [FEATURE] Adds config option to show zero coverage data for source files without tests defined.
   * [FEATURE] Adds support for Rails 4 command guessing. 
     See [#181](https://github.com/colszowka/simplecov/pull/181) (thanks to @semanticart)
   * [REFACTORING] Rename adapters to "profiles" given that they are bundles of settings. The old adapter methods are

--- a/README.md
+++ b/README.md
@@ -446,6 +446,15 @@ require 'simplecov_custom_profile'
 SimpleCov.start 'myprofile'
 ```
 
+## Show coverage for files with no corresponding tests defined.
+
+Some test frameworks will not load source files unless there is a spec written.  Setting this flag will scan the
+project directory, find files with no coverage and report zero coverage for the file.
+
+```ruby
+SimpleCov.start 'rails' do
+  show_uncovered_files true
+end
 
 ## Customizing exit behaviour
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ SimpleCov.configure do
 end
 ```
 
+* Show coverage for files with no corresponding tests defined.
+
+```ruby
+SimpleCov.start 'rails' do
+  show_uncovered_files true
+end
+
 Please check out the [Configuration] API documentation to find out what you can customize.
 
 
@@ -445,16 +452,6 @@ SimpleCov.start 'myprofile'
 require 'simplecov_custom_profile'
 SimpleCov.start 'myprofile'
 ```
-
-## Show coverage for files with no corresponding tests defined.
-
-Some test frameworks will not load source files unless there is a spec written.  Setting this flag will scan the
-project directory, find files with no coverage and report zero coverage for the file.
-
-```ruby
-SimpleCov.start 'rails' do
-  show_uncovered_files true
-end
 
 ## Customizing exit behaviour
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -58,7 +58,7 @@ module SimpleCov
 
       #if the user wants to see files with no test coverage, we load zero'd coverage for all files and let the
       #filters sort it out.
-      if show_uncovered_files
+      if show_uncovered_files?
         @result = SimpleCov::Result.new(@result.original_result.merge_resultset(load_uncovered_files)) if running
       end
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -159,6 +159,14 @@ module SimpleCov::Configuration
   end
 
   #
+  # Defines whether or not to show zero coverage metrics for uncovered files.
+  #
+  def show_uncovered_files(show=nil)
+    @show_uncovered_files = show unless show.nil?
+    @show_uncovered_files = true unless defined? @show_uncovered_files and @show_uncovered_files == false
+  end
+
+  #
   # Defines them maximum age (in seconds) of a resultset to still be included in merged results.
   # i.e. If you run cucumber features, then later rake test, if the stored cucumber resultset is
   # more seconds ago than specified here, it won't be taken into account when merging (and is also

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -161,9 +161,12 @@ module SimpleCov::Configuration
   #
   # Defines whether or not to show zero coverage metrics for uncovered files.
   #
-  def show_uncovered_files(show=nil)
-    @show_uncovered_files = show unless show.nil?
-    @show_uncovered_files = true unless defined? @show_uncovered_files and @show_uncovered_files == false
+  def show_uncovered_files(show=false)
+    @show_uncovered_files = show
+  end
+
+  def show_uncovered_files?
+    @show_uncovered_files
   end
 
   #


### PR DESCRIPTION
implements Feature from issue #16

Off by default, but if someone wants it, they can just set show_uncovered_files to true in the config block.

Why aren't there tests?

I tried to write a few features to demonstrate the functionality but the way the test harness run it touches the uncovered source file and shows up in the coverage data.  So basically when I run the tests I can't recreate the issue.

If it's a big deal maybe I can spend some time in the future trying to work that up.