### PR TITLE
Use Integer instead of Fixnum

### DIFF
--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -204,7 +204,7 @@ module SimpleCov
     # Configure with SimpleCov.merge_timeout(3600) # 1hr
     #
     def merge_timeout(seconds = nil)
-      @merge_timeout = seconds if seconds.is_a?(Fixnum)
+      @merge_timeout = seconds if seconds.is_a?(Integer)
       @merge_timeout ||= 600
     end
 

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -26,8 +26,8 @@ module SimpleCov
 
       def initialize(src, line_number, coverage)
         raise ArgumentError, "Only String accepted for source" unless src.is_a?(String)
-        raise ArgumentError, "Only Fixnum accepted for line_number" unless line_number.is_a?(Fixnum)
-        raise ArgumentError, "Only Fixnum and nil accepted for coverage" unless coverage.is_a?(Fixnum) || coverage.nil?
+        raise ArgumentError, "Only Integer accepted for line_number" unless line_number.is_a?(Integer)
+        raise ArgumentError, "Only Integer and nil accepted for coverage" unless coverage.is_a?(Integer) || coverage.nil?
         @src         = src
         @line_number = line_number
         @coverage    = coverage


### PR DESCRIPTION
The range of `Fixnum` is not guaranteed at all.  And ruby 2.4
unifies `Fixnum` and `Bignum` into `Integer`, and will deprecate
those two constants.