### PR TITLE
add channels group to rails profile

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -29,6 +29,7 @@ SimpleCov.profiles.define "rails" do
   add_filter "/db/"
 
   add_group "Controllers", "app/controllers"
+  add_group "Channels", "app/channels"
   add_group "Models", "app/models"
   add_group "Mailers", "app/mailers"
   add_group "Helpers", "app/helpers"


### PR DESCRIPTION
This basically adds Channels as a group for test coverage. What I don't like about this is that it assumes (a) you're on Rails 5 and (b) that you're using ActionCable. I'm very open to modifying this PR to support Rails <5 and just do a detection for ActionCable.
