### PR TITLE
0.14.0 release?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Unreleased ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...master))
+0.14.0 yyyy-mm-dd ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...v0.14.0))
 ==========
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.14.0 yyyy-mm-dd ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...v0.14.0))
+0.14.0 2017-03-15 ([changes](https://github.com/colszowka/simplecov/compare/v0.13.0...v0.14.0))
 ==========
 
 ## Enhancements

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -1,5 +1,5 @@
 module SimpleCov
-  version = "0.13.0"
+  version = "0.14.0"
 
   def version.to_a
     split(".").map(&:to_i)


### PR DESCRIPTION
All outstanding PRs were closed and among them are some neat bugfixes and features, sounds like a nice thing to release to everyone.

What do you think? @colszowka @bf4 


------------------------------------------

 ## Enhancements
 
 * Officially support JRuby 9.1+ going forward (should also work with previous releases). See [#547](https://github.com/colszowka/simplecov/pull/547) (ping @PragTob when encountering issues)
 * Add Channel group to Rails profile, when `ActionCable` is loaded. See [#492](https://github.com/colszowka/simplecov/pull/492) (thanks @BenMorganIO)
 * Stop `extend`ing instances of `Array` and `Hash` during merging results avoiding problems frozen results while manually merging results. See [#558](https://github.com/colszowka/simplecov/pull/558) (thanks @aroben)
 
 ## Bugfixes
 
 * Fix parallel_tests when a thread ends up running no tests. See [#533](https://github.com/colszowka/simplecov/pull/533) (thanks @cshaffer)
 * Skip the `:nocov:` comments along with the code that they skip. See [#551](https://github.com/colszowka/simplecov/pull/551) (thanks @ebiven)
 * Fix crash when Home environment variable is unset. See [#482](https://github.com/colszowka/simplecov/pull/482) (thanks @waldyr)
 * Make track_files work again when explicitly setting it to nil. See [#463](https://github.com/colszowka/simplecov/pull/463) (thanks @craiglittle)
* Do not overwrite .last_run.json file when refuse_coverage_drop option is enabled and the coverage has dropped (lead to you being able to just rerun tests and everything was _fine_). See [#553](https://github.com/colszowka/simplecov/pull/553) (thanks @Miloshes)