### PR TITLE
CI against JRuby 9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
JRuby 9.1.13 has been released. This PR updates JRuby version on Travis CI.
http://jruby.org/2017/09/06/jruby-9-1-13-0