### PR TITLE
Fix for issue #262 Guard/Spork error in Simplecov 0.8.1 and up

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -40,6 +40,7 @@ end
 SimpleCov::CommandGuesser.original_run_command = "#{$0} #{ARGV.join(" ")}"
 
 at_exit do
+  @exit_status = nil
 
   if $! # was an exception thrown?
     # if it was a SystemExit, use the accompanying status


### PR DESCRIPTION
potential fix for issue #262, all tests still pass and error no longer appears in guard
