### PR TITLE
update README with Spring config

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,8 @@ if ENV['RAILS_ENV'] == 'test'
 end
 ```
 
+(3) Run `spring rspec <path>` as normal. Remember to run `spring stop` after making important changes to your app or its specs!
+
 ## Contributing
 
 See the [contributing guide](https://github.com/colszowka/simplecov/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -589,8 +589,14 @@ Try [coverband](https://github.com/danmayer/coverband).
 
 If you're using [Spring](https://github.com/rails/spring) to speed up test suite runs and want to run SimpleCov along with them, you'll find that it often misreports coverage with the default config due to some sort of eager loading issue. Don't despair!
 
-Just create `config/spring.rb` and move your SimpleCov config into it. Here's a simple version of what the file should look like:
+(1) Change the following settings in `development.rb` and `test.rb`.
+```ruby
+# Disable Rails's static asset server (Apache or nginx will already do this)
+config.serve_static_files = false
+config.eager_load = false
+```
 
+(2) Add your SimpleCov config, as you normally would, to your `spec_helper.rb` (or `rails_helper.rb` for RSpec 3). If you have a `config/spring.rb` file (or anything similar), add it to the start of such file. Here's a simple version of what the config should look like:
 ```ruby
 if ENV['RAILS_ENV'] == 'test'
   require 'simplecov'


### PR DESCRIPTION
I hope the way I phrased everything is okay. As mentioned in issue #381 I set two configurations to `false` in my environment files. Such settings were also recommended by Rails. And although Spring preloads your environment, I find that still disabling `eager_load` helps Spring cooperate with SimpleCov

**ALSO** I know the contributing doc says to write tests for any changes, but since this is just the README, I do not think it is necessary. I can provide my own stats if needed (running my own suite).

```
DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to
`config.serve_static_files` to clarify its role (it merely enables serving everything in the
`public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be
removed in Rails 5.0. Please migrate your configuration files accordingly. (called from block in
<top (required)> at /var/www/rails/hosted-fork/hpbxgui/config/environments/development.rb:15)

config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true
```