### PR TITLE
Allow library to be used with frozen-string-literals enabled.

### DIFF
--- a/lib/simplecov/formatter/simple_formatter.rb
+++ b/lib/simplecov/formatter/simple_formatter.rb
@@ -6,7 +6,7 @@ module SimpleCov
     class SimpleFormatter
       # Takes a SimpleCov::Result and generates a string out of it
       def format(result)
-        output = ""
+        output = "".dup
         result.groups.each do |name, files|
           output << "Group: #{name}\n"
           output << "=" * 40

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -1,25 +1,3 @@
 module SimpleCov
-  version = "0.14.1".dup
-
-  def version.to_a
-    split(".").map(&:to_i)
-  end
-
-  def version.major
-    to_a[0]
-  end
-
-  def version.minor
-    to_a[1]
-  end
-
-  def version.patch
-    to_a[2]
-  end
-
-  def version.pre
-    to_a[3]
-  end
-
-  VERSION = version
+  VERSION = "0.14.1".freeze
 end

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -1,5 +1,5 @@
 module SimpleCov
-  version = "0.14.1"
+  version = "0.14.1".dup
 
   def version.to_a
     split(".").map(&:to_i)


### PR DESCRIPTION
These changes ensure that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards).

I would recommend adding the following to your .travis.yml file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4). However, at this point in time for the tests to pass, you'll need to use the latest RSpec commits, along with submitted patches to simplecov-html, test-unit, and parser (for rubocop):
* https://github.com/colszowka/simplecov-html/pull/56
* https://github.com/test-unit/test-unit/pull/149
* https://github.com/whitequark/parser/pull/354