### PR TITLE
Fix default minimum coverage by file error message

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -68,7 +68,7 @@ at_exit do
         $stderr.printf("Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%).\n", covered_percent, SimpleCov.minimum_coverage)
         @exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
       elsif covered_percentages.any? { |p| p < SimpleCov.minimum_coverage_by_file } # rubocop:disable Metrics/BlockNesting
-        $stderr.printf("File (%.2f%%) is only (%.2f%%) covered. This is below the expected minimum coverage per file of (%.2f%%).\n", least_covered_file, covered_percentages.min, SimpleCov.minimum_coverage_by_file)
+        $stderr.printf("File (%s) is only (%.2f%%) covered. This is below the expected minimum coverage per file of (%.2f%%).\n", SimpleCov.result.least_covered_file, covered_percentages.min, SimpleCov.minimum_coverage_by_file)
         @exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
       elsif (last_run = SimpleCov::LastRun.read) # rubocop:disable Metrics/BlockNesting
         diff = last_run["result"]["covered_percent"] - covered_percent


### PR DESCRIPTION
I wanted to add a test for this, but I couldn't get it working:
* on Ruby 2.2.2, rspec seg faults
* on Ruby 2.2.1 & 2.1.6, the feature (cucumber) tests have a lot of deprecations & failures e.g. 
```
The use of the "#before_cmd"-hook is deprecated. Please define with "#before(:command) {}" instead. Called by /Users/gerry/Dropbox/icc/simplecov/features/support/env.rb:47:in `block in <top (required)>'
Using the default profile...
The use of "in_current_dir" is deprecated. Use "#cd('.') { }" instead. Called by /Users/gerry/Dropbox/icc/simplecov/features/support/env.rb:37:in `block in <top (required)>'
...The use of "#set_env" is deprecated. Please use "set_environment_variable" instead. But be careful, this method uses a different kind of implementation. Called by /Users/gerry/Dropbox/icc/simplecov/features/support/env.rb:48:in `block (2 levels) in <top (required)>'
.
...
*****
The browser raised a syntax error while trying to evaluate css selector "#<RSpec::Matchers::DSL::Matcher:0x007fe7aaf2f348>" (Capybara::Poltergeist::InvalidSelector)
./features/step_definitions/simplecov_steps.rb:36:in `/^a coverage report should have been generated(?: in "([^"]*)")?$/'
./features/step_definitions/simplecov_steps.rb:27:in `/^I open the coverage report generated with `([^`]+)`$/'
features/config_autoload.feature:32:in `And I open the coverage report generated with `bundle exec rspec spec`'

The browser raised a syntax error while trying to evaluate css selector "#<RSpec::Matchers::DSL::Matcher:0x007fe7aaa5dc48>" (Capybara::Poltergeist::InvalidSelector)
./features/step_definitions/simplecov_steps.rb:36:in `/^a coverage report should have been generated(?: in "([^"]*)")?$/'
./features/step_definitions/simplecov_steps.rb:27:in `/^I open the coverage report generated with `([^`]+)`$/'
features/config_command_name.feature:25:in `When I open the coverage report generated with `bundle exec rake test`'
...