### PR TITLE
Filter directories outside SimpleCov.root that have it as a prefix

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -6,7 +6,7 @@ SimpleCov.profiles.define "root_filter" do
   # Exclude all files outside of simplecov root
   root_filter = nil
   add_filter do |src|
-    root_filter ||= /\A#{Regexp.escape(SimpleCov.root)}/io
+    root_filter ||= /\A#{Regexp.escape(SimpleCov.root + File::SEPARATOR)}/io
     src.filename !~ root_filter
   end
 end

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -155,6 +155,34 @@ if SimpleCov.usable?
       end
     end
 
+    context "with the default profile" do
+      def a_file(path)
+        path = File.join(SimpleCov.root, path) unless path.start_with?("/")
+        SimpleCov::SourceFile.new(path, [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
+      end
+
+      context "inside the project" do
+        it "doesn't filter" do
+          expect(SimpleCov.filtered([a_file("foo.rb")]).count).to eq(1)
+        end
+
+        it "filters vendor/bundle" do
+          expect(SimpleCov.filtered([a_file("vendor/bundle/foo.rb")]).count).to eq(0)
+        end
+      end
+
+      context "outside the project" do
+        it "filters" do
+          expect(SimpleCov.filtered([a_file("/other/path/foo.rb")]).count).to eq(0)
+        end
+
+        it "filters even if the sibling directory has SimpleCov.root as a prefix" do
+          sibling_dir = SimpleCov.root + "_cache"
+          expect(SimpleCov.filtered([a_file(sibling_dir + "/foo.rb")]).count).to eq(0)
+        end
+      end
+    end
+
     describe ".class_for_argument" do
       it "returns SimpleCov::StringFilter for a string" do
         expect(SimpleCov::Filter.class_for_argument("filestring")).to eq(SimpleCov::StringFilter)


### PR DESCRIPTION
Given project directory `/foo/app` and BUNDLE_PATH `/foo/app_cache`,
ensure the latter is filtered out correctly by the default root filter,
since it's outside of SimpleCov.root.

Otherwise you'll see all those gem files in your coverage report, with
nonsensical paths like `._cache/ruby/2.4.0/gems...`, unless you add a
nonsensical `/^_cache/` filter

Also add some test coverage for the default filters