### PR TITLE
Add a line in the README regarding a gotcha for deploying to Heroku w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Getting started
       puts "required simplecov"
     end
     ```
+    **Note:** If deploying to Heroku, make sure the line `#!/usr/bin/env ruby.exe` in `bin/rails` is on the very top of your file.
+
 3. Run your tests, open up `coverage/index.html` in your browser and check out
    what you've missed so far.
 4. Add the following to your `.gitignore` file to ensure that coverage results


### PR DESCRIPTION
…hen configuring bin/rails for SimpleCov.

This issue on stack-overflow covers it: http://stackoverflow.com/questions/24274793/heroku-deployment-crash-rails-server-syntax-error-file-expand-path-spring

It's a very annoyingly obscure gotcha. 
