### PR TITLE
Fix coverage rate of the parallel_tests

### DIFF
--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -5,11 +5,11 @@ module SimpleCov
       new_array = dup
       array.each_with_index do |element, i|
         pair = [element, new_array[i]]
-        if pair.any?(&:nil?) && pair.map(&:to_i).all?(&:zero?)
-          new_array[i] = nil
-        else
-          new_array[i] = element.to_i + new_array[i].to_i
-        end
+        new_array[i] = if pair.any?(&:nil?) && pair.map(&:to_i).all?(&:zero?)
+                         nil
+                       else
+                         element.to_i + new_array[i].to_i
+                       end
       end
       new_array
     end

--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -4,14 +4,11 @@ module SimpleCov
     def merge_resultset(array)
       new_array = dup
       array.each_with_index do |element, i|
-        if element.nil? && new_array[i].nil?
-          new_array[i] = nil
-        elsif (element.nil? && new_array[i] == 0) || (element == 0 && new_array[i].nil?)
+        pair = [element, new_array[i]]
+        if pair.any?(&:nil?) && pair.map(&:to_i).all?(&:zero?)
           new_array[i] = nil
         else
-          local_value = element || 0
-          other_value = new_array[i] || 0
-          new_array[i] = local_value + other_value
+          new_array[i] = element.to_i + new_array[i].to_i
         end
       end
       new_array

--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -6,6 +6,8 @@ module SimpleCov
       array.each_with_index do |element, i|
         if element.nil? && new_array[i].nil?
           new_array[i] = nil
+        elsif (element.nil? && new_array[i] == 0) || (element == 0 && new_array[i].nil?)
+          new_array[i] = nil
         else
           local_value = element || 0
           other_value = new_array[i] || 0

--- a/spec/merge_helpers_spec.rb
+++ b/spec/merge_helpers_spec.rb
@@ -9,6 +9,7 @@ describe "merge helpers" do
         source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
         source_fixture("app/controllers/sample_controller.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
         source_fixture("resultset1.rb") => [1, 1, 1, 1],
+        source_fixture("parallel_tests.rb") => [nil, 0, nil, 0],
       }.extend(SimpleCov::HashMergeHelper)
 
       @resultset2 = {
@@ -16,6 +17,7 @@ describe "merge helpers" do
         source_fixture("app/models/user.rb") => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
         source_fixture("app/controllers/sample_controller.rb") => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil],
         source_fixture("resultset2.rb") => [nil, 1, 1, nil],
+        source_fixture("parallel_tests.rb") => [nil, nil, 0, 0],
       }
     end
 
@@ -42,6 +44,10 @@ describe "merge helpers" do
 
       it "has proper results for resultset2.rb" do
         expect(subject[source_fixture("resultset2.rb")]).to eq([nil, 1, 1, nil])
+      end
+
+      it "has proper results for parallel_tests.rb" do
+        expect(subject[source_fixture("parallel_tests.rb")]).to eq([nil, nil, nil, 0])
       end
     end
 


### PR DESCRIPTION
The coverage rate has decreased when used with `parallel_tests`. So, I fixed it.

## merge_resultset

This Pull Request is to change behaviors of 2 and 4.

| no | element | new_array[i] | before | after |
|----|----|----|----|----|
| 1 | nil | nil | nil | nil |
| 2 | nil | 0   | 0   | **nil** |
| 3 | nil | 1   | 1   | 1 |
| 4 | 0   | nil | 0   | **nil** |
| 5 | 0   | 0   | 0   | 0 |
| 6 | 0   | 1   | 1   | 1 |
| 7 | 1   | nil | 1   | 1 |
| 8 | 1   | 0   | 1   | 1 |
| 9 | 1   | 1   | 2   | 2 |

## Environment

- Ruby 2.2.3
- Rails 4.2.5
- simplecov 0.11.1
- parallel_tests 1.7.0