### PR TITLE
Fixes #624 Checks max_coverage_drop on failed tests

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -85,11 +85,10 @@ at_exit do # rubocop:disable Metrics/BlockLength
           @exit_status = SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
         end
       end
-    end
 
-    # Don't overwrite last_run file if refuse_coverage_drop option is enabled and the coverage has dropped
-    unless @exit_status == SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
-      SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
+      if @exit_status == SimpleCov::ExitCodes::SUCCESS # rubocop:disable Metrics/BlockNesting
+        SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #624 

Just taking out the max coverage drop check outside the success if statement. I can't think of a reason to leave it in the success if statement, but of course I am not too familiar with this codebase :) . Can you think of a reason why we would want to write to ```.last_run.json``` on failing tests?

The only thing that I wasn't sure of is, if a test is failing, maybe we want to leave the pre-existing non-zero exit status rather than writing an exit status of 3.