### PR TITLE
Missing require for Forwardable caused crashes on missing constant

### DIFF
--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -1,4 +1,5 @@
 require 'digest/sha1'
+require 'forwardable'
 
 module SimpleCov
   #


### PR DESCRIPTION
This happens in 0.8.0 otherwise:

```
kylev-mac:pol-rails kylev$ COVERAGE=1 rspec spec/
/Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov/result.rb:9:in `<class:Result>': uninitialized constant SimpleCov::Result::Forwardable (NameError)
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov/result.rb:8:in `<module:SimpleCov>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov/result.rb:3:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov.rb:136:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
    from /Volumes/ChangeWork/pol-rails/spec/spec_helper.rb:5:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Volumes/ChangeWork/pol-rails/spec/controllers/authors_controller_spec.rb:1:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `load'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `each'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `load_spec_files'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:17:in `block in autorun'
kylev-mac:pol-rails kylev$ COVERAGE=1 rspec spec/
/Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov/result.rb:9:in `<class:Result>': uninitialized constant SimpleCov::Result::Forwardable (NameError)
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov/result.rb:8:in `<module:SimpleCov>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov/result.rb:3:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/simplecov-0.8.0/lib/simplecov.rb:136:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
    from /Volumes/ChangeWork/pol-rails/spec/spec_helper.rb:5:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Volumes/ChangeWork/pol-rails/spec/controllers/authors_controller_spec.rb:1:in `<top (required)>'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `load'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `each'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `load_spec_files'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'
    from /Users/kylev/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:17:in `block in autorun'
```
