### PR TITLE
Fails specs on ruby warnings

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,5 +1,7 @@
-require "simplecov"
 require "rspec"
+# loaded before simplecov to also capture parse time warnings
+require "support/fail_rspec_on_ruby_warning"
+require "simplecov"
 
 SimpleCov.coverage_dir("tmp/coverage")
 

--- a/spec/support/fail_rspec_on_ruby_warning.rb
+++ b/spec/support/fail_rspec_on_ruby_warning.rb
@@ -1,0 +1,72 @@
+# Borrowed and heavily adjusted from:
+# https://github.com/metricfu/metric_fu/blob/master/spec/capture_warnings.rb
+require 'fileutils'
+
+class FailOnWarnings
+  def initialize
+    @stderr_stream = StringIO.new
+    @app_root = Dir.pwd
+  end
+
+  def collect_warnings
+    $stderr = @stderr_stream
+    $VERBOSE = true
+  end
+
+  def process_warnings
+    lines = close_stream
+    app_warnings, other_warnings = split_lines(lines)
+
+    print_own_warnings(app_warnings) if app_warnings.any?
+    write_other_warnings_to_tmp(other_warnings) if other_warnings.any?
+    fail_script(app_warnings) if app_warnings.any?
+  end
+
+  private
+  def close_stream
+    $stderr = STDERR
+
+    @stderr_stream.rewind
+    lines = @stderr_stream.read.split("\n")
+    lines.uniq!
+    @stderr_stream.close
+    lines
+  end
+
+  def split_lines(lines)
+    lines.partition { |line| line.include?(@app_root) }
+  end
+
+  def print_own_warnings(app_warnings)
+    puts ""
+    puts ""
+    puts <<-WARNINGS
+#{'-' * 30} app warnings: #{'-' * 30}
+    #{app_warnings.join("\n")}
+    #{'-' * 75}
+    WARNINGS
+  end
+
+  def write_other_warnings_to_tmp(other_warnings)
+    output_dir = File.join(@app_root, "tmp")
+    FileUtils.mkdir_p(output_dir)
+    output_file = File.join(output_dir, "warnings.txt")
+    File.write(output_file, other_warnings.join("\n") << "\n")
+    puts
+    puts "Non-app warnings written to tmp/warnings.txt"
+    puts
+  end
+
+  def fail_script(app_warnings)
+    abort "Failing build due to app warnings: #{app_warnings.inspect}"
+  end
+end
+
+warning_collector = FailOnWarnings.new
+warning_collector.collect_warnings
+
+RSpec.configure do |config|
+  config.after(:suite) do
+    warning_collector.process_warnings
+  end
+end

--- a/spec/support/fail_rspec_on_ruby_warning.rb
+++ b/spec/support/fail_rspec_on_ruby_warning.rb
@@ -1,6 +1,6 @@
 # Borrowed and heavily adjusted from:
 # https://github.com/metricfu/metric_fu/blob/master/spec/capture_warnings.rb
-require 'fileutils'
+require "fileutils"
 
 class FailOnWarnings
   def initialize
@@ -22,7 +22,8 @@ class FailOnWarnings
     fail_script(app_warnings) if app_warnings.any?
   end
 
-  private
+private
+
   def close_stream
     $stderr = STDERR
 
@@ -51,7 +52,9 @@ class FailOnWarnings
     output_dir = File.join(@app_root, "tmp")
     FileUtils.mkdir_p(output_dir)
     output_file = File.join(output_dir, "warnings.txt")
-    File.write(output_file, other_warnings.join("\n") << "\n")
+    File.open(output_file, "w") do |file|
+      file.write(other_warnings.join("\n") << "\n")
+    end
     puts
     puts "Non-app warnings written to tmp/warnings.txt"
     puts


### PR DESCRIPTION
Originally stolen from: https://github.com/metricfu/metric_fu/blob/master/spec/capture_warnings.rb

Heavily modified though - e.g. put into a class, using stringio,
removed the bundler directory as not used here and moved to
before the before of the rspec suite to also capture parse time
warning errors.

Replaces #457 ( cc @bf4 @fornellas ) - basically decided for this as it doesn't mess with `Kernel.warn` and is able to capture more, even rearranged it so that it catches parse time errors :tada: 

As this is some functionality I've wanted for a long time, I heavily consider extracting this and making it a small little gem that could then also play with Cucumber/Minitest and friends :)