### PR TITLE
Only filter files in lib folder

### DIFF
--- a/lib/simplecov/profiles/rails.rb
+++ b/lib/simplecov/profiles/rails.rb
@@ -12,7 +12,7 @@ SimpleCov.profiles.define "rails" do
   add_group "Mailers", "app/mailers"
   add_group "Helpers", "app/helpers"
   add_group "Jobs", %w[app/jobs app/workers]
-  add_group "Libraries", "lib"
+  add_group "Libraries", "lib/"
 
   track_files "{app,lib}/**/*.rb"
 end


### PR DESCRIPTION
In my project I have the following file : app/controller/mercadolibre/users_controller.rb

It is wrongly recognized as a Library file.

Workaround while this PR get merged:

```ruby
SimpleCov.start 'rails' do
  add_group 'Libraries', 'lib/'
end
```