### PR TITLE
[ci skip] Update config for using with spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,11 +599,17 @@ Try [Coverband](https://github.com/danmayer/coverband).
 
 If you're using [Spring](https://github.com/rails/spring) to speed up test suite runs and want to run SimpleCov along with them, you'll find that it often misreports coverage with the default config due to some sort of eager loading issue. Don't despair!
 
-1. Change the following settings in `development.rb` and `test.rb`.
+1. Change the following settings in `test.rb`.
 
     ```ruby
+    # For Rails 4 or earlier, use the following configuration:
     # Disable Rails's static asset server (Apache or nginx will already do this)
     config.serve_static_files = false
+    config.eager_load = false
+
+    # For Rails 5, use the following configuration:
+    # Disable Rails's static asset server (Apache or nginx will already do this)
+    config.public_file_server.enabled = false
     config.eager_load = false
     ```
 2. Add your SimpleCov config, as you normally would, to your `spec_helper.rb`


### PR DESCRIPTION

environment: 

* ruby: ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]
* rails: 5.0.0.1
* simplecov (0.12.0)

when running `rails server`, you'll get the warning:

> DEPRECATION WARNING: `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
Please use `config.public_file_server.enabled = false` instead.

[rails line of code for the deprecation](https://github.com/rails/rails/blob/69ab3eb57e8387b0dd9d672b5e8d9185395baa03/railties/lib/rails/application/configuration.rb#L70)