### PR TITLE
Don't overwrite last_run file if refuse_coverage_drop option is enabled and the coverage has dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.11.2...m
 
 ## Enhancements
 
+* Do not overwrite .last_run.json file when refuse_coverage_drop option is enabled and the coverage has dropped
+
 ## Bugfixes
 
 * Fix a regression on old rubies that failed to work with the recently introduced frozen VERSION string. See [#461](https://github.com/colszowka/simplecov/pull/461) (thanks @leafle)

--- a/features/refuse_coverage_drop.feature
+++ b/features/refuse_coverage_drop.feature
@@ -2,6 +2,7 @@
 Feature:
 
   Exit code should be non-zero if the overall coverage decreases.
+  And last_run file should not be overwritten with new coverage value.
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:
@@ -16,6 +17,14 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should be 0
     And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 88.1
+        }
+      }
+      """
 
     Given a file named "lib/faked_project/missed.rb" with:
       """
@@ -32,4 +41,12 @@ Feature:
     Then the exit status should not be 0
     And the output should contain "Coverage has dropped by 3.32% since the last time (maximum allowed: 0.00%)."
     And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 88.1
+        }
+      }
+      """
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -244,6 +244,7 @@ module SimpleCov
     # SimpleCov will return non-zero if the coverage decreases.
     #
     def refuse_coverage_drop
+      @refuse_coverage_drop = true
       maximum_coverage_drop 0
     end
 

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -69,6 +69,7 @@ at_exit do
   if SimpleCov.result? # Result has been computed
     covered_percent = SimpleCov.result.covered_percent.round(2)
     covered_percentages = SimpleCov.result.covered_percentages.map { |p| p.round(2) }
+    coverage_diff = 0
 
     if @exit_status == SimpleCov::ExitCodes::SUCCESS # No other errors
       if covered_percent < SimpleCov.minimum_coverage # rubocop:disable Metrics/BlockNesting
@@ -78,15 +79,18 @@ at_exit do
         $stderr.printf("File (%s) is only (%.2f%%) covered. This is below the expected minimum coverage per file of (%.2f%%).\n", SimpleCov.result.least_covered_file, covered_percentages.min, SimpleCov.minimum_coverage_by_file)
         @exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
       elsif (last_run = SimpleCov::LastRun.read) # rubocop:disable Metrics/BlockNesting
-        diff = last_run["result"]["covered_percent"] - covered_percent
-        if diff > SimpleCov.maximum_coverage_drop # rubocop:disable Metrics/BlockNesting
-          $stderr.printf("Coverage has dropped by %.2f%% since the last time (maximum allowed: %.2f%%).\n", diff, SimpleCov.maximum_coverage_drop)
+        coverage_diff = last_run["result"]["covered_percent"] - covered_percent
+        if coverage_diff > SimpleCov.maximum_coverage_drop # rubocop:disable Metrics/BlockNesting
+          $stderr.printf("Coverage has dropped by %.2f%% since the last time (maximum allowed: %.2f%%).\n", coverage_diff, SimpleCov.maximum_coverage_drop)
           @exit_status = SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
         end
       end
     end
 
-    SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
+    # Don't overwrite last_run file if refuse_coverage_drop option is enabled and the coverage has dropped
+    unless SimpleCov.refuse_coverage_drop && coverage_diff > 0
+      SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
+    end
   end
 
   # Force exit with stored status (see github issue #5)

--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -4,7 +4,7 @@ module SimpleCov
     def merge_resultset(array)
       new_array = dup
       array.each_with_index do |element, i|
-        if element.nil? && new_array[i].nil?
+        if element.nil? || new_array[i].nil?
           new_array[i] = nil
         else
           local_value = element || 0


### PR DESCRIPTION
Refuse_coverage_drop option is great but if the coverage actually dropped, it will only fail your test suite once. The .last_run.json file gets overwritten and tests are passing again.

Proposed changes look for "refuse_coverage_drop" option and if it is enabled, prevent overriding of the file when the coverage has dropped.
