### PR TITLE
Using Kernel.exit to avoid error messages when exiting irb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.8.2...ma
 
   * Ensure calculations return Floats, not Fixnum or Rational. Fixes segfaults with mathn. See [#245][https://github.com/colszowka/simplecov/pull/245] (thanks to @bf4)
 
+## Bugfixes
+
+  * Using `Kernel.exit` instead of exit to avoid uncaught throw :IRB_EXIT when
+    exiting irb sessions.
+    See [#285](https://github.com/colszowka/simplecov/issues/285)
+
 v0.8.2
 =====================
 

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -79,7 +79,7 @@ at_exit do
 
   # Force exit with stored status (see github issue #5)
   # unless it's nil or 0 (see github issue #281)
-  exit @exit_status if @exit_status && @exit_status > 0
+  Kernel.exit @exit_status if @exit_status && @exit_status > 0
 end
 
 # Autoload config from ~/.simplecov if present


### PR DESCRIPTION
Resolves #285

On the latest version of simplecov, errors were being throw on console exit:

../.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/irb.rb:83:in `throw': uncaught throw :IRB_EXIT (ArgumentError)
    from ../.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/irb.rb:83:in`irb_exit'

This addresses this problem by calling Kernel.exit directly, rather than irb's exit. Not sure if this is related to issue #281, but nonethless getting rid of this annoying error message would be great! :)
