### PR TITLE
Correct the detection and guide for JRuby coverage

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -10,9 +10,10 @@ if defined?(JRUBY_VERSION) && defined?(JRuby)
   # @see https://github.com/colszowka/simplecov/issues/86
   # @see https://jira.codehaus.org/browse/JRUBY-6106
 
-  unless JRuby.runtime.debug?
-    warn 'Coverage may be inaccurate; set "cli.debug=true" ("-Xcli.debug=true") in your .jrubyrc or' \
-      ' do JRUBY_OPTS="-d"'
+  unless org.jruby.RubyInstanceConfig.FULL_TRACE_ENABLED
+    warn 'Coverage may be inaccurate; set the "--debug" command line option,' \
+      ' or do JRUBY_OPTS="--debug"' \
+      ' or set the "debug.fullTrace=true" option in your .jrubyrc'
   end
 end
 module SimpleCov


### PR DESCRIPTION
`JRuby.runtime.debug?` does not answer correctly wether coverage is active for JRuby.  `org.jruby.RubyInstanceConfig.FULL_TRACE_ENABLED` does.

Enabling general debug mode on JRuby does not enable coverage.  You need the "--debug" flag on the command line or in JRUBY_OPTS, or set the "debug.fullTrace=true" option in ".jrubyrc".

This change should make using simplecov on JRuby a bit nicer.