### PR TITLE
Update alternate-formatters.md with simplecov-erb

### DIFF
--- a/doc/alternate-formatters.md
+++ b/doc/alternate-formatters.md
@@ -20,6 +20,11 @@ A formatter that generates Cobertura XML.
 
 CSV formatter for SimpleCov
 
+#### [simplecov-erb](https://github.com/kpaulisse/simplecov-erb)
+*by [Kevin Paulisse](https://github.com/kpaulisse)*
+
+Flexible formatter that generates the output from an ERB template.
+
 #### [simplecov-json](https://github.com/vicentllongo/simplecov-json)
 *by Vicent Llongo*
 


### PR DESCRIPTION
I needed to generate output from simplecov that displayed in the output of my CI jobs. I implemented this via a user-configurable ERB template, so that the output format can be customized with minimal friction. Source is at https://github.com/kpaulisse/simplecov-erb and it's available under the MIT license.