### PR TITLE
Update the CONTRIBUTING doc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,9 @@ If you want to contribute, please:
 
 ## Running Individual Tests
 
-This project uses Test::Unit. Individual tests can be run like this:
+This project uses RSpec and Cucumber. Individual tests can be run like this:
 
 ```bash
-ruby -I test path/to/test.rb
+bundle exec rspec path/to/test.rb
+bundle exec cucumber path/to/test.feature
 ```


### PR DESCRIPTION
The doc said simplecov uses Test::Unit but it uses RSpec and Cucumber.
Updated the doc to be correct, and fixed the examples of how to run
tests.