### PR TITLE
Skip the :nocov: comments.

### DIFF
--- a/features/config_nocov_token.feature
+++ b/features/config_nocov_token.feature
@@ -36,7 +36,7 @@ Feature:
       | lib/faked_project/meta_magic.rb         | 100.0 %  |
       | lib/faked_project/nocov.rb              | 100.0 %  |
 
-    And there should be 5 skipped lines in the source files
+    And there should be 7 skipped lines in the source files
 
     And the report should be based upon:
       | Unit Tests |
@@ -73,7 +73,7 @@ Feature:
       | lib/faked_project/meta_magic.rb         | 100.0 %  |
       | lib/faked_project/nocov.rb              | 100.0 %  |
 
-    And there should be 5 skipped lines in the source files
+    And there should be 7 skipped lines in the source files
 
     And the report should be based upon:
       | Unit Tests |

--- a/features/skipping_code_blocks_manually.feature
+++ b/features/skipping_code_blocks_manually.feature
@@ -35,7 +35,7 @@ Feature:
       | lib/faked_project/meta_magic.rb         | 100.0 %  |
       | lib/faked_project/nocov.rb              | 100.0 %  |
 
-    And there should be 5 skipped lines in the source files
+    And there should be 7 skipped lines in the source files
 
     And the report should be based upon:
       | Unit Tests |
@@ -64,7 +64,7 @@ Feature:
       | lib/faked_project/meta_magic.rb         | 100.0 %  |
       | lib/faked_project/nocov.rb              | 100.0 %  |
 
-    And there should be 5 skipped lines in the source files
+    And there should be 7 skipped lines in the source files
 
     And the report should be based upon:
       | Unit Tests |

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -172,6 +172,7 @@ module SimpleCov
       lines.each do |line|
         if line.src =~ /^([\s]*)#([\s]*)(\:#{SimpleCov.nocov_token}\:)/
           skipping = !skipping
+          line.skipped!
         elsif skipping
           line.skipped!
         end

--- a/spec/file_list_spec.rb
+++ b/spec/file_list_spec.rb
@@ -18,16 +18,16 @@ describe SimpleCov::Result do
     expect(subject.missed_lines).to eq(3)
   end
 
-  it "has 19 never lines" do
-    expect(subject.never_lines).to eq(19)
+  it "has 17 never lines" do
+    expect(subject.never_lines).to eq(17)
   end
 
   it "has 14 lines of code" do
     expect(subject.lines_of_code).to eq(14)
   end
 
-  it "has 3 skipped lines" do
-    expect(subject.skipped_lines).to eq(3)
+  it "has 5 skipped lines" do
+    expect(subject.skipped_lines).to eq(5)
   end
 
   it "has the correct covered percent" do

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -41,12 +41,12 @@ describe SimpleCov::SourceFile do
       expect(subject.missed_lines.map(&:line)).to eq([8])
     end
 
-    it "returns lines number 1, 5, 6, 9, 10, 11, 15, 16 for never_lines" do
-      expect(subject.never_lines.map(&:line)).to eq([1, 5, 6, 9, 10, 11, 15, 16])
+    it "returns lines number 1, 5, 6, 9, 10, 16 for never_lines" do
+      expect(subject.never_lines.map(&:line)).to eq([1, 5, 6, 9, 10, 16])
     end
 
-    it "returns line numbers 12, 13, 14 for skipped_lines" do
-      expect(subject.skipped_lines.map(&:line)).to eq([12, 13, 14])
+    it "returns line numbers 11, 12, 13, 14, 15 for skipped_lines" do
+      expect(subject.skipped_lines.map(&:line)).to eq([11, 12, 13, 14, 15])
     end
 
     it "has 80% covered_percent" do


### PR DESCRIPTION
When using the `nocov` comment token the start and stop tokens are considered lines to be covered. Addresses the following issues:

https://github.com/colszowka/simplecov/issues/468

https://github.com/colszowka/simplecov/issues/527
