### PR TITLE
Fix an accidentally inefficient hash filter

### DIFF
--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -60,7 +60,7 @@ module SimpleCov
 
     # Returns a hash representation of this Result that can be used for marshalling it into JSON
     def to_hash
-      {command_name => {"coverage" => original_result.reject { |filename, _| !filenames.include?(filename) }, "timestamp" => created_at.to_i}}
+      {command_name => {"coverage" => coverage, "timestamp" => created_at.to_i}}
     end
 
     # Loads a SimpleCov::Result#to_hash dump
@@ -73,6 +73,11 @@ module SimpleCov
     end
 
   private
+
+    def coverage
+      keys = original_result.keys & filenames
+      Hash[keys.zip(original_result.values_at(*keys))]
+    end
 
     # Applies all configured SimpleCov filters on this result's source files
     def filter!


### PR DESCRIPTION
I (accidentally ⏤ Homebrew/brew#1041) loaded a very large number of files into SimpleCov, and it got stuck for a very long time. I tracked down the slowness to this method, which gets very slow because it iterates `filenames` for every value of `original_result`. Using Ruby's built-in `Array#&` makes this much faster.