### PR TITLE
Fix regression in rails filters

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -26,7 +26,7 @@ SimpleCov.profiles.define "rails" do
   load_profile "test_frameworks"
 
   add_filter %r{^/config/}
-  add_filter %r{/^/db/}
+  add_filter %r{^/db/}
 
   add_group "Controllers", "app/controllers"
   add_group "Channels", "app/channels" if defined?(ActionCable)

--- a/spec/defaults_spec.rb
+++ b/spec/defaults_spec.rb
@@ -1,0 +1,41 @@
+require "helper"
+
+if SimpleCov.usable?
+  describe SimpleCov do
+    skip "requires the default configuration" if ENV["SIMPLECOV_NO_DEFAULTS"]
+
+    context "profiles" do
+      let(:config_class) do
+        Class.new do
+          include SimpleCov::Configuration
+
+          def load_profile(name)
+            configure(&SimpleCov.profiles[name.to_sym])
+          end
+        end
+      end
+
+      let(:config) { config_class.new }
+
+      def filtered?(config, filename)
+        path = File.join(SimpleCov.root, filename)
+        file = SimpleCov::SourceFile.new(path, [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
+        config.filters.any? { |filter| filter.matches?(file) }
+      end
+
+      it "provides a sensible test_frameworks profile" do
+        config.load_profile(:test_frameworks)
+        expect(filtered?(config, "foo.rb")).not_to be
+        expect(filtered?(config, "test/foo.rb")).to be
+        expect(filtered?(config, "spec/bar.rb")).to be
+      end
+
+      it "provides a sensible rails profile" do
+        config.load_profile(:rails)
+        expect(filtered?(config, "app/models/user.rb")).not_to be
+        expect(filtered?(config, "db/schema.rb")).to be
+        expect(filtered?(config, "config/environment.rb")).to be
+      end
+    end
+  end
+end

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -155,7 +155,9 @@ if SimpleCov.usable?
       end
     end
 
-    context "with the default profile" do
+    context "with the default configuration" do
+      skip "requires the default configuration" if ENV["SIMPLECOV_NO_DEFAULTS"]
+
       def a_file(path)
         path = File.join(SimpleCov.root, path) unless path.start_with?("/")
         SimpleCov::SourceFile.new(path, [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])


### PR DESCRIPTION
In converting this to a regex in a0b14a1, an extra leading `/` was added,
making this filter less useful (it would literally match the `/^/db/`
path).