### PR TITLE
Fix for: Merging two resultsets marks uncovered line as irrelevant

### DIFF
--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -23,14 +23,11 @@ module SimpleCov
     def merge_resultset(hash)
       new_resultset = {}
       (keys + hash.keys).each do |filename|
-        new_resultset[filename] = nil
+        new_resultset[filename] = []
       end
 
       new_resultset.each_key do |filename|
-        result1 = self[filename]
-        result2 = hash[filename]
-        new_resultset[filename] =
-          (result1 && result2) ? result1.extend(ArrayMergeHelper).merge_resultset(result2) : (result1 || result2).dup
+        new_resultset[filename] = (self[filename] || []).extend(SimpleCov::ArrayMergeHelper).merge_resultset(hash[filename] || [])
       end
       new_resultset
     end

--- a/lib/simplecov/merge_helpers.rb
+++ b/lib/simplecov/merge_helpers.rb
@@ -2,6 +2,7 @@ module SimpleCov
   module ArrayMergeHelper
     # Merges an array of coverage results with self
     def merge_resultset(array)
+      return array if empty?
       new_array = dup
       array.each_with_index do |element, i|
         pair = [element, new_array[i]]

--- a/spec/merge_helpers_spec.rb
+++ b/spec/merge_helpers_spec.rb
@@ -1,6 +1,41 @@
 require "helper"
 
 describe "merge helpers" do
+  describe SimpleCov::ArrayMergeHelper do
+    before { SimpleCov.use_merging true }
+
+    def merge(values_1, values_2)
+      values_1.extend(SimpleCov::ArrayMergeHelper).merge_resultset(values_2)
+    end
+
+    context "numbers get added" do
+      it { expect(merge([0], [0])).to eq [0] }
+      it { expect(merge([1], [0])).to eq [1] }
+      it { expect(merge([0], [1])).to eq [1] }
+      it { expect(merge([1], [1])).to eq [2] }
+      it { expect(merge([9], [9])).to eq [9 + 9] }
+    end
+    context "numbers and nil" do
+      it { expect(merge([0], [nil])).to eq [nil] }
+      it { expect(merge([1], [nil])).to eq [1] }
+      it { expect(merge([2], [nil])).to eq [2] }
+      it { expect(merge([nil], [0])).to eq [nil] }
+      it { expect(merge([nil], [1])).to eq [1] }
+      it { expect(merge([nil], [2])).to eq [2] }
+    end
+    context "numbers and empty" do
+      it { expect(merge([nil], [])).to eq [nil] }
+      it { expect(merge([0], [])).to eq [0] }
+      it { expect(merge([1], [])).to eq [1] }
+      it { expect(merge([2], [])).to eq [2] }
+
+      it { expect(merge([], [nil])).to eq [nil] }
+      it { expect(merge([], [0])).to eq [0] }
+      it { expect(merge([], [1])).to eq [1] }
+      it { expect(merge([], [2])).to eq [2] }
+    end
+  end
+
   describe "with two faked coverage resultsets" do
     before do
       SimpleCov.use_merging true

--- a/spec/merge_helpers_spec.rb
+++ b/spec/merge_helpers_spec.rb
@@ -5,7 +5,9 @@ describe "merge helpers" do
     before { SimpleCov.use_merging true }
 
     def merge(values_1, values_2)
-      values_1.extend(SimpleCov::ArrayMergeHelper).merge_resultset(values_2)
+      hash_1 = {"test" => values_1}
+      hash_2 = {"test" => values_2}
+      hash_1.extend(SimpleCov::HashMergeHelper).merge_resultset(hash_2)["test"]
     end
 
     context "numbers get added" do

--- a/spec/merge_helpers_spec.rb
+++ b/spec/merge_helpers_spec.rb
@@ -5,9 +5,7 @@ describe "merge helpers" do
     before { SimpleCov.use_merging true }
 
     def merge(values_1, values_2)
-      hash_1 = {"test" => values_1}
-      hash_2 = {"test" => values_2}
-      hash_1.extend(SimpleCov::HashMergeHelper).merge_resultset(hash_2)["test"]
+      values_1.extend(SimpleCov::ArrayMergeHelper).merge_resultset(values_2)
     end
 
     context "numbers get added" do


### PR DESCRIPTION
Fixes issue #517  
