### PR TITLE
Fix merging of resultset 

### DIFF
--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -22,11 +22,14 @@ module SimpleCov
     def merge_resultset(hash)
       new_resultset = {}
       (keys + hash.keys).each do |filename|
-        new_resultset[filename] = []
+        new_resultset[filename] = nil
       end
 
       new_resultset.each_key do |filename|
-        new_resultset[filename] = (self[filename] || []).extend(SimpleCov::ArrayMergeHelper).merge_resultset(hash[filename] || [])
+        result1 = self[filename]
+        result2 = hash[filename]
+        new_resultset[filename] =
+          (result1 && result2) ? result1.extend(ArrayMergeHelper).merge_resultset(result2) : (result1 || result2).dup
       end
       new_resultset
     end

--- a/spec/merge_helpers_spec.rb
+++ b/spec/merge_helpers_spec.rb
@@ -10,6 +10,7 @@ describe "merge helpers" do
         source_fixture("app/controllers/sample_controller.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
         source_fixture("resultset1.rb") => [1, 1, 1, 1],
         source_fixture("parallel_tests.rb") => [nil, 0, nil, 0],
+        source_fixture("conditionally_loaded_1.rb") => [nil, 0, 1],  # loaded only in the first resultset
       }.extend(SimpleCov::HashMergeHelper)
 
       @resultset2 = {
@@ -18,6 +19,7 @@ describe "merge helpers" do
         source_fixture("app/controllers/sample_controller.rb") => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil],
         source_fixture("resultset2.rb") => [nil, 1, 1, nil],
         source_fixture("parallel_tests.rb") => [nil, nil, 0, 0],
+        source_fixture("conditionally_loaded_2.rb") => [nil, 0, 1],  # loaded only in the second resultset
       }
     end
 
@@ -48,6 +50,14 @@ describe "merge helpers" do
 
       it "has proper results for parallel_tests.rb" do
         expect(subject[source_fixture("parallel_tests.rb")]).to eq([nil, nil, nil, 0])
+      end
+
+      it "has proper results for conditionally_loaded_1.rb" do
+        expect(subject[source_fixture("conditionally_loaded_1.rb")]).to eq([nil, 0, 1])
+      end
+
+      it "has proper results for conditionally_loaded_2.rb" do
+        expect(subject[source_fixture("conditionally_loaded_2.rb")]).to eq([nil, 0, 1])
       end
     end
 


### PR DESCRIPTION
In merging two resultsets, if a file only appears in only one of the resultsets, the current merger implementation generates incorrect resultset.

- Merging `{file => [nil, 0, 1]}` and `{}` results in `{file => [nil, 0, 1]}` (ok)
- Merging `{}` and `{file => [nil, 0, 1]}` results in `{file => [nil, nil, 1]}` (0 is lost)

This patch fixes the problem.