### PR TITLE
WIP: easier manual collation of result sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,12 +400,29 @@ end
 
 You normally want to have your coverage analyzed across ALL of your test suites, right?
 
-Simplecov automatically caches coverage results in your (coverage_path)/.resultset.json. Those results will then
-be automatically merged when generating the result, so when coverage is set up properly for Cucumber and your
-unit / functional / integration tests, all of those test suites will be taken into account when building the
-coverage report.
+Simplecov automatically caches coverage results in your (coverage_path)/.resultset.json.
 
-There are two things to note here though:
+### Between subsequent test runs
+
+Test results are be automatically merged with previous runs when generating the result, so when coverage is set up
+properly for Cucumber and your unit / functional / integration tests, all of those test suites will be taken into
+account when building the coverage report.
+
+#### Timeout for merge
+
+Of course, your cached coverage data is likely to become invalid at some point. Thus, when automatically merging
+sequential test runs, result sets that are older than `SimpleCov.merge_timeout` will not be used any more. By default,
+the timeout is 600 seconds (10 minutes), and you can raise (or lower) it by specifying `SimpleCov.merge_timeout 3600`
+(1 hour), or, inside a configure/start block, with just `merge_timeout 3600`.
+
+You can deactivate this automatic merging altogether with `SimpleCov.use_merging false`.
+
+### Between parallel test runs
+
+If your tests are done in parallel aross multiple build machines, you can fetch them all and merge them into a single
+result set using the `SimpleCov.collate` method.
+
+TODO: Add more notes about this here
 
 ### Test suite names
 
@@ -458,15 +475,6 @@ SimpleCov.command_name "features" + (ENV['TEST_ENV_NUMBER'] || '')
 ```
 
 [simplecov-html] prints the used test suites in the footer of the generated coverage report.
-
-### Timeout for merge
-
-Of course, your cached coverage data is likely to become invalid at some point. Thus, result sets that are older than
-`SimpleCov.merge_timeout` will not be used any more. By default, the timeout is 600 seconds (10 minutes), and you can
-raise (or lower) it by specifying `SimpleCov.merge_timeout 3600` (1 hour), or, inside a configure/start block, with
-just `merge_timeout 3600`.
-
-You can deactivate merging altogether with `SimpleCov.use_merging false`.
 
 ## Running coverage only on demand
 

--- a/README.md
+++ b/README.md
@@ -404,9 +404,9 @@ Simplecov automatically caches coverage results in your (coverage_path)/.results
 
 ### Between subsequent test runs
 
-Test results are be automatically merged with previous runs when generating the result, so when coverage is set up
-properly for Cucumber and your unit / functional / integration tests, all of those test suites will be taken into
-account when building the coverage report.
+Test results are automatically merged with previous runs in the same environment when generating the result, so when
+coverage is set up properly for Cucumber and your unit / functional / integration tests, all of those test suites will
+be taken into account when building the coverage report.
 
 #### Timeout for merge
 
@@ -419,7 +419,7 @@ You can deactivate this automatic merging altogether with `SimpleCov.use_merging
 
 ### Between parallel test runs
 
-If your tests are done in parallel aross multiple build machines, you can fetch them all and merge them into a single
+If your tests are done in parallel across multiple build machines, you can fetch them all and merge them into a single
 result set using the `SimpleCov.collate` method. This can be added to a Rakefile or script file, having downloaded a set of
 `.resultset.json` files from each parallel test run.
 
@@ -441,7 +441,6 @@ the `SimpleCov::Formatter::SimpleFormatter`, and only use more complex formatter
 ```ruby
 # spec/spec_helper.rb
 require 'simplecov'
-require 'simplecov-console'
 
 SimpleCov.start 'rails' do
   # Disambiguates individual test runs
@@ -451,7 +450,7 @@ SimpleCov.start 'rails' do
     formatter SimpleCov::Formatter::SimpleFormatter
   else
     formatter SimpleCov::Formatter::MultiFormatter.new([
-      SimpleCov::Formatter::Console,
+      SimpleCov::Formatter::SimpleFormatter,
       SimpleCov::Formatter::HTMLFormatter
     ])
   end
@@ -465,11 +464,10 @@ end
 namespace :coverage do
   task :report do
     require 'simplecov'
-    require 'simplecov-console'
 
     SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"], 'rails' do
       formatter SimpleCov::Formatter::MultiFormatter.new([
-        SimpleCov::Formatter::Console,
+        SimpleCov::Formatter::SimpleFormatter,
         SimpleCov::Formatter::HTMLFormatter
       ])
     end

--- a/features/test_unit_collate.feature
+++ b/features/test_unit_collate.feature
@@ -1,0 +1,43 @@
+@test_unit
+Feature:
+
+  Using SimpleCov.collate should get the user a coverage report
+
+  Scenario:
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start
+      """
+
+    When I successfully run `bundle exec rake part1`
+    Then a coverage report should have been generated
+    When I successfully run `mv coverage/.resultset.json coverage/resultset1.json`
+    And I successfully run `rm coverage/index.html`
+
+    When I successfully run `bundle exec rake part2`
+    Then a coverage report should have been generated
+    When I successfully run `mv coverage/.resultset.json coverage/resultset2.json`
+    And I successfully run `rm coverage/index.html`
+
+    When I open the coverage report generated with `bundle exec rake collate`
+    Then I should see the groups:
+      | name      | coverage | files |
+      | All Files | 91.38%   | 6     |
+
+    And I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project.rb                    | 100.0 %  |
+      | lib/faked_project/some_class.rb         | 80.0 %   |
+      | lib/faked_project/framework_specific.rb | 75.0 %   |
+      | lib/faked_project/meta_magic.rb         | 100.0 %  |
+      | test/meta_magic_test.rb                 | 100.0 %  |
+      | test/some_class_test.rb                 | 100.0 %  |
+
+      # Note: faked_test.rb is not appearing here since that's the first unit test file
+      # loaded by Rake, and only there test_helper is required, which then loads simplecov
+      # and triggers tracking of all other loaded files! Solution for this would be to
+      # configure simplecov in this first test instead of test_helper.
+
+    And the report should be based upon:
+      | Unit Tests |

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -63,7 +63,7 @@ module SimpleCov
     # You can optionally specify configuration with a block:
     #   SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"]
     #    OR
-    #   SimpleCov.start Dir["simplecov-resultset-*/.resultset.json"], 'rails' # using rails profile
+    #   SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"], 'rails' # using rails profile
     #    OR
     #   SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"] do
     #     add_filter 'test'

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -63,13 +63,19 @@ module SimpleCov
     # You can optionally specify configuration with a block:
     #   SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"]
     #    OR
+    #   SimpleCov.start Dir["simplecov-resultset-*/.resultset.json"], 'rails' # using rails profile
+    #    OR
     #   SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"] do
-    #     load_profile 'rails'
+    #     add_filter 'test'
+    #   end
+    #    OR
+    #   SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"], 'rails' do
+    #     add_filter 'test'
     #   end
     #
     # Please check out the RDoc for SimpleCov::Configuration to find about available config options
     #
-    def collate(result_file_names, &block)
+    def collate(result_file_names, profile = nil, &block)
       load_profile(profile) if profile
       configure(&block) if block_given?
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -78,8 +78,7 @@ module SimpleCov
     def collate(result_file_names, profile = nil, &block)
       load_profile(profile) if profile
       configure(&block) if block_given?
-
-      # If the pid is set, SimpleCov will automatically write output on exit
+      self.running = true
       self.pid = Process.pid
 
       results = []

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -75,29 +75,15 @@ module SimpleCov
     #
     # Please check out the RDoc for SimpleCov::Configuration to find about available config options
     #
-    def collate(result_file_names, profile = nil, &block)
+    def collate(result_filenames, profile = nil, &block)
       load_profile(profile) if profile
       configure(&block) if block_given?
       self.running = true
       self.pid = Process.pid
 
-      results = []
-      result_sets = result_file_names.map do |coverage_resultset|
-        # Load each result file, and parse it to JSON.
-        data = File.read(coverage_resultset)
-
-        if data
-          begin
-            JSON.parse(data) || {}
-          rescue
-            {}
-          end
-        else
-          {}
-        end
-      end.reduce(&:merge).each do |command_name, data|
+      results = result_filenames.map { |filename| JSON.parse(File.read(filename)) || {} }.reduce(&:merge).map do |command_name, data|
         # Re-create each included instance of SimpleCov::Result from the stored run data.
-        results << SimpleCov::Result.from_hash(command_name => data)
+        SimpleCov::Result.from_hash(command_name => data)
       end
 
       # Use the ResultMerger to produce a single, merged result, ready to use.

--- a/spec/faked_project/Rakefile
+++ b/spec/faked_project/Rakefile
@@ -6,3 +6,20 @@ Rake::TestTask.new(:test) do |test|
   test.test_files = FileList["test/**/*_test.rb"].sort
   test.verbose = true
 end
+
+Rake::TestTask.new(:part1) do |test|
+  test.libs << "lib"
+  test.test_files = FileList["test/**/*_test.rb"].sort
+  test.verbose = true
+end
+
+Rake::TestTask.new(:part2) do |test|
+  test.libs << "test"
+  test.test_files = FileList["test/**/*_test.rb"].sort
+  test.verbose = true
+end
+
+task :collate do
+  require "simplecov"
+  SimpleCov.collate Dir["coverage/resultset*.json"]
+end


### PR DESCRIPTION
This adds a new entry point for collating multiple `.resultset.json` files, when generated by parallelised, multi-machine test runs (for example when used with [Knapsack Pro](https://www.knapsackpro.com) on Circle, Travis or Buildkite).

In these environments, the current behaviour of merging with the “last” result set is defeated by the fact that runs occur on isolated containers or machines which don’t know about the “last” run.

For these cases, you can create, for instance, a Rakefile or script file, which calls `SimpleCov.collate` with a list of paths to `.resultset.json` files from each parallel test run. In our case, we tar these and upload them as artifacts.

```ruby
# coverage_report.rake
namespace :coverage do
  task :report do
    require 'simplecov'

    SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"], 'rails' do
      formatter SimpleCov::Formatter::MultiFormatter.new([
        SimpleCov::Formatter::SimpleFormatter,
        SimpleCov::Formatter::HTMLFormatter
      ])
    end
  end
end
```

Calling `SimpleCov.collate` takes the same type of configuration block as `SimpleCov.start` but will _not_ collect coverage stats itself, only combine the results from the input JSON files, and configure `SimpleCov` to format the results when the task exits in the same way as if you called `SimpleCov.start`.

To Do:
- [x] Initial pass at feature
- [x] Test in-place in a project
- [ ] Add specs
- [x] Add documentation