### PR TITLE
Filter `/vendor/bundle` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ that shows how you can achieve just that:
 
 ```ruby
 SimpleCov.start :rails do
-  filters.clear # This will remove the :root_filter that comes via simplecov's defaults
+  filters.clear # This will remove the :root_filter and :bundler_filter that come via simplecov's defaults
   add_filter do |src|
     !(src.filename =~ /^#{SimpleCov.root}/) unless src.filename =~ /my_engine/
   end

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -15,12 +15,15 @@ SimpleCov.profiles.define 'test_frameworks' do
   add_filter '/autotest/'
 end
 
+SimpleCov.profiles.define 'bundler_filter' do
+  add_filter '/vendor/bundle/'
+end
+
 SimpleCov.profiles.define 'rails' do
   load_profile 'test_frameworks'
 
   add_filter '/config/'
   add_filter '/db/'
-  add_filter '/vendor/bundle/'
 
   add_group 'Controllers', 'app/controllers'
   add_group 'Models', 'app/models'
@@ -32,6 +35,7 @@ end
 # Default configuration
 SimpleCov.configure do
   formatter SimpleCov::Formatter::HTMLFormatter
+  load_profile 'bundler_filter'
   # Exclude files outside of SimpleCov.root
   load_profile 'root_filter'
 end


### PR DESCRIPTION
The Rails profile filters out `/vendor/bundle`, but this is also needed for many other kinds of Ruby projects.

A GitHub search illustrates how often developers need to configure this:

https://github.com/search?utf8=%E2%9C%93&q=simplecov+%22add_filter*vendor%22&type=Code&ref=searchresults

I can't think of any downside of having this as the default behaviour.