### PR TITLE
Rubocop doesn't exclude .files for **/* --> workaround

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - 'spec/fixtures/iso-8859.rb'
     - 'tmp/**/*'
     - 'vendor/bundle/**/*'
+    - 'vendor/bundle/**/.*'
   TargetRubyVersion: 1.9
 
 Bundler/OrderedGems:

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :test do
     gem "aruba", "~> 0.14"
     gem "capybara"
     gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber"
+    gem "cucumber", "< 3"
     gem "phantomjs", "~> 2.1"
     gem "poltergeist"
     gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")


### PR DESCRIPTION
ref: bbatsov/rubocop#4832