### PR TITLE
Make `track_files` work when configured with nil

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -57,9 +57,9 @@ module SimpleCov
     # their coverage to zero.
     #
     def add_not_loaded_files(result)
-      if track_files
+      if tracked_files
         result = result.dup
-        Dir[track_files].each do |file|
+        Dir[tracked_files].each do |file|
           absolute = File.expand_path(file)
 
           result[absolute] ||= [0] * File.foreach(absolute).count

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -50,9 +50,16 @@ module SimpleCov
     # or not they were explicitly required. Without this, un-required files
     # will not be present in the final report.
     #
-    def track_files(glob = nil)
-      return @track_files if defined?(@track_files) && glob.nil?
-      @track_files = glob
+    def track_files(glob)
+      @tracked_files = glob
+    end
+
+    #
+    # Returns the glob that will be used to include files that were not
+    # explicitly required.
+    #
+    def tracked_files
+      @tracked_files if defined?(@tracked_files)
     end
 
     #

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,29 @@
+require "helper"
+
+describe SimpleCov::Configuration do
+  describe "#tracked_files" do
+    context "when configured" do
+      let(:glob) { "{app,lib}/**/*.rb" }
+
+      before { SimpleCov.track_files(glob) }
+
+      it "returns the configured glob" do
+        expect(SimpleCov.tracked_files).to eq glob
+      end
+
+      context "and configured again with nil" do
+        before { SimpleCov.track_files(nil) }
+
+        it "returns nil" do
+          expect(SimpleCov.tracked_files).to be_nil
+        end
+      end
+    end
+
+    context "when unconfigured" do
+      it "returns nil" do
+        expect(SimpleCov.tracked_files).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #462.

The implementation of `track_files` was refactored recently to suppress a warning in the underlying instance variable had not been initialized. This had the effect of changing the behavior when trying to nullify the default configuration of tracked files in some cases through the use of nil.

With this change, a declaration of `track_files nil` will once again clear out any previous configuration and essentially disable the feature.

Reference:
- https://github.com/colszowka/simplecov/pull/447
- https://github.com/colszowka/simplecov/issues/462

/cc @kmewhort
