### PR TITLE
Only run the at_exit behaviors if the current PID matches the PID that called SimpleCov.start

### DIFF
--- a/features/rspec_basic.feature
+++ b/features/rspec_basic.feature
@@ -14,14 +14,15 @@ Feature:
     When I open the coverage report generated with `bundle exec rspec spec`
     Then I should see the groups:
       | name      | coverage | files |
-      | All Files | 91.23%   | 6     |
+      | All Files | 91.8%   | 7     |
 
     And I should see the source files:
       | name                                    | coverage |
       | lib/faked_project.rb                    | 100.0 %  |
-      | lib/faked_project/some_class.rb         | 80.0 %  |
+      | lib/faked_project/some_class.rb         | 80.0 %   |
       | lib/faked_project/framework_specific.rb | 75.0 %   |
       | lib/faked_project/meta_magic.rb         | 100.0 %  |
+      | spec/forking_spec.rb                    | 100.0 %  |
       | spec/meta_magic_spec.rb                 | 100.0 %  |
       | spec/some_class_spec.rb                 | 100.0 %  |
 

--- a/features/rspec_groups_using_filter_class.feature
+++ b/features/rspec_groups_using_filter_class.feature
@@ -24,10 +24,10 @@ Feature: Grouping on RSpec using a custom filter class
     When I open the coverage report generated with `bundle exec rspec spec`
     Then I should see the groups:
       | name             | coverage | files |
-      | All Files        | 91.23%   | 6     |
+      | All Files        | 91.8%    | 7     |
       | By filter class  | 78.26%   | 2     |
       | By string        | 100.0%   | 1     |
-      | Ungrouped        | 100.0%   | 3     |
+      | Ungrouped        | 100.0%   | 4     |
 
     And I should see the source files:
       | name                                    | coverage |
@@ -35,6 +35,7 @@ Feature: Grouping on RSpec using a custom filter class
       | lib/faked_project/some_class.rb         | 80.0 %   |
       | lib/faked_project.rb                    | 100.0 %  |
       | lib/faked_project/meta_magic.rb         | 100.0 %  |
+      | spec/forking_spec.rb                    | 100.0 %  |
       | spec/meta_magic_spec.rb                 | 100.0 %  |
       | spec/some_class_spec.rb                 | 100.0 %  |
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -4,6 +4,7 @@
 module SimpleCov
   class << self
     attr_accessor :running
+    attr_accessor :pid
 
     #
     # Sets up SimpleCov to run against your project.
@@ -28,6 +29,7 @@ module SimpleCov
         configure(&block) if block_given?
         @result = nil
         self.running = true
+        self.pid = Process.pid
         Coverage.start
       else
         warn "WARNING: SimpleCov is activated, but you're not running Ruby 1.9+ - no coverage analysis will happen"

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -41,6 +41,9 @@ SimpleCov::CommandGuesser.original_run_command = "#{$0} #{ARGV.join(" ")}"
 
 at_exit do
 
+  # If we are in a different process than called start, don't interfere.
+  next if SimpleCov.pid != Process.pid
+
   if $! # was an exception thrown?
     # if it was a SystemExit, use the accompanying status
     # otherwise set a non-zero status representing termination by some other exception

--- a/test/faked_project/spec/forking_spec.rb
+++ b/test/faked_project/spec/forking_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'forking' do
+  it do
+    Process.waitpid(Kernel.fork { })
+  end
+end


### PR DESCRIPTION
This handles the case where a test calls fork at some point, the new process shouldn't try to run coverage formatters or check the minimum coverage level.

This resolves #371.