### PR TITLE
WIP - Travis: update name of preinstalled Rubinius to rubinius-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ rvm:
   - 2.3.0
   - ruby-head
   - jruby-head
-  - rbx-2
+  - rubinius-2
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx-2
+    - rvm: rubinius-2
   fast_finish: true


### PR DESCRIPTION
This PR changes the rvm name of `rbx-2` to the now-correct Travis pre-installed version: `rubinius-2`.

This page: http://rubies.travis-ci.org/rubinius lists all the Rubinius pre-installs. 

(Question: Would it be better to use latest, instead of this early-2016 version?)

Hm...

```
$ rvm use rubinius-2 --install --binary --fuzzy
rubinius-2 is not installed - installing.
Searching for binary rubies, this might take some time.
Requested binary installation but no rubies are available to download, consider skipping --binary flag.
Gemset '' does not exist, 'rvm rubinius-2 do rvm gemset create ' first, or append '--create'.
The command "rvm use rubinius-2 --install --binary --fuzzy" failed and exited with 2 during .
```