### PR TITLE
Add a default_group_name option to override "Ungrouped"

### DIFF
--- a/features/rspec_groups_and_filters_complex.feature
+++ b/features/rspec_groups_and_filters_complex.feature
@@ -11,6 +11,8 @@ Feature: Sophisticated grouping and filtering on RSpec
       """
       require 'simplecov'
       SimpleCov.start do
+        default_group_name 'Remaining'
+
         add_group 'By block' do |src_file|
           src_file.filename =~ /MaGiC/i
         end
@@ -20,18 +22,21 @@ Feature: Sophisticated grouping and filtering on RSpec
         add_filter 'faked_project.rb'
         # Remove all files that include "describe" in their source
         add_filter {|src_file| src_file.lines.any? {|line| line.src =~ /describe/ } }
-        add_filter {|src_file| src_file.covered_percent < 100 }
+        add_filter {|src_file| src_file.covered_percent < 80 }
       end
       """
 
     When I open the coverage report generated with `bundle exec rspec spec`
     Then I should see the groups:
       | name      | coverage | files |
-      | All Files | 100.0%   | 1     |
+      | All Files |  89.29%  | 2     |
       | By block  | 100.0%   | 1     |
       | By string | 100.0%   | 1     |
       | By array  | 100.0%   | 1     |
+      | Remaining |  80.0%   | 1     |
 
     And I should see the source files:
       | name                            | coverage |
       | lib/faked_project/meta_magic.rb | 100.0 %  |
+      | lib/faked_project/some_class.rb |  80.0 %  |
+

--- a/features/test_unit_groups_and_filters_complex.feature
+++ b/features/test_unit_groups_and_filters_complex.feature
@@ -11,25 +11,31 @@ Feature: Sophisticated grouping and filtering on Test/Unit
       """
       require 'simplecov'
       SimpleCov.start do
+        default_group_name 'Remaining'
+
         add_group 'By block' do |src_file|
           src_file.filename =~ /MaGiC/i
         end
         add_group 'By string', 'project/meta_magic'
+        add_group 'By array', ['project/meta_magic']
 
         add_filter 'faked_project.rb'
         # Remove all files that include "describe" in their source
         add_filter {|src_file| src_file.lines.any? {|line| line.src =~ /TestCase/ } }
-        add_filter {|src_file| src_file.covered_percent < 100 }
+        add_filter {|src_file| src_file.covered_percent < 80 }
       end
       """
 
     When I open the coverage report generated with `bundle exec rake test`
     Then I should see the groups:
       | name      | coverage | files |
-      | All Files | 100.0%   | 1     |
+      | All Files |  89.29%  | 2     |
       | By block  | 100.0%   | 1     |
       | By string | 100.0%   | 1     |
+      | By array  | 100.0%   | 1     |
+      | Remaining |  80.0%   | 1     |
 
     And I should see the source files:
       | name                            | coverage |
       | lib/faked_project/meta_magic.rb | 100.0 %  |
+      | lib/faked_project/some_class.rb |  80.0 %  |

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -129,7 +129,7 @@ module SimpleCov
         grouped_files += grouped[name]
       end
       if !groups.empty? && !(other_files = files.reject { |source_file| grouped_files.include?(source_file) }).empty?
-        grouped["Ungrouped"] = SimpleCov::FileList.new(other_files)
+        grouped[SimpleCov.default_group_name] = SimpleCov::FileList.new(other_files)
       end
       grouped
     end

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -287,6 +287,16 @@ module SimpleCov
       groups[group_name] = parse_filter(filter_argument, &filter_proc)
     end
 
+    #
+    # Define the name of the group where ungrouped files are listed. Only applies if
+    # at least one add_group rule is defined.
+    #
+    # Default is "Ungrouped"
+    #
+    def default_group_name(group_name = nil)
+      @default_group_name ||= (group_name || "Ungrouped")
+    end
+
   private
 
     #


### PR DESCRIPTION
Using groups is a great way to make the result more readable but I always have some "Remaining" files which I did not want to group but I dislike the "Ungrouped" keyword. So I looked through the code and it was a rather easy, isolated "fix".

I know I could achieve the same thing with the current setup with a Regex-filter that negates all other filtes but this even uglier then the "Ungrouped" word.

Before:
```ruby
SimpleCov.start do
  add_group 'Foo', 'foo/'
end
# | All Files | 100.0% | 2 Files |
# | Foo       | 100.0% | 1 File  |
# | Ungrouped | 100.0% | 1 File  |

```

After:
```ruby
SimpleCov.start do
  default_group_name 'Remaining'
  add_group 'Foo', 'foo/'
end
# | All Files | 100.0% | 2 Files |
# | Foo       | 100.0% | 1 File  |
# | Remaining | 100.0% | 1 File  |
```

One thing I noticed was that `@test_unit` and `@rspec` of the `groups_and_filters_complex.feature` were different (test_unit was missing the `By array` filter). Was this on purpose? Now both tests are exactly the same.
