### PR TITLE
Unfreeze SimpleCov::VERSION

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,7 @@ Style/TrailingCommaInLiteral:
 
 Style/GuardClause:
   Enabled: false
+
+Style/MutableConstant:
+  Exclude:
+    - 'lib/simplecov/version.rb' # required for older versions of rubygems

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -21,5 +21,5 @@ module SimpleCov
     to_a[3]
   end
 
-  VERSION = version.freeze
+  VERSION = version
 end


### PR DESCRIPTION
Older versions of rubygems choke on an immutable version string.

I wasn't able to actually get rubocop to complain about the mutable constant so I couldn't verify that the second commit actually does anything.