### PR TITLE
switch inject to sum

### DIFF
--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -5,25 +5,25 @@ module SimpleCov
     # Returns the count of lines that have coverage
     def covered_lines
       return 0.0 if empty?
-      map { |f| f.covered_lines.count }.inject(&:+)
+      map { |f| f.covered_lines.count }.inject(:+)
     end
 
     # Returns the count of lines that have been missed
     def missed_lines
       return 0.0 if empty?
-      map { |f| f.missed_lines.count }.inject(&:+)
+      map { |f| f.missed_lines.count }.inject(:+)
     end
 
     # Returns the count of lines that are not relevant for coverage
     def never_lines
       return 0.0 if empty?
-      map { |f| f.never_lines.count }.inject(&:+)
+      map { |f| f.never_lines.count }.inject(:+)
     end
 
     # Returns the count of skipped lines
     def skipped_lines
       return 0.0 if empty?
-      map { |f| f.skipped_lines.count }.inject(&:+)
+      map { |f| f.skipped_lines.count }.inject(:+)
     end
 
     # Computes the coverage based upon lines covered and lines missed for each file
@@ -53,7 +53,7 @@ module SimpleCov
     # @return [Float]
     def covered_strength
       return 0.0 if empty? || lines_of_code.zero?
-      Float(map { |f| f.covered_strength * f.lines_of_code }.inject(&:+) / lines_of_code)
+      Float(map { |f| f.covered_strength * f.lines_of_code }.inject(:+) / lines_of_code)
     end
   end
 end


### PR DESCRIPTION
In certain cases I get an error for inject(&:+) however things work fine for inject(:+) and sum. This change to use inject(:+) seems to solve it for me across ruby versions whereas sum fails on older rubies. Otherwise have to use a monkeypatched version which is a bit of a shame :(