### PR TITLE
Recurse upward looking for .simplecov

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -1,5 +1,6 @@
 # Load default formatter gem
 require "simplecov-html"
+require "pathname"
 
 SimpleCov.profiles.define "root_filter" do
   # Exclude all files outside of simplecov root
@@ -97,5 +98,20 @@ if home_dir
 end
 
 # Autoload config from .simplecov if present
-config_path = File.join(SimpleCov.root, ".simplecov")
-load config_path if File.exist?(config_path)
+# Recurse upwards until we find .simplecov or reach the root directory
+
+config_path = Pathname.new(SimpleCov.root)
+loop do
+  filename = config_path.join(".simplecov")
+  if filename.exist?
+    begin
+      load filename
+    rescue LoadError, StandardError
+      $stderr.puts "Warning: Error occurred while trying to load #{filename}. " \
+        "Error message: #{$!.message}"
+    end
+    break
+  end
+  config_path, = config_path.split
+  break if config_path.root?
+end


### PR DESCRIPTION
The SimpleCov documentation states: "To avoid [duplicated configuration], you
can place a file called `.simplecov` in your project root." However, SimpleCov did
not actually look in the "project root" for this file, unless specially configured
to know where the project root is. Rather, it would simply look in the working
directory. Working directory != project root. (Unfortunately.)

Therefore, when looking for `.simplecov`, recurse upwards from the working directory
until it is found (or the root directory is reached). This is comparable to the
way that git recurses upwards looking for a .git directory, meaning that you can
use git anywhere in your project root or below.

Since there is no guarantee that you have permissions to read `.simplecov`, catch
exceptions and display a warning message if one occurs.