### PR TITLE
Test current JRuby release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,13 @@ rvm:
   - 2.3.1
   - ruby-head
   - jruby-head
+  - jruby-9.1.6.0
   - rbx-2
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: jruby-9.1.6.0
     - rvm: rbx-2
   fast_finish: true


### PR DESCRIPTION
I thought it'd be worth running against the current JRuby release, not just head. I didn't want to interfere with a support decision (although I'd love to see JRuby officially supported!) so added it to the allow_failures for now. Thanks for the great work, long time simplecov user :) (and with that also the whole shoes4 project on JRuby) !