### PR TITLE
Performance: memomize LinesClassifier::no_cov_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 
 * Relax version constraint on `docile`, per SemVer
 * exception that occurred on exit is available as `exit_exception`! See [#639](https://github.com/colszowka/simplecov/pull/639)  (thanks @thomas07vt)
+* Performance: processing results now runs from 2.5x to 3.75x faster.
 
 ## Bugfixes
 

--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -13,7 +13,7 @@ module SimpleCov
     WHITESPACE_OR_COMMENT_LINE = Regexp.union(WHITESPACE_LINE, COMMENT_LINE)
 
     def self.no_cov_line
-      /^(\s*)#(\s*)(\:#{SimpleCov.nocov_token}\:)/
+      @no_cov_line ||= /^(\s*)#(\s*)(\:#{SimpleCov.nocov_token}\:)/
     end
 
     def classify(lines)


### PR DESCRIPTION
In my measurements the majority of the time in SimpleCov was being
spent in this one-line function.

In my tests on a large project at Airbnb, this change makes SimpleCov run
from **2.5x to 3.75x faster** when processing results. 

(From 154.2 seconds down to 60.6 seconds in one test. 
From 16.6 seconds down to 4.4 seconds in another.)

Admittedly, memoizing it does change its behavior but only in the edge
case where someone runs SimpleCov twice in a single test run, changing
the +nocov_token+ between the two runs. This is such an odd edge case I
decided not to worry about it.