### PR TITLE
Limit rake version to 10.x for Ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", ">= 10.3"
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"


### PR DESCRIPTION
Fixes #474 