### PR TITLE
Avoid forking test for JRuby since fork is not implemented

### DIFF
--- a/spec/faked_project/spec/forking_spec.rb
+++ b/spec/faked_project/spec/forking_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe "forking" do
   it do
-    Process.waitpid(Kernel.fork {})
+    # TODO: The defined?(RUBY_ENGINE) check can be dropped for simplecov 1.0.0
+    Process.waitpid(Kernel.fork {}) unless defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
   end
 end


### PR DESCRIPTION
This fixes 10 test failures for JRuby in travis