### PR TITLE
Expect coverage for `.simplecov` when running with JRuby

### DIFF
--- a/features/config_styles.feature
+++ b/features/config_styles.feature
@@ -76,8 +76,24 @@ Feature:
     Then I should see "4 files in total."
     And I should see "using Config Test Runner" within "#footer"
 
+  Scenario: Using configure block after start with JRuby
+    Given the Ruby engine is jruby
+      And a file named ".simplecov" with:
+      """
+      SimpleCov.start
+      SimpleCov.configure do
+        add_filter 'test'
+        command_name 'Config Test Runner'
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+    Then I should see "5 files in total."
+    And I should see "using Config Test Runner" within "#footer"
+
   Scenario: Using configure block after start
-    Given a file named ".simplecov" with:
+    Given the Ruby engine is not jruby
+      And a file named ".simplecov" with:
       """
       SimpleCov.start
       SimpleCov.configure do

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -5,6 +5,10 @@ module WithinHelpers
 end
 World(WithinHelpers)
 
+Given /^the Ruby engine is (not )?(.*)$/ do |invert, engine|
+  skip_this_scenario unless (RUBY_ENGINE == engine) ^ !!invert
+end
+
 When /^I open the coverage report$/ do
   visit "/"
 end


### PR DESCRIPTION
...when running code in `.simplecov` after `SimpleCov.start` has finished.

Downside is we get a skipped scenario indicated with dashes.
