### PR TITLE
Refactor at_exit process result

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,10 @@ Metrics/MethodLength:
   CountComments: false
   Max: 12 # TODO: Lower to 10
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'lib/simplecov.rb'
+
 Metrics/ParameterLists:
   Max: 4
   CountKeywordArgs: true

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -198,8 +198,8 @@ module SimpleCov
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/AbcSize
     def process_result(result, exit_status)
-      covered_percent = SimpleCov.result.covered_percent.round(2)
-      covered_percentages = SimpleCov.result.covered_percentages.map { |p| p.round(2) }
+      covered_percent = result.covered_percent.round(2)
+      covered_percentages = result.covered_percentages.map { |p| p.round(2) }
       return exit_status if exit_status != SimpleCov::ExitCodes::SUCCESS # Existing errors
       if covered_percent < SimpleCov.minimum_coverage
         $stderr.printf("Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%).\n", covered_percent, SimpleCov.minimum_coverage)

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -190,38 +190,67 @@ module SimpleCov
       end
     end
 
+    # @api private
+    #
+    # Called from at_exit block
+    #
+    def run_exit_tasks!
+      exit_status = SimpleCov.exit_status_from_exception
+
+      SimpleCov.at_exit.call
+
+      exit_status = SimpleCov.process_result(SimpleCov.result, exit_status)
+
+      # Force exit with stored status (see github issue #5)
+      # unless it's nil or 0 (see github issue #281)
+      Kernel.exit exit_status if exit_status && exit_status > 0
+    end
+
+    # @api private
     #
     # Usage:
     #   exit_status = SimpleCov.process_result(SimpleCov.result, exit_status)
     #
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/AbcSize
     def process_result(result, exit_status)
-      covered_percent = result.covered_percent.round(2)
-      covered_percentages = result.covered_percentages.map { |p| p.round(2) }
+      return exit_status unless SimpleCov.result? # Result has been computed
       return exit_status if exit_status != SimpleCov::ExitCodes::SUCCESS # Existing errors
+
+      covered_percent = result.covered_percent.round(2)
+      result_exit_status = result_exit_status(result, covered_percent)
+      if result_exit_status == SimpleCov::ExitCodes::SUCCESS # No result errors
+        write_last_run(covered_percent)
+      end
+      result_exit_status
+    end
+
+    # @api private
+    #
+    # rubocop:disable Metrics/MethodLength
+    def result_exit_status(result, covered_percent)
+      covered_percentages = result.covered_percentages.map { |percentage| percentage.round(2) }
       if covered_percent < SimpleCov.minimum_coverage
         $stderr.printf("Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%).\n", covered_percent, SimpleCov.minimum_coverage)
-        exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
+        SimpleCov::ExitCodes::MINIMUM_COVERAGE
       elsif covered_percentages.any? { |p| p < SimpleCov.minimum_coverage_by_file }
         $stderr.printf("File (%s) is only (%.2f%%) covered. This is below the expected minimum coverage per file of (%.2f%%).\n", result.least_covered_file, covered_percentages.min, SimpleCov.minimum_coverage_by_file)
-        exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
+        SimpleCov::ExitCodes::MINIMUM_COVERAGE
       elsif (last_run = SimpleCov::LastRun.read)
         coverage_diff = last_run["result"]["covered_percent"] - covered_percent
         if coverage_diff > SimpleCov.maximum_coverage_drop
           $stderr.printf("Coverage has dropped by %.2f%% since the last time (maximum allowed: %.2f%%).\n", coverage_diff, SimpleCov.maximum_coverage_drop)
-          exit_status = SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
-        else write_last_run(covered_percent)
+          SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
+        else
+          SimpleCov::ExitCodes::SUCCESS
         end
-      else write_last_run(covered_percent)
+      else
+        SimpleCov::ExitCodes::SUCCESS
       end
-      exit_status
     end
-    # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    #
+    # @api private
+    #
     def write_last_run(covered_percent)
       SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
     end

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -24,18 +24,7 @@ at_exit do
   next if SimpleCov.pid != Process.pid
 
   SimpleCov.set_exit_exception
-
-  @exit_status = SimpleCov.exit_status_from_exception
-
-  SimpleCov.at_exit.call
-
-  if SimpleCov.result? # Result has been computed
-    @exit_status = SimpleCov.process_result(SimpleCov.result, @exit_status)
-  end
-
-  # Force exit with stored status (see github issue #5)
-  # unless it's nil or 0 (see github issue #281)
-  Kernel.exit @exit_status if @exit_status && @exit_status > 0
+  SimpleCov.run_exit_tasks!
 end
 
 # Autoload config from ~/.simplecov if present

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -19,7 +19,7 @@ end
 # Gotta stash this a-s-a-p, see the CommandGuesser class and i.e. #110 for further info
 SimpleCov::CommandGuesser.original_run_command = "#{$PROGRAM_NAME} #{ARGV.join(' ')}"
 
-at_exit do # rubocop:disable Metrics/BlockLength
+at_exit do
   # If we are in a different process than called start, don't interfere.
   next if SimpleCov.pid != Process.pid
 
@@ -30,28 +30,7 @@ at_exit do # rubocop:disable Metrics/BlockLength
   SimpleCov.at_exit.call
 
   if SimpleCov.result? # Result has been computed
-    covered_percent = SimpleCov.result.covered_percent.round(2)
-    covered_percentages = SimpleCov.result.covered_percentages.map { |p| p.round(2) }
-
-    if @exit_status == SimpleCov::ExitCodes::SUCCESS # No other errors
-      if covered_percent < SimpleCov.minimum_coverage # rubocop:disable Metrics/BlockNesting
-        $stderr.printf("Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%).\n", covered_percent, SimpleCov.minimum_coverage)
-        @exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
-      elsif covered_percentages.any? { |p| p < SimpleCov.minimum_coverage_by_file } # rubocop:disable Metrics/BlockNesting
-        $stderr.printf("File (%s) is only (%.2f%%) covered. This is below the expected minimum coverage per file of (%.2f%%).\n", SimpleCov.result.least_covered_file, covered_percentages.min, SimpleCov.minimum_coverage_by_file)
-        @exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
-      elsif (last_run = SimpleCov::LastRun.read) # rubocop:disable Metrics/BlockNesting
-        coverage_diff = last_run["result"]["covered_percent"] - covered_percent
-        if coverage_diff > SimpleCov.maximum_coverage_drop # rubocop:disable Metrics/BlockNesting
-          $stderr.printf("Coverage has dropped by %.2f%% since the last time (maximum allowed: %.2f%%).\n", coverage_diff, SimpleCov.maximum_coverage_drop)
-          @exit_status = SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
-        end
-      end
-
-      if @exit_status == SimpleCov::ExitCodes::SUCCESS # rubocop:disable Metrics/BlockNesting
-        SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
-      end
-    end
+    @exit_status = SimpleCov.process_result(SimpleCov.result, @exit_status)
   end
 
   # Force exit with stored status (see github issue #5)


### PR DESCRIPTION
I extracted a SimpleCov.process_result method from the at_exit block in defaults.rb

I originally used this to decouple the SimpleCov run from report generation, so
that I can merge reports.

See an example of this at
- https://github.com/rails-api/active_model_serializers/blob/13340790c5c162718a6a4fe2f8aa542f8ec3b23e/scripts/coverage_report.rb#L51-L80
- https://github.com/rails-api/active_model_serializers/blob/13340790c5c162718a6a4fe2f8aa542f8ec3b23e/.simplecov#L31-L48

pasted below for convenience

`.simplecov`

```ruby
 # https://github.com/colszowka/simplecov#using-simplecov-for-centralized-config
 # see https://github.com/colszowka/simplecov/blob/master/lib/simplecov/defaults.rb
 # vim: set ft=ruby

ENV['FULL_BUILD'] ||= ENV['CI']

 ## CONFIGURE SIMPLECOV
 SimpleCov.profiles.define 'app' do
   coverage_dir 'coverage'
  load_profile 'test_frameworks'

  add_group 'Libraries', 'lib'

  add_group 'Long files' do |src_file|
    src_file.lines.count > 100
  end
  class MaxLinesFilter < SimpleCov::Filter
    def matches?(source_file)
      source_file.lines.count < filter_argument
    end
  end
  add_group 'Short files', MaxLinesFilter.new(5)

  # Exclude these paths from analysis
  add_filter '/config/'
  add_filter '/db/'
  add_filter 'tasks'
  add_filter '/.bundle/'
end

generate_report = !!(ENV['COVERAGE'] =~ /\Atrue\z/i)
running_ci = !!(ENV['FULL_BUILD'] =~ /\Atrue\z/i)
generate_result = running_ci || generate_report
require_relative 'scripts/coverage_report'
reporter = CoverageReport.new
if generate_report
  reporter.configure_to_generate_report!
  SimpleCov.at_exit do
    reporter.generate_report!
  end
end
if generate_result
  # only start when generating a result
  SimpleCov.start 'app'
  STDERR.puts '[COVERAGE] Running'
  reporter.configure_to_generate_result!
end
SimpleCov.formatters = reporter.formatters
```

`scripts/coverage_report.rb`

```ruby
 #!/usr/bin/env ruby

require 'json'
class CoverageReport
  attr_reader :formatters

  def initialize
    @formatters = []
  end

  def configure_to_generate_result!
    SimpleCov.configure do
      # use_merging   true
      minimum_coverage 0.0 # disable
      maximum_coverage_drop 100.0 # disable
    end
    SimpleCov.at_exit do
      STDERR.puts "[COVERAGE] creating #{File.join(SimpleCov.coverage_dir, '.resultset.json')}"
      SimpleCov.result.format!
    end
  end

  def configure_to_generate_report!
    @minimum_coverage = ENV.fetch('COVERAGE_MINIMUM') { 100.0 }.to_f.round(2)
    SimpleCov.configure do
      minimum_coverage @minimum_coverage
      # minimum_coverage_by_file 60
      # maximum_coverage_drop 1
      refuse_coverage_drop
    end

    @formatters = [SimpleCov::Formatter::HTMLFormatter]
  end

  def generate_report!
    report_dir = SimpleCov.coverage_dir
    file = File.join(report_dir, '.resultset.json')
    if File.exist?(file)
      json = JSON.parse(File.read(file))
      result = SimpleCov::Result.from_hash(json)
      results = [result]
      merged_result = SimpleCov::ResultMerger.merge_results(*results)
      merged_result.format!
      STDERR.puts "[COVERAGE] merged #{file}; processing..."
      process_result(merged_result)
    else
      abort "No files found to report: #{Dir.glob(report_dir)}"
    end
  end

  # https://github.com/colszowka/simplecov/blob/v0.14.1/lib/simplecov/defaults.rb#L71-L98
  def process_result(result)
    @exit_status = SimpleCov::ExitCodes::SUCCESS
    covered_percent = result.covered_percent.round(2)
    covered_percentages = result.covered_percentages.map { |p| p.round(2) }

    if @exit_status == SimpleCov::ExitCodes::SUCCESS # No other errors
      if covered_percent < SimpleCov.minimum_coverage # rubocop:disable Metrics/BlockNesting
        $stderr.printf("Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%).\n", covered_percent, SimpleCov.minimum_coverage)
        @exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
      elsif covered_percentages.any? { |p| p < SimpleCov.minimum_coverage_by_file } # rubocop:disable Metrics/BlockNesting
        $stderr.printf("File (%s) is only (%.2f%%) covered. This is below the expected minimum coverage per file of (%.2f%%).\n", result.least_covered_file, covered_percentages.min, SimpleCov.minimum_coverage_by_file)
        @exit_status = SimpleCov::ExitCodes::MINIMUM_COVERAGE
      elsif (last_run = SimpleCov::LastRun.read) # rubocop:disable Metrics/BlockNesting
        coverage_diff = last_run["result"]["covered_percent"] - covered_percent
        if coverage_diff > SimpleCov.maximum_coverage_drop # rubocop:disable Metrics/BlockNesting
          $stderr.printf("Coverage has dropped by %.2f%% since the last time (maximum allowed: %.2f%%).\n", coverage_diff, SimpleCov.maximum_coverage_drop)
          @exit_status = SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
        end
      end
    end

    # Don't overwrite last_run file if refuse_coverage_drop option is enabled and the coverage has dropped
    unless @exit_status == SimpleCov::ExitCodes::MAXIMUM_COVERAGE_DROP
      SimpleCov::LastRun.write(:result => {:covered_percent => covered_percent})
    end

    # Force exit with stored status (see github issue #5)
    # unless it's nil or 0 (see github issue #281)
    Kernel.exit @exit_status if @exit_status && @exit_status > 0
  end
end
if __FILE__ == $0
  require 'simplecov'
  reporter = CoverageReport.new
  reporter.configure_to_generate_report!
  reporter.generate_report!
end
```