### PR TITLE
memoize SimpleCov::Configuration#coverage_path

### DIFF
--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -28,6 +28,7 @@ module SimpleCov
     #
     def coverage_dir(dir = nil)
       return @coverage_dir if defined?(@coverage_dir) && dir.nil?
+      @coverage_path = nil # invalidate cache
       @coverage_dir = (dir || "coverage")
     end
 
@@ -37,9 +38,11 @@ module SimpleCov
     # values. Will create the directory if it's missing
     #
     def coverage_path
-      coverage_path = File.expand_path(coverage_dir, root)
-      FileUtils.mkdir_p coverage_path
-      coverage_path
+      @coverage_path ||= begin
+        coverage_path = File.expand_path(coverage_dir, root)
+        FileUtils.mkdir_p coverage_path
+        coverage_path
+      end
     end
 
     #


### PR DESCRIPTION
This is to avoid calling `FileUtils.mkdir_p` like 50 times, like visible here when `$DEBUG = true`:

```
[...]
Finished in 0.20738 seconds (files took 0.69467 seconds to load)
42 examples, 1 failure, 1 pending

Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
[Coveralls] Outside the CI environment, not sending data.
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
Exception `Errno::EEXIST' at /Users/paddor/.rubies/ruby-2.3.0/lib/ruby/2.3.0/fileutils.rb:253 - File exists @ dir_s_mkdir - /Users/paddor/src/ruby/cztop/coverage
```