### PR TITLE
Pin bundler to 1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: ruby
 
 before_install:
   - gem update --system
-  - gem install bundler
+  # Pin bundler version due to https://github.com/rubygems/rubygems/issues/2055
+  - gem install bundler -v 1.16.0
 
 bundler_args: --without development --jobs=3 --retry=3
 


### PR DESCRIPTION
This is a workaround for https://github.com/rubygems/rubygems/issues/2055
which seems to have worked for other projects tested on Travis CI.