### PR TITLE
gemspec: Avoid distributing cucumber.yml

### DIFF
--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 1.9"
 
-  gem.files         = `git ls-files`.split("\n")
+  gem.files         = `git ls-files`.split("\n") - %w[cucumber.yml]
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.require_paths = ["lib"]


### PR DESCRIPTION
This PR excludes the `cucumber.yml` configuration file from the gem.

See https://github.com/cucumber/cucumber-rails/issues/346#issuecomment-361167227