### PR TITLE
Fixes deprecation warning in cucumber related to in_current_dir

### DIFF
--- a/features/step_definitions/transformers.rb
+++ b/features/step_definitions/transformers.rb
@@ -8,6 +8,6 @@
 #
 Transform "bundle exec rspec spec" do |_|
   files = nil # Avoid shadowing
-  in_current_dir { files = Dir["spec/**/*_spec.rb"] }
+  in_current_directory { files = Dir["spec/**/*_spec.rb"] }
   "bundle exec rspec #{files.sort.join(' ')}"
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,7 +34,7 @@ Before do
   this_dir = File.dirname(__FILE__)
 
   # Clean up and create blank state for fake project
-  in_current_dir do
+  in_current_directory do
     FileUtils.rm_rf "project"
     FileUtils.cp_r File.join(this_dir, "../../spec/faked_project/"), "project"
   end


### PR DESCRIPTION
I was running tests and noticed there was a deprecation warning, as seen here:

https://travis-ci.org/colszowka/simplecov/jobs/78887751

Not sure if this will work in all the rubies, though. Let's see what travis has to say about that.