### PR TITLE
Specified in the gemspec that simplecov needs ruby 1.8.7

### DIFF
--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.summary     = gem.description
   gem.license     = "MIT"
 
+  gem.required_ruby_version = ">= 1.8.7"
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'simplecov-html', '~> 0.8.0'
   gem.add_dependency 'docile', '~> 1.1.0'


### PR DESCRIPTION
1.8.7 support is a deliberate feature, for the time being (see #26).

This is a follow up to #342
