### PR TITLE
Execute `bundle exec rake spec` to run RSpec test cases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To fetch & test the library for development, do:
     $ git clone https://github.com/colszowka/simplecov.git
     $ cd simplecov
     $ bundle
-    $ bundle exec rake
+    $ bundle exec rake spec
 
 If you want to contribute, please:
 


### PR DESCRIPTION
This pull request updates contribution document to execute tests.  it runs rubocop, not spec in my enviornment.

* Steps to reproduce

```ruby
$ bundle exec rake
Running RuboCop...
Inspecting 79 files
..................C.................................................C..........

Offenses:

spec/result_merger_spec.rb:59:71: C: %w-literals should be delimited by [ and ].
            expect(SimpleCov::ResultMerger.resultset.keys.sort).to eq %w(result1 result2)
                                                                      ^^^^^^^^^^^^^^^^^^^
lib/simplecov/defaults.rb:36:21: C: %w-literals should be delimited by [ and ].
  add_group "Jobs", %w(app/jobs app/workers)
                    ^^^^^^^^^^^^^^^^^^^^^^^^

79 files inspected, 2 offenses detected
RuboCop failed!
```

* To execute rspec
```ruby
$ bundle exec rake spec
/home/yahonda/.rbenv/versions/jruby-9.1.9.0-dev/bin/jruby -I/home/yahonda/.rbenv/versions/jruby-9.1.9.0-dev/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib:/home/yahonda/.rbenv/versions/jruby-9.1.9.0-dev/lib/ruby/gems/shared/gems/rspec-support-3.5.0/lib /home/yahonda/.rbenv/versions/jruby-9.1.9.0-dev/lib/ruby/gems/shared/gems/rspec-core-3.5.4/exe/rspec spec/1_8_fallbacks_spec.rb spec/command_guesser_spec.rb spec/config_loader_spec.rb spec/configuration_spec.rb spec/deleted_source_spec.rb spec/file_list_spec.rb spec/filters_spec.rb spec/last_run_spec.rb spec/multi_formatter_spec.rb spec/raw_coverage_spec.rb spec/result_merger_spec.rb spec/result_spec.rb spec/return_codes_spec.rb spec/source_file_line_spec.rb spec/source_file_spec.rb

Randomized with seed 22608
...................................................................................................................................................

Finished in 34.98 seconds (files took 1.4 seconds to load)
147 examples, 0 failures

Randomized with seed 22608

$
```


* SimpleCov version - master branch whose latest commit is d99967999776b33f5025ea893cec55c549d07477

```
$ ruby -e "puts RUBY_DESCRIPTION"
jruby 9.1.9.0-SNAPSHOT (2.3.3) 2017-04-03 e7bcde5 OpenJDK 64-Bit Server VM 25.121-b14 on 1.8.0_121-b14 +jit [linux-x86_64]
```

```
$ java -version
openjdk version "1.8.0_121"
OpenJDK Runtime Environment (build 1.8.0_121-b14)
OpenJDK 64-Bit Server VM (build 25.121-b14, mixed mode)
```

```
$ bundle show
Gems included by the bundle:
  * addressable (2.5.1)
  * aruba (0.7.4)
  * ast (2.3.0)
  * builder (3.2.3)
  * bundler (1.14.6)
  * capybara (2.13.0)
  * childprocess (0.6.3)
  * cliver (0.3.2)
  * cucumber (2.4.0)
  * cucumber-core (1.5.0)
  * cucumber-wire (0.0.1)
  * diff-lcs (1.3)
  * docile (1.1.5)
  * ffi (1.9.18)
  * gherkin (4.1.1)
  * json (2.0.3)
  * mime-types (3.1)
  * mime-types-data (3.2016.0521)
  * multi_json (1.12.1)
  * multi_test (0.1.2)
  * nokogiri (1.7.1)
  * parser (2.4.0.0)
  * phantomjs (2.1.1.0)
  * poltergeist (1.14.0)
  * power_assert (1.0.1)
  * powerpack (0.1.1)
  * public_suffix (2.0.5)
  * rack (2.0.1)
  * rack-test (0.6.3)
  * rainbow (2.2.1)
  * rake (12.0.0)
  * rspec (3.5.0)
  * rspec-core (3.5.4)
  * rspec-expectations (3.5.0)
  * rspec-mocks (3.5.0)
  * rspec-support (3.5.0)
  * rubocop (0.48.1)
  * ruby-progressbar (1.8.1)
  * simplecov (0.14.1)
  * simplecov-html (0.10.0)
  * test-unit (3.2.3)
  * unicode-display_width (1.1.3)
  * websocket-driver (0.6.5)
  * websocket-extensions (0.1.2)
  * xpath (2.0.0)
$
```

