### PR TITLE
Fix merging race conditions

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -75,23 +75,21 @@ module SimpleCov
     # from cache using SimpleCov::ResultMerger if use_merging is activated (default)
     #
     def result
-      # Ensure the variable is defined to avoid ruby warnings
-      @result = nil unless defined?(@result)
+      return @result if result?
 
       # Collect our coverage result
-      if running && !result?
+      if running
         @result = SimpleCov::Result.new add_not_loaded_files(Coverage.result)
       end
 
       # If we're using merging of results, store the current result
-      # first, then merge the results and return those
+      # first (if there is one), then merge the results and return those
       if use_merging
         SimpleCov::ResultMerger.store_result(@result) if result?
-
-        SimpleCov::ResultMerger.merged_result
-      else
-        @result
+        @result = SimpleCov::ResultMerger.merged_result
       end
+
+      @result
     ensure
       self.running = false
     end
@@ -157,6 +155,13 @@ module SimpleCov
       rescue LoadError
         false
       end
+    end
+
+    #
+    # Clear out the previously cached .result. Primarily useful in testing
+    #
+    def clear_result
+      @result = nil
     end
   end
 end

--- a/spec/result_merger_spec.rb
+++ b/spec/result_merger_spec.rb
@@ -1,10 +1,16 @@
 require "helper"
+require "tempfile"
+require "timeout"
 
 if SimpleCov.usable?
   describe SimpleCov::ResultMerger do
+    before do
+      SimpleCov::ResultMerger.clear_resultset
+      File.delete(SimpleCov::ResultMerger.resultset_path) if File.exist?(SimpleCov::ResultMerger.resultset_path)
+    end
+
     describe "with two faked coverage resultsets" do
       before do
-        SimpleCov.use_merging true
         @resultset1 = {
           source_fixture("sample.rb") => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
           source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
@@ -73,15 +79,92 @@ if SimpleCov.usable?
               expect(SimpleCov::ResultMerger.results.length).to eq(1)
             end
           end
+        end
+      end
+    end
 
-          context "with merging disabled" do
-            before { SimpleCov.use_merging false }
+    describe ".store_result" do
+      it "refreshes the resultset" do
+        set = SimpleCov::ResultMerger.resultset
+        SimpleCov::ResultMerger.store_result({})
+        new_set = SimpleCov::ResultMerger.resultset
+        expect(new_set).not_to be(set)
+      end
 
-            it "returns nil for SimpleCov.result" do
-              expect(SimpleCov.result).to be_nil
+      it "persists to disk" do
+        SimpleCov::ResultMerger.store_result("a" => [1])
+        SimpleCov::ResultMerger.clear_resultset
+        new_set = SimpleCov::ResultMerger.resultset
+        expect(new_set).to eq("a" => [1])
+      end
+
+      it "synchronizes writes" do
+        expect(SimpleCov::ResultMerger).to receive(:synchronize_resultset)
+        SimpleCov::ResultMerger.store_result({})
+      end
+    end
+
+    describe ".resultset" do
+      it "caches" do
+        set = SimpleCov::ResultMerger.resultset
+        new_set = SimpleCov::ResultMerger.resultset
+        expect(new_set).to be(set)
+      end
+
+      it "synchronizes reads" do
+        expect(SimpleCov::ResultMerger).to receive(:synchronize_resultset)
+        SimpleCov::ResultMerger.resultset
+      end
+    end
+
+    describe ".synchronize_resultset" do
+      it "is reentrant (i.e. doesn't block its own process)" do
+        # without @resultset_locked, this spec would fail and
+        # `.store_result` wouldn't work
+        expect do
+          Timeout.timeout(1) do
+            SimpleCov::ResultMerger.synchronize_resultset do
+              SimpleCov::ResultMerger.synchronize_resultset do
+              end
             end
           end
+        end.not_to raise_error
+      end
+
+      it "blocks other processes" do
+        file = Tempfile.new("foo")
+
+        other_process = open("|ruby -e " + Shellwords.escape(<<-CODE) + " 2>/dev/null")
+          require "simplecov"
+          SimpleCov.coverage_dir(#{SimpleCov.coverage_dir.inspect})
+
+          # ensure the parent process has enough time to get a
+          # lock before we do
+          sleep 0.5
+
+          $stdout.sync = true
+          puts "running" # see `sleep`s in parent process
+
+          SimpleCov::ResultMerger.synchronize_resultset do
+            File.open(#{file.path.inspect}, "a") { |f| f.write("process 2\n") }
+          end
+        CODE
+
+        SimpleCov::ResultMerger.synchronize_resultset do
+          # wait until the child process is going, and then wait some more
+          # so we can be sure it blocks on the lock we already have.
+          sleep 0.1 until other_process.gets == "running\n"
+          sleep 1
+
+          # despite the sleeps, this will be written first since we got
+          # the first lock
+          File.open(file.path, "a") { |f| f.write("process 1\n") }
         end
+
+        # wait for it to finish
+        other_process.gets
+
+        expect(file.read).to eq("process 1\nprocess 2\n")
       end
     end
   end

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -1,0 +1,109 @@
+require "helper"
+
+if SimpleCov.usable?
+  describe SimpleCov do
+    describe ".result" do
+      before do
+        SimpleCov.clear_result
+        allow(Coverage).to receive(:result).once.and_return({})
+      end
+
+      context "with merging disabled" do
+        before do
+          allow(SimpleCov).to receive(:use_merging).once.and_return(false)
+        end
+
+        context "when not running" do
+          before do
+            allow(SimpleCov).to receive(:running).and_return(false)
+          end
+
+          it "returns nil" do
+            expect(SimpleCov.result).to be_nil
+          end
+        end
+
+        context "when running" do
+          before do
+            allow(SimpleCov).to receive(:running).and_return(true, false)
+          end
+
+          it "uses the result from Coverage" do
+            expect(Coverage).to receive(:result).once.and_return(__FILE__ => [0, 1])
+            expect(SimpleCov.result.filenames).to eq [__FILE__]
+          end
+
+          it "adds not-loaded-files" do
+            expect(SimpleCov).to receive(:add_not_loaded_files).once.and_return({})
+            SimpleCov.result
+          end
+
+          it "doesn't store the current coverage" do
+            expect(SimpleCov::ResultMerger).not_to receive(:store_result)
+            SimpleCov.result
+          end
+
+          it "doesn't merge the result" do
+            expect(SimpleCov::ResultMerger).not_to receive(:merged_result)
+            SimpleCov.result
+          end
+
+          it "caches its result" do
+            result = SimpleCov.result
+            expect(SimpleCov.result).to be(result)
+          end
+        end
+      end
+
+      context "with merging enabled" do
+        let(:the_merged_result) { double }
+
+        before do
+          allow(SimpleCov).to receive(:use_merging).once.and_return(true)
+          allow(SimpleCov::ResultMerger).to receive(:store_result).once
+          allow(SimpleCov::ResultMerger).to receive(:merged_result).once.and_return(the_merged_result)
+        end
+
+        context "when not running" do
+          before do
+            allow(SimpleCov).to receive(:running).and_return(false)
+          end
+
+          it "merges the result" do
+            expect(SimpleCov.result).to be(the_merged_result)
+          end
+        end
+
+        context "when running" do
+          before do
+            allow(SimpleCov).to receive(:running).and_return(true, false)
+          end
+
+          it "uses the result from Coverage" do
+            expect(Coverage).to receive(:result).once.and_return({})
+            SimpleCov.result
+          end
+
+          it "adds not-loaded-files" do
+            expect(SimpleCov).to receive(:add_not_loaded_files).once.and_return({})
+            SimpleCov.result
+          end
+
+          it "stores the current coverage" do
+            expect(SimpleCov::ResultMerger).to receive(:store_result).once
+            SimpleCov.result
+          end
+
+          it "merges the result" do
+            expect(SimpleCov.result).to be(the_merged_result)
+          end
+
+          it "caches its result" do
+            result = SimpleCov.result
+            expect(SimpleCov.result).to be(result)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ensure we cache appropriately so we don't merge more than once or do unsafe reads of the resultset.

See https://gist.github.com/jenseng/62465f674f8c02de09ef776f23d4dca4 for simple repro script.

Fixes #406 and may partially address #559 (though enforcing covered_percentage still requires workarounds à la [this comment](https://github.com/colszowka/simplecov/issues/559#issuecomment-280805651), since any process before the last one won't have all the coverage data)

Basically there are 3 main problems when using merging:

1. `SimpleCov.result` doesn't cache the `@result`, so the default `at_exit` behavior causes it to store and merge 3 times.
2. `SimpleCov::ResultMerger.resultset` calls `.stored_data` twice.
3. `SimpleCov::ResultMerger.merged_result` doesn't synchronize or use a cached `.resultset`, so a concurrent `.store_result` call can cause us to read an empty file.

This can cause the formatter to miss out on coverage data in our formatters and/or get the wrong values for covered percentages.

Furthermore, if you use OJ, `JSON.parse("") -> nil`, which means `.resultset` can be nil, causing exceptions as seen in #406. So I went ahead and rolled that fix into this, since `|| {}` is trivial, and the bug can easily be verified with my repro script above.