### PR TITLE
Set useful JRUBY_OPTS

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -45,6 +45,6 @@ end
 # Workaround for https://github.com/cucumber/aruba/pull/125
 Aruba.configure do |config|
   config.before_cmd do
-    set_env("JRUBY_OPTS", "-X-C --1.9")
+    set_env("JRUBY_OPTS", "--dev --debug")
   end
 end


### PR DESCRIPTION
`--dev` sets useful options for faster startup and better performance for short-running apps, including -X-C
`--debug` is necessary on JRuby 9K to get coverage at all
`--1.9` is default for JRuby 1.7.x and not recognized on JRuby 9K