### PR TITLE
Static asset server setting has nothing to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,14 +633,8 @@ If you're using [Spring](https://github.com/rails/spring) to speed up test suite
 1. Change the following settings in `test.rb`.
 
     ```ruby
-    # For Rails 4 or earlier, use the following configuration:
-    # Disable Rails's static asset server (Apache or nginx will already do this)
-    config.serve_static_files = false
-    config.eager_load = false
-
-    # For Rails 5, use the following configuration:
-    # Disable Rails's static asset server (Apache or nginx will already do this)
-    config.public_file_server.enabled = false
+    # For Rails
+    # Do not eager load code on boot
     config.eager_load = false
     ```
 2. Add your SimpleCov config, as you normally would, to your `spec_helper.rb`


### PR DESCRIPTION
In my Rails 5 app, 
`config.public_file_server.enabled = false` 
setting will make all UI tests (RSpec System spec) fail.

I believe that static asset server setting has nothing to do with Spring and SimpleCov.
`config.eager_load = false` is just enough.

For the same reason, for Rails 4 we may not need to set
`config.serve_static_files = false`
but I haven't checked it.