### PR TITLE
add a group for Active Jobs classes to default Rails profile

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -31,6 +31,7 @@ SimpleCov.profiles.define "rails" do
   add_group "Models", "app/models"
   add_group "Mailers", "app/mailers"
   add_group "Helpers", "app/helpers"
+  add_group "Jobs", %w(app/jobs app/workers)
   add_group "Libraries", "lib"
 
   track_files "{app,lib}/**/*.rb"


### PR DESCRIPTION
I'm using Active Job in a Rails project for the first time and my job classes are currently "Ungrouped". Since `app/jobs` is the default location for these classes, I think it's worth adding this to the Rails profile.

Are there tests for this? I couldn't find any but if I've missed them, please point them out and I'll add a test as well. Thanks