### PR TITLE
Make tests pass.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -5,7 +5,7 @@ require "simplecov/version"
 
 Gem::Specification.new do |gem|
   gem.name        = "simplecov"
-  gem.version     = SimpleCov::VERSION
+  gem.version     = SimpleCov::VERSION.dup
   gem.platform    = Gem::Platform::RUBY
   gem.authors     = ["Christoph Olszowka"]
   gem.email       = ["christoph at olszowka de"]

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rspec"
+require "stringio"
 # loaded before simplecov to also capture parse time warnings
 require "support/fail_rspec_on_ruby_warning"
 require "simplecov"
@@ -12,8 +13,6 @@ def source_fixture(filename)
 end
 
 # Taken from http://stackoverflow.com/questions/4459330/how-do-i-temporarily-redirect-stderr-in-ruby
-require "stringio"
-
 def capture_stderr
   # The output stream must be an IO-like object. In this case we capture it in
   # an in-memory IO object so we can return the string value. You can assign any


### PR DESCRIPTION
- Ruby 1.9.3 could not bundle install because it complained about frozen
  strings RUBY_VERSION and SimpleCov::VERSION. Calling `dup` returns
  an unfrozen string.
- Tests weren't passing in any Ruby version because `require "stringio"`
  was happening too late. This resulted in:

```
Failure/Error: @stderr_stream = StringIO.new

NameError:
  uninitialized constant FailOnWarnings::StringIO
./spec/support/fail_rspec_on_ruby_warning.rb:9:in `initialize'
```
