### PR TITLE
Cucumber 3.x breaks the specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :test do
     gem "aruba", "~> 0.14"
     gem "capybara"
     gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber"
+    gem "cucumber", "> 2"
     gem "phantomjs", "~> 2.1"
     gem "poltergeist"
     gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")


### PR DESCRIPTION
Cucumber 3.x has depricated Transform. When you run the specs with cucumber 3, you get this warning:

```
WARNING: #Transform is deprecated and will be removed after version 3.0.0.                                                                                                                   
         Please follow the upgrade instructions at https://cucumber.io/blog/2017/09/21/upgrading-to-cucumber-3.                                                                              
(Called from simplecov/features/step_definitions/transformers.rb:9:in `<top (required)>')
```

I guess we should get the suite running on cucumber 3.x but this at least will keep a new contributor from running ```bundle`` and having the specs fail right away.