### PR TITLE
TIL there is an `o` modifier doing the same thanks to @eregon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ unreleased
 
 * Relax version constraint on `docile`, per SemVer
 * exception that occurred on exit is available as `exit_exception`! See [#639](https://github.com/colszowka/simplecov/pull/639)  (thanks @thomas07vt)
-* Performance: processing results now runs from 2.5x to 3.75x faster. See [#662](https://github.com/colszowka/simplecov/pull/662) (thanks @BMorearty)
+* Performance: processing results now runs from 2.5x to 3.75x faster. See [#662](https://github.com/colszowka/simplecov/pull/662) (thanks @BMorearty & @eregon)
 
 ## Bugfixes
 

--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -13,7 +13,7 @@ module SimpleCov
     WHITESPACE_OR_COMMENT_LINE = Regexp.union(WHITESPACE_LINE, COMMENT_LINE)
 
     def self.no_cov_line
-      @no_cov_line ||= /^(\s*)#(\s*)(\:#{SimpleCov.nocov_token}\:)/
+      /^(\s*)#(\s*)(\:#{SimpleCov.nocov_token}\:)/o
     end
 
     def classify(lines)


### PR DESCRIPTION
It's even a tiny bit faster it seems.

```
Memoization:
tobi@speedy ~/github/simplecov $ bundle exec ruby benchmarks/result.rb
Warming up --------------------------------------
generating a simplecov result
                        28.000  i/100ms
Calculating -------------------------------------
generating a simplecov result
                        282.997  (± 1.4%) i/s -      1.428k in   5.047055s

Modifier:
tobi@speedy ~/github/simplecov $ bundle exec ruby benchmarks/result.rb
Warming up --------------------------------------
generating a simplecov result
                        28.000  i/100ms
Calculating -------------------------------------
generating a simplecov result
                        289.115  (± 1.7%) i/s -      1.456k in   5.037437s
```