### PR TITLE
Adds option to track uncovered source files.

### DIFF
--- a/features/config_tracked_files.feature
+++ b/features/config_tracked_files.feature
@@ -16,7 +16,7 @@ Feature:
     When I open the coverage report generated with `bundle exec rake test`
     Then I should see the groups:
       | name      | coverage | files |
-      | All Files | 81.54%   | 7     |
+      | All Files | 76.81%   | 7     |
 
     And I should see the source files:
       | name                                    | coverage |

--- a/features/config_tracked_files.feature
+++ b/features/config_tracked_files.feature
@@ -1,0 +1,29 @@
+@test_unit
+Feature:
+
+  Using the setting `tracked_files` should add files that were not
+  required to the report.
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        track_files "lib/**/*.rb"
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+    Then I should see the groups:
+      | name      | coverage | files |
+      | All Files | 81.54%   | 7     |
+
+    And I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project.rb                    | 100.0 %  |
+      | lib/faked_project/untested_class.rb     | 0.0 %    |
+      | lib/faked_project/some_class.rb         | 80.0 %   |
+      | lib/faked_project/framework_specific.rb | 75.0 %   |
+      | lib/faked_project/meta_magic.rb         | 100.0 %  |
+      | test/meta_magic_test.rb                 | 100.0 %  |
+      | test/some_class_test.rb                 | 100.0 %  |

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -49,19 +49,16 @@ module SimpleCov
     end
 
     #
-    # Finds files that were to be tracked but were not covered and initializes
-    # their coverage to zero, with an estimation of the line count.
+    # Finds files that were to be tracked but were not loaded and initializes
+    # their coverage to zero.
     #
-    def add_uncovered_files(result)
+    def add_not_loaded_files(result)
       if @track_files_glob
         result = result.dup
         Dir[@track_files_glob].each do |file|
           absolute = File.expand_path(file)
 
-          unless result[absolute]
-            lines = File.readlines(absolute)
-            result[absolute] = [0] * lines.count { |l| relevant_line?(l) }
-          end
+          result[absolute] ||= [0] * File.foreach(absolute).count
         end
       end
 
@@ -69,24 +66,11 @@ module SimpleCov
     end
 
     #
-    # Determines if a line should be considered by coverage tools.
-    # This method is just an estimation, but it is not very important
-    # that it is accurate. It is only used when all lines in a file
-    # are not covered. As soon as a single line is covered, the counting
-    # method will be the one provided by the Coverage module.
-    #
-    def relevant_line?(line)
-      l = line.strip
-
-      !(l.empty? || l =~ /^else$/ || l =~ /^end$/ || l[0] == '#' || l =~ /^rescue(\s+.*)?$/)
-    end
-
-    #
     # Returns the result for the current coverage run, merging it across test suites
     # from cache using SimpleCov::ResultMerger if use_merging is activated (default)
     #
     def result
-      @result ||= SimpleCov::Result.new(add_uncovered_files(Coverage.result)) if running
+      @result ||= SimpleCov::Result.new(add_not_loaded_files(Coverage.result)) if running
       # If we're using merging of results, store the current result
       # first, then merge the results and return those
       if use_merging

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -42,6 +42,10 @@ module SimpleCov
       coverage_path
     end
 
+    def track_files(glob)
+      @track_files_glob = glob
+    end
+
     #
     # Returns the list of configured filters. Add filters using SimpleCov.add_filter.
     #

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -32,6 +32,8 @@ SimpleCov.profiles.define "rails" do
   add_group "Mailers", "app/mailers"
   add_group "Helpers", "app/helpers"
   add_group "Libraries", "lib"
+
+  track_files "{app,lib}/**/*.rb"
 end
 
 # Default configuration

--- a/spec/faked_project/lib/faked_project.rb
+++ b/spec/faked_project/lib/faked_project.rb
@@ -4,7 +4,7 @@ class FakedProject
   end
 end
 
-Dir[File.join(File.dirname(__FILE__), "faked_project/*.rb")].each do |file|
+Dir[File.join(File.dirname(__FILE__), "faked_project/*.rb")].reject { |f| /untested/.match(f) }.each do |file|
   require file # Require all source files in project dynamically so we can inject some stuff depending on test situation
 end
 

--- a/spec/faked_project/lib/faked_project/untested_class.rb
+++ b/spec/faked_project/lib/faked_project/untested_class.rb
@@ -1,0 +1,11 @@
+class UntestedClass
+  def initialize(yogurts)
+    @yogurts = yogurts
+  end
+
+  def power_level
+    @yogurts.map do |yo|
+      yo.experience_points**2
+    end.reduce(0, &:+)
+  end
+end


### PR DESCRIPTION
Fixes #413 

Added a configuration option `track_files` that accepts
a glob. With this enabled, coverage result will include
uncovered files that match the glob.

In the `rails` profile this is set to `{app,lib}/**/*.rb`

Regarding line count issue:

It is not easy to determine which lines should be classified as relevant (this is done by the ruby parser), so this implementation does not touch the coverage information for covered files, to avoid ruining the accurate percentages.
When handling uncovered files it uses an approximation function to determine if the line is relevant or not, based on the code present in #16. As uncovered files have 0% coverage, this will only affect the global percentage, so I don't think it's an issue.
