### PR TITLE
Remove unused fixtures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,5 @@
 AllCops:
   Exclude:
-    - 'spec/fixtures/iso-8859.rb'
     - 'tmp/**/*'
     - 'vendor/bundle/**/*'
     - 'vendor/bundle/**/.*'
@@ -73,10 +72,6 @@ Style/SpecialGlobalVars:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
-
-Style/FileName:
-  Exclude:
-    - 'spec/fixtures/utf-8.rb'
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma

--- a/spec/fixtures/iso-8859.rb
+++ b/spec/fixtures/iso-8859.rb
@@ -1,3 +1,0 @@
-
-# localized to Español thus:
-

--- a/spec/fixtures/utf-8.rb
+++ b/spec/fixtures/utf-8.rb
@@ -1,3 +1,0 @@
-# encoding: utf-8
-
-puts "135°C"


### PR DESCRIPTION
The tests associated with these fixtures look like they disappeared during the test-unit to rspec migration, but the fixtures themselves stayed around anyway.