### PR TITLE
Break default profiles out into new files

### DIFF
--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -3,43 +3,10 @@
 # Load default formatter gem
 require "simplecov-html"
 require "pathname"
-
-SimpleCov.profiles.define "root_filter" do
-  # Exclude all files outside of simplecov root
-  root_filter = nil
-  add_filter do |src|
-    root_filter ||= /\A#{Regexp.escape(SimpleCov.root + File::SEPARATOR)}/io
-    src.filename !~ root_filter
-  end
-end
-
-SimpleCov.profiles.define "test_frameworks" do
-  add_filter "/test/"
-  add_filter "/features/"
-  add_filter "/spec/"
-  add_filter "/autotest/"
-end
-
-SimpleCov.profiles.define "bundler_filter" do
-  add_filter "/vendor/bundle/"
-end
-
-SimpleCov.profiles.define "rails" do
-  load_profile "test_frameworks"
-
-  add_filter %r{^/config/}
-  add_filter %r{^/db/}
-
-  add_group "Controllers", "app/controllers"
-  add_group "Channels", "app/channels" if defined?(ActionCable)
-  add_group "Models", "app/models"
-  add_group "Mailers", "app/mailers"
-  add_group "Helpers", "app/helpers"
-  add_group "Jobs", %w[app/jobs app/workers]
-  add_group "Libraries", "lib"
-
-  track_files "{app,lib}/**/*.rb"
-end
+require "simplecov/profiles/root_filter"
+require "simplecov/profiles/test_frameworks"
+require "simplecov/profiles/bundler_filter"
+require "simplecov/profiles/rails"
 
 # Default configuration
 SimpleCov.configure do

--- a/lib/simplecov/profiles/bundler_filter.rb
+++ b/lib/simplecov/profiles/bundler_filter.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+SimpleCov.profiles.define "bundler_filter" do
+  add_filter "/vendor/bundle/"
+end

--- a/lib/simplecov/profiles/rails.rb
+++ b/lib/simplecov/profiles/rails.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+SimpleCov.profiles.define "rails" do
+  load_profile "test_frameworks"
+
+  add_filter %r{^/config/}
+  add_filter %r{^/db/}
+
+  add_group "Controllers", "app/controllers"
+  add_group "Channels", "app/channels" if defined?(ActionCable)
+  add_group "Models", "app/models"
+  add_group "Mailers", "app/mailers"
+  add_group "Helpers", "app/helpers"
+  add_group "Jobs", %w[app/jobs app/workers]
+  add_group "Libraries", "lib"
+
+  track_files "{app,lib}/**/*.rb"
+end

--- a/lib/simplecov/profiles/root_filter.rb
+++ b/lib/simplecov/profiles/root_filter.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+SimpleCov.profiles.define "root_filter" do
+  # Exclude all files outside of simplecov root
+  root_filter = nil
+  add_filter do |src|
+    root_filter ||= /\A#{Regexp.escape(SimpleCov.root + File::SEPARATOR)}/io
+    src.filename !~ root_filter
+  end
+end

--- a/lib/simplecov/profiles/test_frameworks.rb
+++ b/lib/simplecov/profiles/test_frameworks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+SimpleCov.profiles.define "test_frameworks" do
+  add_filter "/test/"
+  add_filter "/features/"
+  add_filter "/spec/"
+  add_filter "/autotest/"
+end


### PR DESCRIPTION
The goal behind this PR is to simplify the ```defaults.rb``` file. It
just breaks out the default profiles into their own files to
reduce the noise in this ```defaults.rb``` file

Things I like about this PR:

- It simplifies ```defaults.rb```
- It gives structure to any more default profiles that will be added, or
other default files to be added.

Things I don't like about this PR:

- Typically folders are used for namespacing and the ```defaults/``` folder
is not used in that way in the PR.
- There will probably be very few if any more default profiles added, so
point 2 above has little weight.
- The files inside```defaults/``` actually sets up default profiles, so
maybe we should use a ```profiles/``` folder? or ```default_profiles/```
folder? Although a ```default/``` folder is generic enough to add say
a ```config.rb``` file that has the ```SimpleCov.configure do``` setup.

What do you think? Worth the refactor? 