### PR TITLE
Avoid bundling aruba 0.8.x for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
     gem "i18n", "~> 0.6.11"
   end
   platform :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22 do
-    gem "aruba", "~> 0.6"
+    gem "aruba", "~> 0.7.4"
     gem "capybara", "~> 2.4"
     gem "cucumber", "~> 2.0"
     gem "phantomjs", "~> 1.9"

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -166,7 +166,7 @@ module SimpleCov
     def project_name(new_name = nil)
       return @project_name if defined?(@project_name) && @project_name && new_name.nil?
       @project_name = new_name if new_name.is_a?(String)
-      @project_name ||= File.basename(root.split("/").last).capitalize.gsub("_", " ")
+      @project_name ||= File.basename(root.split("/").last).capitalize.tr("_", " ")
     end
 
     #


### PR DESCRIPTION
As discussed at #400, simplecov features are currently broken, and that prevents some PRs unrelated to the failing features to get merged in.

This was caused by aruba's internal refactoring between 0.7 and 0.8 around [here](https://github.com/cucumber/aruba/blob/v0.8.1/lib/aruba/cucumber.rb#L339).
It seems like that `all be_...` is expected to to invoke RSpec's built in All matcher, but it actually calls Capybara's `page.all` in our context.

I would raise an issue for the aruba repo later, but let us lock the gem's version here until the problem is fixed there.