### PR TITLE
Add regex filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ report.
 
 ### Defining custom filters
 
-You can currently define a filter using either a String (that will then be Regexp-matched against each source file's path),
+You can currently define a filter using either a String or Regexp (that will then be Regexp-matched against each source file's path),
 a block or by passing in your own Filter class.
 
 #### String filter
@@ -274,6 +274,16 @@ end
 ```
 
 This simple string filter will remove all files that match "/test/" in their path.
+
+#### Regex filter
+
+```ruby
+SimpleCov.start do
+  add_filter %r{^/test/}
+end
+```
+
+This simple regex filter will remove all files that start with /test/ in their path.
 
 #### Block filter
 
@@ -304,6 +314,17 @@ SimpleCov.add_filter LineFilter.new(5)
 Defining your own filters is pretty easy: Just inherit from SimpleCov::Filter and define a method 'matches?(source_file)'. When running
 the filter, a true return value from this method will result in the removal of the given source_file. The filter_argument method
 is being set in the SimpleCov::Filter initialize method and thus is set to 5 in this example.
+
+#### Array filter
+
+```ruby
+SimpleCov.start do
+  proc = Proc.new { |source_file| fales }
+  add_filter ["string", /regex/, proc, LineFilter.new(5)]
+end
+```
+
+You can pass in an array containing any of the other filter types.
 
 #### Ignoring/skipping code
 

--- a/doc/editor-integration.md
+++ b/doc/editor-integration.md
@@ -7,6 +7,11 @@ Some editors have a graphical integration for the simplecov gem.
 
 Adds an overview of your current test coverage to Atom.
 
+#### [Sublime Editor: Simple​Cov](https://packagecontrol.io/packages/SimpleCov)
+*by sentience*
+
+Adds in editor live coverage highlighting, status bar coverage information, and summary coverage information.
+
 #### [cadre](https://github.com/nyarly/cadre)
 *by Judson Lester*
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -293,12 +293,10 @@ module SimpleCov
     def parse_filter(filter_argument = nil, &filter_proc)
       if filter_argument.is_a?(SimpleCov::Filter)
         filter_argument
-      elsif filter_argument.is_a?(String)
-        SimpleCov::StringFilter.new(filter_argument)
       elsif filter_proc
         SimpleCov::BlockFilter.new(filter_proc)
-      elsif filter_argument.is_a?(Array)
-        SimpleCov::ArrayFilter.new(filter_argument)
+      elsif filter_argument
+        SimpleCov::Filter.class_for_argument(filter_argument).new(filter_argument)
       else
         raise ArgumentError, "Please specify either a string or a block to filter with"
       end

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -293,10 +293,8 @@ module SimpleCov
     def parse_filter(filter_argument = nil, &filter_proc)
       filter = filter_argument || filter_proc
 
-      if filter_argument.is_a?(SimpleCov::Filter)
-        filter_argument
-      elsif filter
-        SimpleCov::Filter.class_for_argument(filter).new(filter)
+      if filter
+        SimpleCov::Filter.build_filter(filter)
       else
         raise ArgumentError, "Please specify either a filter or a block to filter with"
       end

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -291,14 +291,14 @@ module SimpleCov
     # The actual filter processor. Not meant for direct use
     #
     def parse_filter(filter_argument = nil, &filter_proc)
+      filter = filter_argument || filter_proc
+
       if filter_argument.is_a?(SimpleCov::Filter)
         filter_argument
-      elsif filter_proc
-        SimpleCov::BlockFilter.new(filter_proc)
-      elsif filter_argument
-        SimpleCov::Filter.class_for_argument(filter_argument).new(filter_argument)
+      elsif filter
+        SimpleCov::Filter.class_for_argument(filter).new(filter)
       else
-        raise ArgumentError, "Please specify either a string or a block to filter with"
+        raise ArgumentError, "Please specify either a filter or a block to filter with"
       end
     end
   end

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -25,8 +25,8 @@ end
 SimpleCov.profiles.define "rails" do
   load_profile "test_frameworks"
 
-  add_filter "/config/"
-  add_filter "/db/"
+  add_filter %r{^/config/}
+  add_filter %r{/^/db/}
 
   add_group "Controllers", "app/controllers"
   add_group "Channels", "app/channels" if defined?(ActionCable)

--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -42,7 +42,7 @@ module SimpleCov
     # Returns true when the given source file's filename matches the
     # string configured when initializing this Filter with StringFilter.new('somestring)
     def matches?(source_file)
-      (source_file.filename =~ /#{filter_argument}/)
+      (source_file.project_filename =~ /#{filter_argument}/)
     end
   end
 
@@ -67,7 +67,7 @@ module SimpleCov
     # configured when initializing this Filter with StringFilter.new(['some/path', 'other/path'])
     def matches?(source_files_list)
       filter_argument.any? do |arg|
-        source_files_list.filename =~ /#{arg}/
+        source_files_list.project_filename =~ /#{arg}/
       end
     end
   end

--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -25,7 +25,14 @@ module SimpleCov
       matches?(source_file)
     end
 
+    def self.build_filter(filter_argument)
+      return filter_argument if filter_argument.is_a?(SimpleCov::Filter)
+      class_for_argument(filter_argument).new(filter_argument)
+    end
+
     def self.class_for_argument(filter_argument)
+      return filter_argument if filter_argument.is_a?(SimpleCov::Filter)
+
       if filter_argument.is_a?(String)
         SimpleCov::StringFilter
       elsif filter_argument.is_a?(Regexp)
@@ -66,7 +73,7 @@ module SimpleCov
 
   class ArrayFilter < SimpleCov::Filter
     def initialize(filter_argument)
-      filter_argument.map! do |arg|
+      filter_objects = filter_argument.map do |arg|
         if arg.is_a?(SimpleCov::Filter)
           arg
         else
@@ -74,7 +81,7 @@ module SimpleCov
         end
       end
 
-      super(filter_argument)
+      super(filter_objects)
     end
 
     # Returns true if any of the filters in the array match the given source file.

--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -31,8 +31,6 @@ module SimpleCov
     end
 
     def self.class_for_argument(filter_argument)
-      return filter_argument if filter_argument.is_a?(SimpleCov::Filter)
-
       if filter_argument.is_a?(String)
         SimpleCov::StringFilter
       elsif filter_argument.is_a?(Regexp)
@@ -74,11 +72,7 @@ module SimpleCov
   class ArrayFilter < SimpleCov::Filter
     def initialize(filter_argument)
       filter_objects = filter_argument.map do |arg|
-        if arg.is_a?(SimpleCov::Filter)
-          arg
-        else
-          Filter.class_for_argument(arg).new(arg)
-        end
+        Filter.build_filter(arg)
       end
 
       super(filter_objects)

--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -24,6 +24,18 @@ module SimpleCov
       warn "#{Kernel.caller.first}: [DEPRECATION] #passes? is deprecated. Use #matches? instead."
       matches?(source_file)
     end
+
+    def self.class_for_argument(filter_argument)
+      if filter_argument.is_a?(String)
+        SimpleCov::StringFilter
+      elsif filter_argument.is_a?(Regexp)
+        SimpleCov::RegexFilter
+      elsif filter_argument.is_a?(Array)
+        SimpleCov::ArrayFilter
+      else
+        raise ArgumentError, "You have provided an unrecognized filter type"
+      end
+    end
   end
 
   class StringFilter < SimpleCov::Filter
@@ -31,6 +43,14 @@ module SimpleCov
     # string configured when initializing this Filter with StringFilter.new('somestring)
     def matches?(source_file)
       (source_file.filename =~ /#{filter_argument}/)
+    end
+  end
+
+  class RegexFilter < SimpleCov::Filter
+    # Returns true when the given source file's filename matches the
+    # regex configured when initializing this Filter with RegexFilter.new(/someregex/)
+    def matches?(source_file)
+      (source_file.project_filename =~ filter_argument)
     end
   end
 

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -80,6 +80,12 @@ module SimpleCov
       @coverage = coverage
     end
 
+    # The path to this source file relative to the projects directory
+    def project_filename
+      project_dir = File.dirname(File.expand_path(File.basename(__FILE__)))
+      @filename.sub(/^#{project_dir}/, "")
+    end
+
     # The source code for this file. Aliased as :source
     def src
       # We intentionally read source code lazily to

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -82,8 +82,7 @@ module SimpleCov
 
     # The path to this source file relative to the projects directory
     def project_filename
-      project_dir = File.dirname(File.expand_path(File.basename(__FILE__)))
-      @filename.sub(/^#{project_dir}/, "")
+      @filename.sub(/^#{SimpleCov.root}/, "")
     end
 
     # The source code for this file. Aliased as :source

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -72,6 +72,40 @@ if SimpleCov.usable?
       expect(SimpleCov::ArrayFilter.new([parent_dir_name])).not_to be_matches subject
     end
 
+    it "matches a new SimpleCov::ArrayFilter when /sample.rb/ is passed as array" do
+      expect(SimpleCov::ArrayFilter.new([/sample.rb/])).to be_matches subject
+    end
+
+    it "doesn't match a new SimpleCov::ArrayFilter when a file path different than /sample.rb/ is passed as array" do
+      expect(SimpleCov::ArrayFilter.new([/other_file.rb/])).not_to be_matches subject
+    end
+
+    it "matches a new SimpleCov::ArrayFilter when a block is passed as array and returns true" do
+      expect(SimpleCov::ArrayFilter.new([proc { true }])).to be_matches subject
+    end
+
+    it "doesn't match a new SimpleCov::ArrayFilter when a block that returns false is passed as array" do
+      expect(SimpleCov::ArrayFilter.new([proc { false }])).not_to be_matches subject
+    end
+
+    it "matches a new SimpleCov::ArrayFilter when a custom class that returns true is passed as array" do
+      filter = Class.new(SimpleCov::Filter) do
+        def matches?(_)
+          true
+        end
+      end.new(nil)
+      expect(SimpleCov::ArrayFilter.new([filter])).to be_matches subject
+    end
+
+    it "doesn't match a new SimpleCov::ArrayFilter when a custom class that returns false is passed as array" do
+      filter = Class.new(SimpleCov::Filter) do
+        def matches?(_)
+          false
+        end
+      end.new(nil)
+      expect(SimpleCov::ArrayFilter.new([filter])).not_to be_matches subject
+    end
+
     context "with no filters set up and a basic source file in an array" do
       before do
         @prev_filters = SimpleCov.filters

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -26,6 +26,22 @@ if SimpleCov.usable?
       expect(SimpleCov::StringFilter.new("sample.rb")).to be_matches subject
     end
 
+    it "matches a new SimpleCov::StringFilter '/fixtures/'" do
+      expect(SimpleCov::StringFilter.new("sample.rb")).to be_matches subject
+    end
+
+    it "matches a new SimpleCov::RegexFilter /\/fixtures\//" do
+      expect(SimpleCov::RegexFilter.new(/\/fixtures\//)).to be_matches subject
+    end
+
+    it "doesn't match a new SimpleCov::RegexFilter /^\/fixtures\//" do
+      expect(SimpleCov::RegexFilter.new(/^\/fixtures\//)).not_to be_matches subject
+    end
+
+    it "matches a new SimpleCov::RegexFilter /^\/spec\//" do
+      expect(SimpleCov::RegexFilter.new(/^\/spec\//)).to be_matches subject
+    end
+
     it "doesn't match a new SimpleCov::BlockFilter that is not applicable" do
       expect(SimpleCov::BlockFilter.new(proc { |s| File.basename(s.filename) == "foo.rb" })).not_to be_matches subject
     end
@@ -92,6 +108,20 @@ if SimpleCov.usable?
       it "returns a FileList after filtering" do
         SimpleCov.add_filter "fooo"
         expect(SimpleCov.filtered(subject)).to be_a SimpleCov::FileList
+      end
+    end
+
+    describe ".class_for_argument" do
+      it "returns SimpleCov::StringFilter for a string" do
+        expect(SimpleCov::Filter.class_for_argument("filestring")).to eq(SimpleCov::StringFilter)
+      end
+
+      it "returns SimpleCov::RegexFilter for a string" do
+        expect(SimpleCov::Filter.class_for_argument(/regex/)).to eq(SimpleCov::RegexFilter)
+      end
+
+      it "returns SimpleCov::RegexFilter for a string" do
+        expect(SimpleCov::Filter.class_for_argument(%w[file1 file2])).to eq(SimpleCov::ArrayFilter)
       end
     end
   end

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -26,6 +26,11 @@ if SimpleCov.usable?
       expect(SimpleCov::StringFilter.new("sample.rb")).to be_matches subject
     end
 
+    it "doesn't match a parent directory with a new SimpleCov::StringFilter" do
+      parent_dir_name = File.basename(File.expand_path("..", File.dirname(__FILE__)))
+      expect(SimpleCov::StringFilter.new(parent_dir_name)).not_to be_matches subject
+    end
+
     it "matches a new SimpleCov::StringFilter '/fixtures/'" do
       expect(SimpleCov::StringFilter.new("sample.rb")).to be_matches subject
     end
@@ -60,6 +65,11 @@ if SimpleCov.usable?
 
     it "matches a new SimpleCov::ArrayFilter when two file paths including 'sample.rb' are passed as array" do
       expect(SimpleCov::ArrayFilter.new(["sample.rb", "other_file.rb"])).to be_matches subject
+    end
+
+    it "doesn't match a parent directory with a new SimpleCov::ArrayFilter" do
+      parent_dir_name = File.basename(File.expand_path("..", File.dirname(__FILE__)))
+      expect(SimpleCov::ArrayFilter.new([parent_dir_name])).not_to be_matches subject
     end
 
     context "with no filters set up and a basic source file in an array" do

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -16,6 +16,10 @@ if SimpleCov.usable?
         expect(subject.src).to eq(subject.source)
       end
 
+      it "has a project filename which removes the project directory" do
+        expect(subject.project_filename).to eq("/spec/fixtures/sample.rb")
+      end
+
       it "has source_lines equal to lines" do
         expect(subject.lines).to eq(subject.source_lines)
       end


### PR DESCRIPTION
Add the ability to use regex filters. The regexes should match against the files path relative to the current project, not the full path to root. For example, the file /Users/jon/project/app/foo/test.rb would match on a filter of "jon". I made the String and Array matchers follow that new rule as well.

Fixes #514 