### PR TITLE
Make compatible with latest RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,3 +68,6 @@ Style/FileName:
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
+
+Style/GuardClause:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,5 +66,5 @@ Style/FileName:
   Exclude:
     - 'spec/fixtures/utf-8.rb'
 
-Style/TrailingComma:
-  EnforcedStyleForMultiline: 'comma'
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :test do
     gem "cucumber", "~> 2.0"
     gem "phantomjs", "~> 1.9"
     gem "poltergeist", "~> 1.1"
-    gem "rubocop", ">= 0.30"
+    gem "rubocop", "~> 0.36.0"
     gem "test-unit", "~> 3.0"
   end
 end

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -74,14 +74,22 @@ module SimpleCov
     # from cache using SimpleCov::ResultMerger if use_merging is activated (default)
     #
     def result
-      @result ||= SimpleCov::Result.new(add_not_loaded_files(Coverage.result)) if running
+      # Ensure the variable is defined to avoid ruby warnings
+      @result = nil unless defined?(@result)
+
+      # Collect our coverage result
+      if running && !result?
+        @result = SimpleCov::Result.new add_not_loaded_files(Coverage.result)
+      end
+
       # If we're using merging of results, store the current result
       # first, then merge the results and return those
       if use_merging
-        SimpleCov::ResultMerger.store_result(@result) if @result
-        return SimpleCov::ResultMerger.merged_result
+        SimpleCov::ResultMerger.store_result(@result) if result?
+
+        SimpleCov::ResultMerger.merged_result
       else
-        return @result if defined? @result
+        @result
       end
     ensure
       self.running = false

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -114,7 +114,7 @@ module SimpleCov
       return @nocov_token if defined?(@nocov_token) && nocov_token.nil?
       @nocov_token = (nocov_token || "nocov")
     end
-    alias_method :skip_token, :nocov_token
+    alias skip_token nocov_token
 
     #
     # Returns the configured groups. Add groups using SimpleCov.add_group

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -51,15 +51,16 @@ at_exit do
   # If we are in a different process than called start, don't interfere.
   next if SimpleCov.pid != Process.pid
 
-  if $! # was an exception thrown?
-    # if it was a SystemExit, use the accompanying status
-    # otherwise set a non-zero status representing termination by some other exception
-    # (see github issue 41)
-    @exit_status = $!.is_a?(SystemExit) ? $!.status : SimpleCov::ExitCodes::EXCEPTION
-  else
-    # Store the exit status of the test run since it goes away after calling the at_exit proc...
-    @exit_status = SimpleCov::ExitCodes::SUCCESS
-  end
+  @exit_status = if $! # was an exception thrown?
+                   # if it was a SystemExit, use the accompanying status
+                   # otherwise set a non-zero status representing termination by
+                   # some other exception (see github issue 41)
+                   $!.is_a?(SystemExit) ? $!.status : SimpleCov::ExitCodes::EXCEPTION
+                 else
+                   # Store the exit status of the test run since it goes away
+                   # after calling the at_exit proc...
+                   SimpleCov::ExitCodes::SUCCESS
+                 end
 
   SimpleCov.at_exit.call
 

--- a/lib/simplecov/jruby_fix.rb
+++ b/lib/simplecov/jruby_fix.rb
@@ -11,7 +11,7 @@ if defined?(JRUBY_VERSION) && JRUBY_VERSION.to_f < 1.7
   # This monkey patches Coverage to address those issues
   module Coverage
     class << self
-      alias_method :__broken_result__, :result
+      alias __broken_result__ result
 
       def result # rubocop:disable Metrics/MethodLength
         fixed = {}

--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -12,7 +12,7 @@ module SimpleCov
     attr_reader :original_result
     # Returns all files that are applicable to this result (sans filters!) as instances of SimpleCov::SourceFile. Aliased as :source_files
     attr_reader :files
-    alias_method :source_files, :files
+    alias source_files files
     # Explicitly set the Time this result has been created
     attr_writer :created_at
     # Explicitly set the command name that was used for this coverage result. Defaults to SimpleCov.command_name

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -20,9 +20,9 @@ module SimpleCov
       attr_reader :skipped
 
       # Lets grab some fancy aliases, shall we?
-      alias_method :source, :src
-      alias_method :line, :line_number
-      alias_method :number, :line_number
+      alias source src
+      alias line line_number
+      alias number line_number
 
       def initialize(src, line_number, coverage)
         fail ArgumentError, "Only String accepted for source" unless src.is_a?(String)
@@ -76,7 +76,7 @@ module SimpleCov
     attr_reader :coverage
     # The source code for this file. Aliased as :source
     attr_reader :src
-    alias_method :source, :src
+    alias source src
 
     def initialize(filename, coverage)
       @filename = filename
@@ -102,7 +102,7 @@ module SimpleCov
       process_skipped_lines!
       @lines
     end
-    alias_method :source_lines, :lines
+    alias source_lines lines
 
     # Access SimpleCov::SourceFile::Line source lines by line number
     def line(number)
@@ -116,7 +116,7 @@ module SimpleCov
       if relevant_lines.zero?
         0.0
       else
-        Float((covered_lines.count) * 100.0 / relevant_lines.to_f)
+        Float(covered_lines.count * 100.0 / relevant_lines.to_f)
       end
     end
 
@@ -172,8 +172,8 @@ module SimpleCov
       lines.each do |line|
         if line.src =~ /^([\s]*)#([\s]*)(\:#{SimpleCov.nocov_token}\:)/
           skipping = !skipping
-        else
-          line.skipped! if skipping
+        elsif skipping
+          line.skipped!
         end
       end
     end

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -1,22 +1,25 @@
 module SimpleCov
-  VERSION = "0.11.1"
-  def VERSION.to_a
+  version = "0.11.1"
+
+  def version.to_a
     split(".").map(&:to_i)
   end
 
-  def VERSION.major
+  def version.major
     to_a[0]
   end
 
-  def VERSION.minor
+  def version.minor
     to_a[1]
   end
 
-  def VERSION.patch
+  def version.patch
     to_a[2]
   end
 
-  def VERSION.pre
+  def version.pre
     to_a[3]
   end
+
+  VERSION = version.freeze
 end

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -1,7 +1,7 @@
 require "helper"
 
 describe SimpleCov::SourceFile do
-  COVERAGE_FOR_SAMPLE_RB = [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil]
+  COVERAGE_FOR_SAMPLE_RB = [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil].freeze
   context "a source file initialized with some coverage data" do
     subject do
       SimpleCov::SourceFile.new(source_fixture("sample.rb"), COVERAGE_FOR_SAMPLE_RB)


### PR DESCRIPTION
This brings it up-to-date for `v0.36.0`.

Changelog: https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0360-14012016