### PR TITLE
Remove Rubinius/rbx from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,10 @@ rvm:
   - ruby-head
   - jruby-head
   - jruby-9.1.7.0
-  - rbx-2
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: jruby-9.1.7.0
-    - rvm: rbx-2
   fast_finish: true


### PR DESCRIPTION
Keen eyes might have observed that in #547 while reformatting the
section about supported rubies I also removed the mention of
Rubinius. I did this as it said they were just tested to make sure
they don't crash which wasn't true anymore - full test suite is run
but it was set to allowed failures.

Sadly Rubinius hasn't been running/installing at all on travis for
quite some time: https://travis-ci.org/colszowka/simplecov/jobs/169209429

And before when it was still running it was failing on a lot of
cukes: https://travis-ci.org/colszowka/simplecov/jobs/141918713

As tests don't run/no one looks at aren't worth much I'm inclined
to drop it from the test matrix, plus my recent experience with
getting it running hasn't been stellar.

We might always readd once they get their new interpreter and JIT
going.