### PR TITLE
Don't overwrite last_run file if refuse_coverage_drop option is enabled and the coverage has dropped 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...m
 
 * Officially support JRuby 9.1+ going forward (should also work with previous releases). See [#547](https://github.com/colszowka/simplecov/pull/547) (ping @PragTob when encountering issues)
 * Add Channel group to Rails profile, when `ActionCable` is loaded. See [#492](https://github.com/colszowka/simplecov/pull/492) (thanks @BenMorganIO)
+* Do not overwrite .last_run.json file when refuse_coverage_drop option is enabled and the coverage has dropped
 
 ## Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...m
 
 * Officially support JRuby 9.1+ going forward (should also work with previous releases). See [#547](https://github.com/colszowka/simplecov/pull/547) (ping @PragTob when encountering issues)
 * Add Channel group to Rails profile, when `ActionCable` is loaded. See [#492](https://github.com/colszowka/simplecov/pull/492) (thanks @BenMorganIO)
-* Do not overwrite .last_run.json file when refuse_coverage_drop option is enabled and the coverage has dropped
 
 ## Bugfixes
 
@@ -13,6 +12,7 @@ Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...m
 * Skip the `:nocov:` comments along with the code that they skip. See [#551](https://github.com/colszowka/simplecov/pull/551) (thanks @ebiven)
 * Fix crash when Home environment variable is unset. See [#482](https://github.com/colszowka/simplecov/pull/482) (thanks @waldyr)
 * Make track_files work again when explicitly setting it to nil. See [#463](https://github.com/colszowka/simplecov/pull/463) (thanks @craiglittle)
+* Do not overwrite .last_run.json file when refuse_coverage_drop option is enabled and the coverage has dropped (lead to you being able to just rerun tests and everything was _fine_). See [#553](https://github.com/colszowka/simplecov/pull/553) (thanks @Miloshes)
 
 0.13.0 2017-01-25 ([changes](https://github.com/colszowka/simplecov/compare/v0.12.0...v0.13.0))
 ==========

--- a/features/maximum_coverage_drop.feature
+++ b/features/maximum_coverage_drop.feature
@@ -4,7 +4,7 @@ Feature:
   Exit code should be non-zero if the overall coverage decreases by more than
   the maximum_coverage_drop threshold.
 
-  Scenario:
+  Scenario: maximum_coverage_drop configured cam cause spec failure
     Given SimpleCov for Test/Unit is configured with:
       """
       require 'simplecov'
@@ -33,4 +33,57 @@ Feature:
     Then the exit status should not be 0
     And the output should contain "Coverage has dropped by 3.32% since the last time (maximum allowed: 3.14%)."
     And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 88.1
+        }
+      }
+      """
+
+  Scenario: maximum_coverage_drop not configured updates resultset
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should be 0
+    And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 88.1
+        }
+      }
+      """
+
+    Given a file named "lib/faked_project/missed.rb" with:
+      """
+      class UncoveredSourceCode
+        def foo
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should be 0
+    And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 84.78
+        }
+      }
+      """
+
 

--- a/features/refuse_coverage_drop.feature
+++ b/features/refuse_coverage_drop.feature
@@ -4,7 +4,7 @@ Feature:
   Exit code should be non-zero if the overall coverage decreases.
   And last_run file should not be overwritten with new coverage value.
 
-  Scenario:
+  Scenario: refuse_coverage_drop configured
     Given SimpleCov for Test/Unit is configured with:
       """
       require 'simplecov'
@@ -50,3 +50,46 @@ Feature:
       }
       """
 
+  Scenario: refuse_coverage_drop not configured updates resultset
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should be 0
+    And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 88.1
+        }
+      }
+      """
+
+    Given a file named "lib/faked_project/missed.rb" with:
+      """
+      class UncoveredSourceCode
+        def foo
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should be 0
+    And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 84.78
+        }
+      }
+      """

--- a/features/refuse_coverage_drop.feature
+++ b/features/refuse_coverage_drop.feature
@@ -2,6 +2,7 @@
 Feature:
 
   Exit code should be non-zero if the overall coverage decreases.
+  And last_run file should not be overwritten with new coverage value.
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:
@@ -16,6 +17,14 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should be 0
     And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 88.1
+        }
+      }
+      """
 
     Given a file named "lib/faked_project/missed.rb" with:
       """
@@ -32,4 +41,12 @@ Feature:
     Then the exit status should not be 0
     And the output should contain "Coverage has dropped by 3.32% since the last time (maximum allowed: 0.00%)."
     And a file named "coverage/.last_run.json" should exist
+    And the file "coverage/.last_run.json" should contain:
+      """
+      {
+        "result": {
+          "covered_percent": 88.1
+        }
+      }
+      """
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -252,6 +252,7 @@ module SimpleCov
     # SimpleCov will return non-zero if the coverage decreases.
     #
     def refuse_coverage_drop
+      @refuse_coverage_drop = true
       maximum_coverage_drop 0
     end
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -252,7 +252,6 @@ module SimpleCov
     # SimpleCov will return non-zero if the coverage decreases.
     #
     def refuse_coverage_drop
-      @refuse_coverage_drop = true
       maximum_coverage_drop 0
     end
 

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -70,7 +70,6 @@ at_exit do # rubocop:disable Metrics/BlockLength
   if SimpleCov.result? # Result has been computed
     covered_percent = SimpleCov.result.covered_percent.round(2)
     covered_percentages = SimpleCov.result.covered_percentages.map { |p| p.round(2) }
-    coverage_diff = 0
 
     if @exit_status == SimpleCov::ExitCodes::SUCCESS # No other errors
       if covered_percent < SimpleCov.minimum_coverage # rubocop:disable Metrics/BlockNesting
@@ -89,7 +88,7 @@ at_exit do # rubocop:disable Metrics/BlockLength
     end
 
     # Don't overwrite last_run file if refuse_coverage_drop option is enabled and the coverage has dropped
-    unless SimpleCov.refuse_coverage_drop && coverage_diff > 0
+    unless @exit_status == SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
       SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
     end
   end


### PR DESCRIPTION
Rebased/slightly cut reopen of #469 by @Miloshes

Original text:

> Refuse_coverage_drop option is great but if the coverage actually dropped, it will only fail your test suite once. The .last_run.json file gets overwritten and tests are passing again.
>
> Proposed changes look for "refuse_coverage_drop" option and if it is enabled, prevent overriding of the file when the coverage has dropped.