### PR TITLE
Officially Support JRuby 9.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,5 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.1.7.0
     - rvm: rbx-2
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -582,14 +582,11 @@ SimpleCov.formatters = [
 
 ## Ruby version compatibility
 
-Only Ruby 1.9+ ships with the coverage library that SimpleCov depends upon.
-SimpleCov is built against various other Rubies, including Rubinius and JRuby,
-in [Continuous Integration], but this happens only to ensure that SimpleCov
-does not make your test suite crash right now. Whether SimpleCov will support
-JRuby/Rubinius in the future depends solely on whether those Ruby interpreters
-add the coverage library.
+Only Ruby 1.9+ ships with the coverage library that SimpleCov depends upon and that's what SimpleCov supports. Additionally JRuby 9.1+ is supported as well, while JRuby 1.7 and 9.0 should work they're not "officially" supported.
+SimpleCov is also built against Ruby 1.8 in [Continuous Integration], but this happens only to ensure that SimpleCov
+does not make your test suite crash right now.
 
-SimpleCov is built in [Continuous Integration] on Ruby 1.9.3, 2.0.0, 2.1, and 2.2.
+SimpleCov is built in [Continuous Integration] on Ruby 1.9.3, 2.0.0, 2.1, 2.2, 2.3, 2.4 as well as JRuby 9.1.
 
 ## Want to find dead code in production?
 


### PR DESCRIPTION
I've personally been running simplecov with JRuby 1.7+ for years
so I'd say it is good to go either way ;P

The reality of edge cases is more complicated but it seems the
fine folks at @jruby (namely @enebo ) made the last fixes
necessary as seen in jruby/jruby#1196 so that they're available
in 9.1+ releases! The others should work, but have some little
failures (9.0.5.0 fails on one cuke for me).

So, the easiest way forward is to support 9.1+. Sadly the tests
take a while as they always start new interpreter instances and
startup time isn't exactly JRuby's strength, but CI does it
so it's bearable. :)

If anyone has problems with JRuby on a PR, in an issue or whatever
please feel free to ping me (@PragTob)

Also, special thanks goes to @donv who created did a lot of testing,
issue reporting et. al. for simplecov on JRuby for a long time!

* fixes #524