### PR TITLE
Fix root_filter evaluates SimpleCov.root before initialization.

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -4,8 +4,9 @@ require "pathname"
 
 SimpleCov.profiles.define "root_filter" do
   # Exclude all files outside of simplecov root
-  root_filter = /\A#{Regexp.escape(SimpleCov.root)}/io
+  root_filter = nil
   add_filter do |src|
+    root_filter ||= /\A#{Regexp.escape(SimpleCov.root)}/io
     !(src.filename =~ root_filter)
   end
 end


### PR DESCRIPTION
If SimpleCov.root is set to other directory, but root_filter uses current directory.

```ruby
require 'simplecov'
SimpleCov.root '/other/directory'
obj = Struct.new(:filename).new('/other/directory/test.rb')
p SimpleCov.filters.any?{ |filter| filter.matches? obj }
#=> returns true but it should be false.
```