### PR TITLE
CI agains jruby-9.1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ rvm:
   - 2.4.1
   - ruby-head
   - jruby-head
-  - jruby-9.1.8.0
+  - jruby-9.1.9.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
http://jruby.org/2017/05/16/jruby-9-1-9-0.html

There is `NoMethodError: undefined method `status' for #<Array:0x47c4ecdc>` error reported at CI with jruby-head. This error may reproduce with Ruby 9.1.9.0.