### PR TITLE
Allow for empty last_run files for parallel tests by cschaffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...master))
+==========
+
+## Enhancements
+
+## Bugfixes
+
+* Fix parallel_tests when a thread ends up running no tests. See [#533](https://github.com/colszowka/simplecov/pull/533) (thanks @cshaffer)
+
 0.13.0 2016-01-25 ([changes](https://github.com/colszowka/simplecov/compare/v0.12.0...v0.13.0))
 ==========
 

--- a/lib/simplecov/last_run.rb
+++ b/lib/simplecov/last_run.rb
@@ -9,7 +9,8 @@ module SimpleCov
 
       def read
         return nil unless File.exist?(last_run_path)
-        JSON.parse(File.read(last_run_path))
+        json = File.read(last_run_path)
+        JSON.parse(json) unless json.strip.empty?
       end
 
       def write(json)

--- a/lib/simplecov/last_run.rb
+++ b/lib/simplecov/last_run.rb
@@ -10,7 +10,8 @@ module SimpleCov
       def read
         return nil unless File.exist?(last_run_path)
         json = File.read(last_run_path)
-        JSON.parse(json) unless json.strip.empty?
+        return nil if json.strip.empty?
+        JSON.parse(json)
       end
 
       def write(json)

--- a/spec/last_run_spec.rb
+++ b/spec/last_run_spec.rb
@@ -1,0 +1,45 @@
+require "helper"
+
+describe SimpleCov::LastRun do
+  subject { SimpleCov::LastRun }
+
+  it "defines a last_run_path" do
+    expect(subject.last_run_path).to eq(File.join(SimpleCov.coverage_path, ".last_run.json"))
+  end
+
+  it "writes json to its last_run_path" do
+    json = []
+    subject.write(json)
+    expect(File.read(subject.last_run_path).strip).to eq(JSON.pretty_generate(json))
+  end
+
+  context "reading" do
+    context "but the last_run file does not exist" do
+      before { File.delete(subject.last_run_path) if File.exist?(subject.last_run_path) }
+
+      it "returns nil" do
+        expect(subject.read).to be_nil
+      end
+    end
+
+    context "a non empty result" do
+      before { subject.write([]) }
+
+      it "reads json from its last_run_path" do
+        expect(subject.read).to eq(JSON.parse("[]"))
+      end
+    end
+
+    context "an empty result" do
+      before do
+        File.open(subject.last_run_path, "w+") do |f|
+          f.puts ""
+        end
+      end
+
+      it "returns nil" do
+        expect(subject.read).to be_nil
+      end
+    end
+  end
+end if SimpleCov.usable?

--- a/spec/last_run_spec.rb
+++ b/spec/last_run_spec.rb
@@ -1,45 +1,48 @@
 require "helper"
 
-describe SimpleCov::LastRun do
-  subject { SimpleCov::LastRun }
+if SimpleCov.usable?
+  describe SimpleCov::LastRun do
+    subject { SimpleCov::LastRun }
 
-  it "defines a last_run_path" do
-    expect(subject.last_run_path).to eq(File.join(SimpleCov.coverage_path, ".last_run.json"))
-  end
-
-  it "writes json to its last_run_path" do
-    json = []
-    subject.write(json)
-    expect(File.read(subject.last_run_path).strip).to eq(JSON.pretty_generate(json))
-  end
-
-  context "reading" do
-    context "but the last_run file does not exist" do
-      before { File.delete(subject.last_run_path) if File.exist?(subject.last_run_path) }
-
-      it "returns nil" do
-        expect(subject.read).to be_nil
-      end
+    it "defines a last_run_path" do
+      expect(subject.last_run_path).to include "tmp/coverage/.last_run.json"
     end
 
-    context "a non empty result" do
-      before { subject.write([]) }
-
-      it "reads json from its last_run_path" do
-        expect(subject.read).to eq(JSON.parse("[]"))
-      end
+    it "writes json to its last_run_path that can be parsed again" do
+      structure = [{"key" => "value"}]
+      subject.write(structure)
+      file_contents = File.read(subject.last_run_path)
+      expect(JSON.parse(file_contents)).to eq structure
     end
 
-    context "an empty result" do
-      before do
-        File.open(subject.last_run_path, "w+") do |f|
-          f.puts ""
+    context "reading" do
+      context "but the last_run file does not exist" do
+        before { File.delete(subject.last_run_path) if File.exist?(subject.last_run_path) }
+
+        it "returns nil" do
+          expect(subject.read).to be_nil
         end
       end
 
-      it "returns nil" do
-        expect(subject.read).to be_nil
+      context "a non empty result" do
+        before { subject.write([]) }
+
+        it "reads json from its last_run_path" do
+          expect(subject.read).to eq([])
+        end
+      end
+
+      context "an empty result" do
+        before do
+          File.open(subject.last_run_path, "w+") do |f|
+            f.puts ""
+          end
+        end
+
+        it "returns nil" do
+          expect(subject.read).to be_nil
+        end
       end
     end
   end
-end if SimpleCov.usable?
+end


### PR DESCRIPTION
I took the liberty to merge the #533 of @cshaffer to resolve the merge conflict. Sorry that it took some time!

Original text:

> Fixes #410 
> When running tests in parallel using [parallel_tests](https://github.com/grosser/parallel_tests) and [parallel_tests-fine_grain_test](https://github.com/appfolio/parallel_tests-fine_grain_test) sometimes one thread will be completely starved from running any tests which results in an empty last_run json file which blows up when collecting all the results.  This PR makes it so we don't try to parse an empty string as json and instead return `nil` as if the file wasn't there at all.
> 
> Since there were no tests for `SimpleCov::LastRun` I took the liberty of writing tests for everything including the change I made.