### PR TITLE
Stop handling string filters as regexps

### DIFF
--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -49,7 +49,7 @@ module SimpleCov
     # Returns true when the given source file's filename matches the
     # string configured when initializing this Filter with StringFilter.new('somestring)
     def matches?(source_file)
-      (source_file.project_filename =~ /#{filter_argument}/)
+      source_file.project_filename.include?(filter_argument)
     end
   end
 

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -31,10 +31,6 @@ if SimpleCov.usable?
       expect(SimpleCov::StringFilter.new(parent_dir_name)).not_to be_matches subject
     end
 
-    it "matches a new SimpleCov::StringFilter '/fixtures/'" do
-      expect(SimpleCov::StringFilter.new("sample.rb")).to be_matches subject
-    end
-
     it "matches a new SimpleCov::RegexFilter /\/fixtures\//" do
       expect(SimpleCov::RegexFilter.new(/\/fixtures\//)).to be_matches subject
     end

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -26,6 +26,10 @@ if SimpleCov.usable?
       expect(SimpleCov::StringFilter.new("sample.rb")).to be_matches subject
     end
 
+    it "doesn't match a new SimpleCov::StringFilter '.pl'" do
+      expect(SimpleCov::StringFilter.new(".pl")).not_to be_matches subject
+    end
+
     it "doesn't match a parent directory with a new SimpleCov::StringFilter" do
       parent_dir_name = File.basename(File.expand_path("..", File.dirname(__FILE__)))
       expect(SimpleCov::StringFilter.new(parent_dir_name)).not_to be_matches subject


### PR DESCRIPTION
Previously, filter strings passed to `add_filter` have been handled as regexps. It means, for example, `add_filter '.pl'` matches against `sample.rb` because `.` is handled as _any character_ in regexp.

As now we have [regexp filter](#589), there's no reason to handle filter strings as regexps.

However we need to think about semver with this change. If this behavior was intentional, we cannot introduce this change until next major version bump. Or we can do if this was a _bug_.

What do you think?