### PR TITLE
RFC: Ignore coverage on skipped lines

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -77,9 +77,11 @@ module SimpleCov
     # The array of coverage data received from the Coverage.result
     attr_reader :coverage
 
-    def initialize(filename, coverage)
-      @filename = filename
-      @coverage = coverage
+    def initialize(filename, coverage, final_result)
+      @filename     = filename
+      @coverage     = coverage
+      @final_result = final_result
+      lines
     end
 
     # The path to this source file relative to the projects directory
@@ -179,15 +181,18 @@ module SimpleCov
     # Will go through all source files and mark lines that are wrapped within # :nocov: comment blocks
     # as skipped.
     def process_skipped_lines(lines)
+      @final_result[filename] ||= coverage.dup
+
       skipping = false
 
-      lines.each do |line|
+      lines.each_with_index do |line, i|
         if line.src =~ SimpleCov::LinesClassifier.no_cov_line
           skipping = !skipping
           line.skipped!
         elsif skipping
           line.skipped!
         end
+        @final_result[filename][i] = -1 if line.skipped?
       end
     end
 


### PR DESCRIPTION
The json resultset will include 0 passes on lines that are marked as
:nocov:. This can lead external tools to think that this line was not
in any pass, when it was effectively marked as to be ignored by the
coverage.

This PR is mainly a discussion on how we could achieve something
similar. I have three possible options (off the top of my head):

1) Discard this completely, this makes no sense on `simplecov`.
2) This PR: the speed is penalized in the general case, what is not
good at all. Plus, it modifies the `resultset.json` in a way that is not
what ruby would have written for coverage.
3) *Possibly my ideal solution*: we can allow an option to be provided
when we call to `SimpleCov.start` in which we can provide a different
file for the `:nocov:` sections on all files. This file would be again a hash
of filenames with arrays, with a boolean, marking if the line was in a
`:nocov:` section or not. If this option is not provided, everything runs
as default and this nocov file is not generated, so really fast as usual.

The rationale behind this change is that external tools processing the
`resultset.json` file have no indication about ignored lines, what makes
them hard to do calculations on them properly.

More background: https://github.com/codeclimate/test-reporter/issues/246