### PR TITLE
nocov_regex feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,16 @@ The name of the token can be changed to your liking. [Learn more about the nocov
 
 **Note:** You shouldn't have to use the nocov token to skip private methods that are being included in your coverage. If you appropriately test the public interface of your classes and objects you should automatically get full coverage of your private methods.
 
+You can also exclude code using a regular expression. Setup your .simplecov file like this:
+
+```ruby
+SimpleCov.start do
+  nocov_regex /^[\s]*annoying_method/
+end
+```
+
+and lines matching the regular expression will be skipped, just as if they were inside a :nocov: block. In this example, the code for annoying_method would be tested ("def annoying_method"), but any call to that method would be skipped. This may be useful for code that renders errors, if you don't want to write tests for every single error handling condition.
+
 ## Default root filter and coverage for things outside of it
 
 By default, SimpleCov filters everything outside of the `SimpleCov.root` directory. However, sometimes you may want

--- a/features/skipping_code_blocks_automatically.feature
+++ b/features/skipping_code_blocks_automatically.feature
@@ -1,0 +1,39 @@
+@test_unit @nocov_regex
+Feature:
+
+  When code matches a nocov regex, it does not count against the coverage numbers
+
+  Background:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start 'test_frameworks' do
+        SimpleCov.nocov_regex /^[\s]*def some_weird_code/
+        SimpleCov.nocov_regex /^[\s]*never_reached/
+      end
+      """
+
+  Scenario: Plain run with a nocov'd method
+    Given a file named "lib/faked_project/nocov_regex.rb" with:
+      """
+      class SourceCodeMatchingNocovRegex
+        def some_weird_code
+          never_reached
+        end
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+
+    Then I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project.rb                    | 100.0 %  |
+      | lib/faked_project/some_class.rb         | 80.0 %   |
+      | lib/faked_project/framework_specific.rb | 75.0 %   |
+      | lib/faked_project/meta_magic.rb         | 100.0 %  |
+      | lib/faked_project/nocov_regex.rb        | 100.0 %  |
+
+    And there should be 2 skipped lines in the source files
+
+    And the report should be based upon:
+      | Unit Tests |

--- a/features/skipping_code_blocks_automatically.feature
+++ b/features/skipping_code_blocks_automatically.feature
@@ -1,4 +1,4 @@
-@test_unit @nocov_regex
+@test_unit
 Feature:
 
   When code matches a nocov regex, it does not count against the coverage numbers

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -128,8 +128,7 @@ module SimpleCov
     # this method multiple times to define multiple regular expressions
     #
     def nocov_regexes(nocov_regex = nil)
-      return @nocov_regexes if defined?(@nocov_regexes) && nocov_regex.nil?
-      @nocov_regexes = [] if @nocov_regexes.nil?
+      @nocov_regexes ||= []
       @nocov_regexes << nocov_regex unless nocov_regex.nil?
       @nocov_regexes
     end

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -121,6 +121,21 @@ module SimpleCov
     alias skip_token nocov_token
 
     #
+    # Any lines matching regular expressions in this array will be excluded
+    # from the coverage metrics, just as if they were wrapped with :nocov:
+    #
+    # Configure with SimpleCov.nocov_regex(/^[\s]*my_method/). You may call
+    # this method multiple times to define multiple regular expressions
+    #
+    def nocov_regexes(nocov_regex = nil)
+      return @nocov_regexes if defined?(@nocov_regexes) && nocov_regex.nil?
+      @nocov_regexes = [] if @nocov_regexes.nil?
+      @nocov_regexes << nocov_regex unless nocov_regex.nil?
+      @nocov_regexes
+    end
+    alias nocov_regex nocov_regexes
+
+    #
     # Returns the configured groups. Add groups using SimpleCov.add_group
     #
     def groups

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -166,7 +166,8 @@ module SimpleCov
     end
 
     # Will go through all source files and mark lines that are wrapped within # :nocov: comment blocks
-    # as skipped.
+    # as skipped. If they aren't in a nocov block but match a nocov_regex, they
+    # will similarly be skipped.
     def process_skipped_lines!
       skipping = false
       lines.each do |line|
@@ -174,6 +175,12 @@ module SimpleCov
           skipping = !skipping
         elsif skipping
           line.skipped!
+        else
+          SimpleCov.nocov_regexes.each do |regex|
+            if line.src =~ regex
+              line.skipped!
+            end
+          end
         end
       end
     end

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -177,9 +177,7 @@ module SimpleCov
           line.skipped!
         else
           SimpleCov.nocov_regexes.each do |regex|
-            if line.src =~ regex
-              line.skipped!
-            end
+            line.skipped! if line.src =~ regex
           end
         end
       end


### PR DESCRIPTION
If you add regular expressions like this:

```
SimpleCov.start do
  nocov_regex /^[\s]*annoying_method/
end
```

then lines matching the regular expression will be skipped, just as if
they were inside a :nocov: block.

I'm hoping to be able to use this for a project. I've got a number of controllers that render errors in certain cases. I don't want to write rspec tests for every single possible error case, and I know the render_error function works, so I'm hoping to be able to just filter out lines that call that function (but not the lines of the function itself).
