### PR TITLE
[ci skip] Add editor support to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ A formatter that generates a coverage badge for use in your project's readme usi
 
 Some editors have a graphical integration for the simplecov gem.
 
-### [Atom Editor: coverage](https://atom.io/packages/coverage)
+#### [Atom Editor: coverage](https://atom.io/packages/coverage)
 *by Philip Giuliani*
 
 Adds an overview of your current test coverage to Atom.

--- a/README.md
+++ b/README.md
@@ -587,6 +587,15 @@ JSON formatter for SimpleCov
 
 A formatter that generates a coverage badge for use in your project's readme using ImageMagick.
 
+## Editor integration
+
+Some editors have a integration for the simplecov gem.
+
+### Atom Editor: [coverage](https://github.com/philipgiuliani/coverage)
+*by Philip Giuliani*
+
+Adds an overview of your current test coverage to Atom.
+
 ## Ruby version compatibility
 
 [![Build Status](https://secure.travis-ci.org/colszowka/simplecov.png)](http://travis-ci.org/colszowka/simplecov)

--- a/README.md
+++ b/README.md
@@ -589,9 +589,9 @@ A formatter that generates a coverage badge for use in your project's readme usi
 
 ## Editor integration
 
-Some editors have a integration for the simplecov gem.
+Some editors have a graphical integration for the simplecov gem.
 
-### Atom Editor: [coverage](https://github.com/philipgiuliani/coverage)
+### [Atom Editor: coverage](https://atom.io/packages/coverage)
 *by Philip Giuliani*
 
 Adds an overview of your current test coverage to Atom.


### PR DESCRIPTION
In this pull request i would like to add the supported text editors and plugins for simplecov to the README.

I recently developed a [Atom Editor](http://atom.io) Package which displays the simplecov results in a graphical layout.

I think thats its a good idea to list the supported text editors in the README. If you know more supported editors and plugins, please comment and i will add it in this pull request.

#### Editor: Plugin
- [Atom Editor: coverage](github.com/philipgiuliani/coverage)