### PR TITLE
Ignore invalid byte sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ unreleased
 
 * (breaking) Stop handling string filters as regular expressions, use the dedicated regex filter if you need that behaviour. See [#616](https://github.com/colszowka/simplecov/pull/616) (thanks @yujinakayama)
 * Avoid overwriting the last coverage results on unsuccessful test runs. See [#625](https://github.com/colszowka/simplecov/pull/625) (thanks @thomas07vt)
+* Don't crash on invalid UTF-8 byte sequences.
 
 0.15.1 (2017-09-11) ([changes](https://github.com/colszowka/simplecov/compare/v0.15.0...v0.15.1))
 =======

--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -16,21 +16,30 @@ module SimpleCov
       @no_cov_line ||= /^(\s*)#(\s*)(\:#{SimpleCov.nocov_token}\:)/
     end
 
+    def self.no_cov_line?(line)
+      line =~ no_cov_line
+    rescue ArgumentError
+      # E.g., line contains an invalid byte sequence in UTF-8
+      false
+    end
+
+    def self.whitespace_line?(line)
+      line =~ WHITESPACE_OR_COMMENT_LINE
+    rescue ArgumentError
+      # E.g., line contains an invalid byte sequence in UTF-8
+      false
+    end
+
     def classify(lines)
       skipping = false
 
       lines.map do |line|
-        begin
-          if line =~ self.class.no_cov_line
-            skipping = !skipping
-            NOT_RELEVANT
-          elsif skipping || line =~ WHITESPACE_OR_COMMENT_LINE
-            NOT_RELEVANT
-          else
-            RELEVANT
-          end
-        rescue ArgumentError
-          # E.g., line contains an invalid byte sequence in UTF-8
+        if self.class.no_cov_line?(line)
+          skipping = !skipping
+          NOT_RELEVANT
+        elsif skipping || self.class.whitespace_line?(line)
+          NOT_RELEVANT
+        else
           RELEVANT
         end
       end

--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -20,12 +20,17 @@ module SimpleCov
       skipping = false
 
       lines.map do |line|
-        if line =~ self.class.no_cov_line
-          skipping = !skipping
-          NOT_RELEVANT
-        elsif skipping || line =~ WHITESPACE_OR_COMMENT_LINE
-          NOT_RELEVANT
-        else
+        begin
+          if line =~ self.class.no_cov_line
+            skipping = !skipping
+            NOT_RELEVANT
+          elsif skipping || line =~ WHITESPACE_OR_COMMENT_LINE
+            NOT_RELEVANT
+          else
+            RELEVANT
+          end
+        rescue ArgumentError
+          # E.g., line contains an invalid byte sequence in UTF-8
           RELEVANT
         end
       end

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -182,7 +182,7 @@ module SimpleCov
       skipping = false
 
       lines.each do |line|
-        if line.src =~ SimpleCov::LinesClassifier.no_cov_line
+        if SimpleCov::LinesClassifier.no_cov_line?(line.src)
           skipping = !skipping
           line.skipped!
         elsif skipping

--- a/spec/lines_classifier_spec.rb
+++ b/spec/lines_classifier_spec.rb
@@ -20,6 +20,15 @@ describe SimpleCov::LinesClassifier do
         expect(classified_lines.length).to eq 7
         expect(classified_lines).to all be_relevant
       end
+
+      it "determines invalid UTF-8 byte sequences as relevant" do
+        classified_lines = subject.classify [
+          "bytes = \"\xF1t\xEBrn\xE2ti\xF4n\xE0liz\xE6ti\xF8n\"",
+        ]
+
+        expect(classified_lines.length).to eq 1
+        expect(classified_lines).to all be_relevant
+      end
     end
 
     describe "not-relevant lines" do


### PR DESCRIPTION
This is an improvement on #664, which fixes SimpleCov so it won't crash when it encounters an invalid byte sequence in UTF-8.

This version is better in these ways:

1. The `classify` method is still short enough to make Rubocop happy.
2. The code that ignores invalid byte sequences is reused in the two places where we iterate over all the lines looking for `:nocov:`: `SimpleCov::LinesClassifier#classify` and `SimpleCov::SourceFile.process_skipped_lines`.

Like #664, this fixes a regression that was introduced in v0.15.0 when `add_not_loaded_files` was changed to call `LinesClassifier#classify`, which runs a RegExp on each line--and raises ArgumentError if the line had an invalid byte sequence.