### PR TITLE
Fix rubocop errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,9 @@ Style/DoubleNegation:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
+Style/IndentHeredoc:
+  Enabled: false
+
 Style/RegexpLiteral:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - 'spec/fixtures/iso-8859.rb'
     - 'tmp/**/*'
     - 'vendor/bundle/**/*'
+  TargetRubyVersion: 1.9
 
 Bundler/OrderedGems:
   Enabled: false

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -7,7 +7,7 @@ SimpleCov.profiles.define "root_filter" do
   root_filter = nil
   add_filter do |src|
     root_filter ||= /\A#{Regexp.escape(SimpleCov.root)}/io
-    !(src.filename =~ root_filter)
+    src.filename !~ root_filter
   end
 end
 


### PR DESCRIPTION
Thank you for your nice gem.

I found that latest travis-ci failed due to rubocop offense errors.
This is caused by updating rubocop version to v0.48.0.

There are 3 kinds of errors.

1. Sytle/InverseMethods
2. Style/SymbolArray
3. Style/IndentHeredoc

I fixed these errors as follows. Please check my PR.
Thanks.


## Sytle/InverseMethods

```
lib/simplecov/defaults.rb:10:5: C: Use !~ instead of inverting =~.
    !(src.filename =~ root_filter)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This cop is added on v0.48.0 by [this PR](https://github.com/bbatsov/rubocop/pull/4000).

I fixed this offense by using `!~` instead of invering the result of `=~`.


## Style/SymbolArray

```
Rakefile:37:22: C: Use %i or %I for an array of symbols.
    task :default => [:spec, :cucumber]
                     ^^^^^^^^^^^^^^^^^^
Rakefile:39:22: C: Use %i or %I for an array of symbols.
    task :default => [:rubocop, :spec, :cucumber]
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/result_spec.rb:65:9: C: Use %i or %I for an array of symbols.
        [:covered_percent, :covered_percentages, :least_covered_file, :covered_strength, :covered_lines, :missed_lines, :total_lines].each do |msg|
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This cop is enabled by default since v0.48.0 by [this PR](https://github.com/bbatsov/rubocop/pull/4144).

This offenses can be fixed by using `%i()` notation.
But this notation can be used since Ruby 2.0.
simplecov supports Ruby 1.9, so this solutioin cannot be applied.

This cop can be disabled to set rubocop's TargetRubyVersion less than 2.0.
So I set this value 1.9 and fix this cop offenses.

I worried about the supported ruby version of simplecov. Is it 1.9 right? Should I change 1.8?
(Ruby 1.8.7 is included in travis-ci target ruby versions(rvm))


## Style/IndentHeredoc

```
spec/support/fail_rspec_on_ruby_warning.rb:45:1: C: Use 2 spaces for indentation in a heredoc by using some library(e.g. ActiveSupport's String#strip_heredoc).
#{'-' * 30} app warnings: #{'-' * 30} ...
```

This cop is also added on v0.48.0 by [this PR](https://github.com/bbatsov/rubocop/pull/4028).

This cop can be fixed by using squiggly heredoc `<<~EOS ... EOS` or `String#strip_heredoc`.
But the former is available since Ruby 2.3.0, and the latter requires ActiveSupport, these solutions cannot be used in this gem.

So I make this cop disabled.
