### PR TITLE
Stop to read unused source code

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -74,15 +74,19 @@ module SimpleCov
     attr_reader :filename
     # The array of coverage data received from the Coverage.result
     attr_reader :coverage
-    # The source code for this file. Aliased as :source
-    attr_reader :src
-    alias source src
 
     def initialize(filename, coverage)
       @filename = filename
       @coverage = coverage
-      File.open(filename, "rb") { |f| @src = f.readlines }
     end
+
+    # The source code for this file. Aliased as :source
+    def src
+      # We intentionally read source code lazily to
+      # suppress reading unused source code.
+      @src ||= File.open(filename, "rb", &:readlines)
+    end
+    alias source src
 
     # Returns all source lines for this file as instances of SimpleCov::SourceFile::Line,
     # and thus including coverage data. Aliased as :source_lines


### PR DESCRIPTION
Before this commit all source code were loaded, even if
they are not used.
For example when taking test coverage for rails applications,
in many cases files on "vendor/bundle" are filtered out.
By reading source code lazily, the time required to generate
results will be shortened.