### PR TITLE
Stop polluting ::Array and ::Hash

### DIFF
--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -27,12 +27,9 @@ module SimpleCov
       end
 
       new_resultset.each_key do |filename|
-        new_resultset[filename] = (self[filename] || []).merge_resultset(hash[filename] || [])
+        new_resultset[filename] = (self[filename] || []).extend(SimpleCov::ArrayMergeHelper).merge_resultset(hash[filename] || [])
       end
       new_resultset
     end
   end
 end
-
-Array.send :include, SimpleCov::ArrayMergeHelper
-Hash.send :include, SimpleCov::HashMergeHelper

--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -24,6 +24,7 @@ module SimpleCov
     # Initialize a new SimpleCov::Result from given Coverage.result (a Hash of filenames each containing an array of
     # coverage data)
     def initialize(original_result)
+      original_result = original_result.dup.extend(SimpleCov::HashMergeHelper) unless original_result.is_a? SimpleCov::HashMergeHelper
       @original_result = original_result.freeze
       @files = SimpleCov::FileList.new(original_result.map do |filename, coverage|
         SimpleCov::SourceFile.new(filename, coverage) if File.file?(filename)

--- a/spec/merge_helpers_spec.rb
+++ b/spec/merge_helpers_spec.rb
@@ -9,7 +9,7 @@ describe "merge helpers" do
         source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
         source_fixture("app/controllers/sample_controller.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
         source_fixture("resultset1.rb") => [1, 1, 1, 1],
-      }
+      }.extend(SimpleCov::HashMergeHelper)
 
       @resultset2 = {
         source_fixture("sample.rb") => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil],


### PR DESCRIPTION
Requiring simlpecov globally adds the `merge_resultset` method to the built-in Array class and Hash class via monkey-patching, which means this gem widely changes the test subject's behavior.
Such a horrible vandalism should never be done by a test coverage measurement tool. We should immediately stop doing this.

I suppose the same merging logic could be more safely and cleanly implemented by two or three static methods instead of extending the core classes, but for now, I'd suggest a patch that changes the Result class to dynamically extend the result objects using the existing Modules.

This way we would be able to minimize the conflict with other PRs working on the merging_helpers e.g. #436 and #441.