### PR TITLE
Fixes order dependencies in unit tests

### DIFF
--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -37,8 +37,12 @@ class TestFilters < Minitest::Test
 
   context "with no filters set up and a basic source file in an array" do
     setup do
-      SimpleCov.filters = []
+      @prev_filters, SimpleCov.filters = SimpleCov.filters, []
       @files = [SimpleCov::SourceFile.new(source_fixture('sample.rb'), [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])]
+    end
+
+    teardown do
+      SimpleCov.filters = @prev_filters
     end
 
     should "return 0 items after executing SimpleCov.filtered on files when using a 'sample' string filter" do

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -3,12 +3,19 @@ require 'helper'
 class TestResult < Minitest::Test
   context "With a (mocked) Coverage.result" do
     setup do
-      SimpleCov.filters = []
-      SimpleCov.groups = {}
-      SimpleCov.formatter = nil
+      @prev_filters,   SimpleCov.filters   = SimpleCov.filters,   []
+      @prev_groups,    SimpleCov.groups    = SimpleCov.groups,    {}
+      @prev_formatter, SimpleCov.formatter = SimpleCov.formatter, nil
+
       @original_result = {source_fixture('sample.rb') => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
           source_fixture('app/models/user.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
           source_fixture('app/controllers/sample_controller.rb') => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
+    end
+
+    teardown do
+      SimpleCov.filters   = @prev_filters
+      SimpleCov.groups    = @prev_groups
+      SimpleCov.formatter = @prev_formatter
     end
 
     context "a simple cov result initialized from that" do


### PR DESCRIPTION
Some tests were changing global configuration settings
without restoring them afterwards. Fixes #362