### PR TITLE
Updated information about SimpleCov-Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,10 +521,10 @@ available:
 
 CSV formatter for SimpleCov code coverage tool for ruby 1.9+
 
-#### [simplecov-vim](https://github.com/nyarly/Simplecov-Vim)
+#### [cadre](https://github.com/nyarly/cadre)
 *by Judson Lester*
 
-A formatter for Simplecov that emits a Vim script to mark up code files with coverage information.
+Includes a formatter for Simplecov that emits a Vim script to mark up code files with coverage information.
 
 #### [simplecov-single_file_reporter](https://github.com/grosser/simplecov-single_file_reporter)
 *by [Michael Grosser](http://grosser.it)*


### PR DESCRIPTION
I've pulled an improved version of SimpleCov-Vim into a different gem called "cadre" - eventually I'd also like (if possible) to add something similar for other editors, like the TextMate family, or even emacs. In the meantime, the old gem isn't getting any love in the foreseeable future.
