### PR TITLE
Added feature from #104 allowing a array to be passed in a filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.9.2...ma
 ## Enhancements
 
  * Add writeup about using with Spring to README. See [#341](https://github.com/colszowka/simplecov/issues/341) (thanks (@swrobel)
+ * Add support to pass in an Array when creating filter groups (original PR #104)
 
 ## Bugfixes
 
@@ -14,7 +15,7 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.9.2...ma
 This is a minor bugfix release for simplecov-html, released as `0.9.0`. Due to the tight version constraint in the gemspec
 a new release of simplecov had to be shipped to allow using simplecov-html `~> 0.9.0`.
 
-  * The browser back / forward button should now work again. See [#36](https://github.com/colszowka/simplecov-html/pull/36) and 
+  * The browser back / forward button should now work again. See [#36](https://github.com/colszowka/simplecov-html/pull/36) and
     [#35](https://github.com/colszowka/simplecov-html/pull/35). Thanks @whatasunnyday and @justinsteele for submitting PRs to fix this.
   * Fix "warning: possibly useless use of a variable in void context" See [#31](https://github.com/colszowka/simplecov-html/pull/31). Thanks @cbandy
   * Always use binary file format. See [#32](https://github.com/colszowka/simplecov-html/pull/32). Thanks @andy128k

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ SimpleCov.start do
   add_group "Long files" do |src_file|
     src_file.lines.count > 100
   end
+  add_group "Multiple Files", ["app/models", "app/controllers"] # You can also pass in an array
   add_group "Short files", LineFilter.new(5) # Using the LineFilter class defined in Filters section above
 end
 ```

--- a/features/rspec_groups_and_filters_complex.feature
+++ b/features/rspec_groups_and_filters_complex.feature
@@ -15,6 +15,7 @@ Feature: Sophisticated grouping and filtering on RSpec
           src_file.filename =~ /MaGiC/i
         end
         add_group 'By string', 'project/meta_magic'
+        add_group 'By array', ['project/meta_magic']
 
         add_filter 'faked_project.rb'
         # Remove all files that include "describe" in their source
@@ -29,6 +30,7 @@ Feature: Sophisticated grouping and filtering on RSpec
       | All Files | 100.0%   | 1     |
       | By block  | 100.0%   | 1     |
       | By string | 100.0%   | 1     |
+      | By array  | 100.0%   | 1     |
 
     And I should see the source files:
       | name                            | coverage |

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -261,6 +261,8 @@ module SimpleCov::Configuration
       SimpleCov::StringFilter.new(filter_argument)
     elsif filter_proc
       SimpleCov::BlockFilter.new(filter_proc)
+    elsif filter_argument.kind_of?(Array)
+      SimpleCov::ArrayFilter.new(filter_argument)
     else
       raise ArgumentError, "Please specify either a string or a block to filter with"
     end

--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -41,4 +41,14 @@ module SimpleCov
       filter_argument.call(source_file)
     end
   end
+
+  class ArrayFilter < SimpleCov::Filter
+    # Returns true if any of the file paths passed in the given array matches the string
+    # configured when initializing this Filter with StringFilter.new(['some/path', 'other/path'])
+    def matches?(source_files_list)
+      filter_argument.any? do |arg|
+        source_files_list.filename =~ /#{arg}/
+      end
+    end
+  end
 end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -33,6 +33,18 @@ class TestFilters < Minitest::Test
     should "match a new SimpleCov::BlockFilter that is applicable" do
       assert SimpleCov::BlockFilter.new(Proc.new {|s| File.basename(s.filename) == 'sample.rb'}).matches?(@source_file)
     end
+
+    should "match a new SimpleCov::ArrayFilter when 'sample.rb' is passed as array" do
+      assert SimpleCov::ArrayFilter.new(['sample.rb']).matches?(@source_file)
+    end
+
+    should "not match a new SimpleCov::ArrayFilter when a file path different than 'sample.rb' is passed as array" do
+      assert !SimpleCov::ArrayFilter.new(['other_file.rb']).matches?(@source_file)
+    end
+
+    should "match a new SimpleCov::ArrayFilter when two file paths including 'sample.rb' are passed as array" do
+      assert SimpleCov::ArrayFilter.new(['sample.rb', 'other_file.rb']).matches?(@source_file)
+    end
   end
 
   context "with no filters set up and a basic source file in an array" do

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -97,7 +97,7 @@ class TestResult < Minitest::Test
     context "with groups set up for all files" do
       setup do
         SimpleCov.add_group 'Models', 'app/models'
-        SimpleCov.add_group 'Controllers', 'app/controllers'
+        SimpleCov.add_group 'Controllers', ['app/controllers']
         SimpleCov.add_group 'Other' do |src_file|
           File.basename(src_file.filename) == 'sample.rb'
         end


### PR DESCRIPTION
After two years of waiting we finally can use arrays in simplecov groups

Thanks for the original PR #104 since the author did not respond after 2 years I decided to copy past the PR based on the master branch.