### PR TITLE
Don't call SimpleCov.result before checking SimpleCov.result?

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -199,7 +199,9 @@ module SimpleCov
 
       SimpleCov.at_exit.call
 
-      exit_status = SimpleCov.process_result(SimpleCov.result, exit_status)
+      # Don't modify the exit status unless the result has already been
+      # computed
+      exit_status = SimpleCov.process_result(SimpleCov.result, exit_status) if SimpleCov.result?
 
       # Force exit with stored status (see github issue #5)
       # unless it's nil or 0 (see github issue #281)
@@ -212,7 +214,6 @@ module SimpleCov
     #   exit_status = SimpleCov.process_result(SimpleCov.result, exit_status)
     #
     def process_result(result, exit_status)
-      return exit_status unless SimpleCov.result? # Result has been computed
       return exit_status if exit_status != SimpleCov::ExitCodes::SUCCESS # Existing errors
 
       covered_percent = result.covered_percent.round(2)


### PR DESCRIPTION
Encountered in infertux/bashcov#36.

In the following snippet, `SimpleCov.process_result` is called with `SimpleCov.result` as the first parameter.  Because of this, the `SimpleCov.result?` check at the very beginning of `SimpleCov.process_result` will always return `true`, as `@result` was initialized by the preceding `SimpleCov.result` call:

https://github.com/colszowka/simplecov/blob/03a9f7fde44a9388580977e4002b4f6823c2b4cc/lib/simplecov.rb#L197-L224

Due to the misordering of the `.result` and `.result?` calls, any code that (like [`bashcov`](https://github.com/infertux/bashcov/blob/5d67802dabd01bd0996556b735c44f6622aa1c66/bin/bashcov#L22-L31)) stores results manually with `ResultMerger.store_result` will have its coverage data clobbered when `SimpleCov.result` calls `SimpleCov::ResultMerger.store_result` (as long as `SimpleCov.command_name` hasn't changed between the two `.store_result` calls).  See [this Travis build](https://travis-ci.org/BaxterStockman/simplecov/builds/365303403), which contains the test case from this PR but not the code fix, for an illustration of the problem.

This PR makes the call to `SimpleCov.process_result` conditional on `SimpleCov.result?` returning `true`, ensuring that existing data is overwritten only if `SimpleCov.result` has already been instantiated elsewhere.

Thanks in advance for your consideration!