### PR TITLE
Require the Ruby English library prior to use

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -1,3 +1,5 @@
+require "English"
+
 # Load default formatter gem
 require "simplecov-html"
 


### PR DESCRIPTION
The use of English's `$ERROR_INFO`, rather than the standard `$!`, causes a warning in Ruby when no exceptions have previously occurred. Requiring the English library preloads and initializes the global and removes this warning.