### PR TITLE
Tests for warnings

### DIFF
--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -10,12 +10,6 @@ module SimpleCov
   module Configuration # rubocop:disable ModuleLength
     attr_writer :filters, :groups, :formatter
 
-    def self.extended(base)
-      base.instance_eval do
-        @track_files_glob = nil
-      end
-    end
-
     #
     # The root for the project. This defaults to the
     # current working directory.

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -10,6 +10,12 @@ module SimpleCov
   module Configuration # rubocop:disable ModuleLength
     attr_writer :filters, :groups, :formatter
 
+    def self.extended(base)
+      base.instance_eval do
+        @track_files_glob = nil
+      end
+    end
+
     #
     # The root for the project. This defaults to the
     # current working directory.

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -22,3 +22,12 @@ ensure
   # Restore the previous value of stderr (typically equal to STDERR).
   $stderr = previous_stderr
 end
+
+RSpec.configure do |config|
+  # Fail tests if code generates runtime warnings
+  config.around(:example) do |example|
+    expect{example.call}
+      .not_to output(/^#{Regexp.escape(Dir.pwd)}\/.+:\d+: warning: /)
+      .to_stderr
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -49,8 +49,6 @@ RSpec.configure do |config|
   end
   # Fail tests if code generates runtime warnings
   config.around(:example) do |example|
-    expect { example.call }
-      .not_to output(/^#{project_path_regexp}\/.+:\d+: warning: /)
-      .to_stderr
+    expect { example.call }.not_to output(/^#{project_path_regexp}\/.+:\d+: warning: /).to_stderr
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
         end
       end
       example.call
-      kernel_warn_callers.keep_if{|c| c.match(/^#{project_path_regexp}/)}
+      kernel_warn_callers.keep_if { |c| c =~ /^#{project_path_regexp}/ }
       expect(kernel_warn_callers).to be_empty, "Kernel\#warn called from: #{kernel_warn_callers.join(', ')}."
     ensure
       Kernel.class_exec do
@@ -49,7 +49,7 @@ RSpec.configure do |config|
   end
   # Fail tests if code generates runtime warnings
   config.around(:example) do |example|
-    expect{example.call}
+    expect { example.call }
       .not_to output(/^#{project_path_regexp}\/.+:\d+: warning: /)
       .to_stderr
   end


### PR DESCRIPTION
@colszowka , regarding #451, I found a partial solution. It seems Ruby warnings are issued without consistency:
- From Ruby code, using [Kernel#warn](http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-warn)
- From C code, using [rb_warn()](https://github.com/ruby/ruby/blob/439224a5904411b288e441096e21a41244ddd1d6/error.c#L236)
- Printing to $stderr directly [in some cases](https://github.com/ruby/ruby/blob/439224a5904411b288e441096e21a41244ddd1d6/lib/net/ftp.rb#L223)

If warnings are issued within an example block, this PR will detect and fail the test. As  bonus, it will not fail tests if warnings were issued by code at some dependency outside the project.

Warnings issued outside example blocks, for example with a require, will not be detected though. The solution, would be to use the same technique, but inside the Rakefile perhaps.

Anyway, partial solution is better than nothing :-D
