### PR TITLE
Allow coverage directory to be a symlink.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.12.0...m
 
 ## Enhancements
 
+* Allow coverage directory to be a symlink.
+
 ## Bugfixes
 
 0.12.0 2016-07-02 ([changes](https://github.com/colszowka/simplecov/compare/v0.11.2...v0.12.0))

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -40,7 +40,7 @@ module SimpleCov
     def coverage_path
       @coverage_path ||= begin
         coverage_path = File.expand_path(coverage_dir, root)
-        FileUtils.mkdir_p(coverage_path) unless Dir.exist?(coverage_path) || File.symlink?(coverage_path)
+        FileUtils.mkdir_p(coverage_path) unless File.directory?(coverage_path) || File.symlink?(coverage_path)
         coverage_path
       end
     end

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -40,7 +40,7 @@ module SimpleCov
     def coverage_path
       @coverage_path ||= begin
         coverage_path = File.expand_path(coverage_dir, root)
-        FileUtils.mkdir_p coverage_path
+        FileUtils.mkdir_p(coverage_path) unless Dir.exist?(coverage_path) || File.symlink?(coverage_path)
         coverage_path
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,69 @@
+require 'helper'
+
+RSpec.describe SimpleCov::Configuration do
+  subject { SimpleCov }
+
+  describe '.coverage_path' do
+    let(:coverage_dir)  { '/tmp/simplecov/testing/coverage' }
+
+    before(:each) do
+      # ensure we're starting from a clean slate
+      FileUtils.rmdir(coverage_dir) if Dir.exist?(coverage_dir)
+      @original_coverage_dir = subject.instance_variable_get('@coverage_dir')
+      @original_coverage_path = subject.instance_variable_get('@coverage_path')
+      subject.instance_variable_set('@coverage_dir', coverage_dir)
+      subject.instance_variable_set('@coverage_path', nil)
+    end
+
+    after(:each) do
+      # so there's no bleed to affect other tests
+      subject.instance_variable_set('@coverage_dir', @original_coverage_dir)
+      subject.instance_variable_set('@coverage_path', @original_coverage_path)
+    end
+
+    it 'sets @coverage_path when creating the directory' do
+      subject.coverage_path
+      expect(subject.instance_variable_get('@coverage_path')).not_to be_nil
+    end
+
+    it 'memoizes @coverage_path' do
+      subject.instance_variable_set('@coverage_path', coverage_dir)
+      expect(FileUtils).not_to receive(:mkdir_p)
+      subject.coverage_path
+    end
+
+    context "when it's a directory" do
+      it "creates the directory if it doesn't exist" do
+        expect(FileUtils).to receive(:mkdir_p).with(coverage_dir)
+        subject.coverage_path
+      end
+
+      it 'does not create the directory if does exist' do
+        FileUtils.mkdir_p(coverage_dir)
+        expect(FileUtils).not_to receive(:mkdir_p)
+        subject.coverage_path
+      end
+    end # context '"when it's a directory"'
+
+    context "when it's a symlink" do
+      let(:coverage_link) { "#{coverage_dir}-link" }
+
+      before(:each) do
+        FileUtils.rm(coverage_link) if File.symlink?(coverage_link)
+        subject.instance_variable_set('@coverage_dir', coverage_link)
+      end
+
+      it "creates the directory if it doesn't exist" do
+        expect(FileUtils).to receive(:mkdir_p).with(coverage_link)
+        subject.coverage_path
+      end
+
+      it 'does not create the directory if does exist' do
+        FileUtils.symlink(coverage_dir, coverage_link)
+        expect(FileUtils).not_to receive(:mkdir_p)
+        subject.coverage_path
+      end
+    end # context '"when it's a symlink"'
+  end # describe '.coverage_path'
+end
+

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SimpleCov::Configuration do
 
     before(:each) do
       # ensure we're starting from a clean slate
-      FileUtils.rmdir(coverage_dir) if Dir.exist?(coverage_dir)
+      FileUtils.rmdir(coverage_dir) if File.directory?(coverage_dir)
       @original_coverage_dir = subject.instance_variable_get("@coverage_dir")
       @original_coverage_path = subject.instance_variable_get("@coverage_path")
       subject.instance_variable_set("@coverage_dir", coverage_dir)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,33 +1,33 @@
-require 'helper'
+require "helper"
 
 RSpec.describe SimpleCov::Configuration do
   subject { SimpleCov }
 
-  describe '.coverage_path' do
-    let(:coverage_dir)  { '/tmp/simplecov/testing/coverage' }
+  describe ".coverage_path" do
+    let(:coverage_dir) { "/tmp/simplecov/testing/coverage" }
 
     before(:each) do
       # ensure we're starting from a clean slate
       FileUtils.rmdir(coverage_dir) if Dir.exist?(coverage_dir)
-      @original_coverage_dir = subject.instance_variable_get('@coverage_dir')
-      @original_coverage_path = subject.instance_variable_get('@coverage_path')
-      subject.instance_variable_set('@coverage_dir', coverage_dir)
-      subject.instance_variable_set('@coverage_path', nil)
+      @original_coverage_dir = subject.instance_variable_get("@coverage_dir")
+      @original_coverage_path = subject.instance_variable_get("@coverage_path")
+      subject.instance_variable_set("@coverage_dir", coverage_dir)
+      subject.instance_variable_set("@coverage_path", nil)
     end
 
     after(:each) do
       # so there's no bleed to affect other tests
-      subject.instance_variable_set('@coverage_dir', @original_coverage_dir)
-      subject.instance_variable_set('@coverage_path', @original_coverage_path)
+      subject.instance_variable_set("@coverage_dir", @original_coverage_dir)
+      subject.instance_variable_set("@coverage_path", @original_coverage_path)
     end
 
-    it 'sets @coverage_path when creating the directory' do
+    it "sets @coverage_path when creating the directory" do
       subject.coverage_path
-      expect(subject.instance_variable_get('@coverage_path')).not_to be_nil
+      expect(subject.instance_variable_get("@coverage_path")).not_to be_nil
     end
 
-    it 'memoizes @coverage_path' do
-      subject.instance_variable_set('@coverage_path', coverage_dir)
+    it "memoizes @coverage_path" do
+      subject.instance_variable_set("@coverage_path", coverage_dir)
       expect(FileUtils).not_to receive(:mkdir_p)
       subject.coverage_path
     end
@@ -38,19 +38,19 @@ RSpec.describe SimpleCov::Configuration do
         subject.coverage_path
       end
 
-      it 'does not create the directory if does exist' do
+      it "does not create the directory if does exist" do
         FileUtils.mkdir_p(coverage_dir)
         expect(FileUtils).not_to receive(:mkdir_p)
         subject.coverage_path
       end
-    end # context '"when it's a directory"'
+    end # context "when it's a directory"
 
     context "when it's a symlink" do
       let(:coverage_link) { "#{coverage_dir}-link" }
 
       before(:each) do
         FileUtils.rm(coverage_link) if File.symlink?(coverage_link)
-        subject.instance_variable_set('@coverage_dir', coverage_link)
+        subject.instance_variable_set("@coverage_dir", coverage_link)
       end
 
       it "creates the directory if it doesn't exist" do
@@ -58,12 +58,11 @@ RSpec.describe SimpleCov::Configuration do
         subject.coverage_path
       end
 
-      it 'does not create the directory if does exist' do
+      it "does not create the directory if does exist" do
         FileUtils.symlink(coverage_dir, coverage_link)
         expect(FileUtils).not_to receive(:mkdir_p)
         subject.coverage_path
       end
-    end # context '"when it's a symlink"'
+    end # context "when it's a symlink"
   end # describe '.coverage_path'
 end
-


### PR DESCRIPTION
In a Vagrant setup, I have symlinked the coverage directory to a shared folder so I can easily access it from the host. In 0.12, I get an error when the symlink exists and simplecov tries to create the directory. This change allows for the possibility that coverage is a symlink. I've also added some specs around creating the directory and such.