### PR TITLE
Explicitly print the exit status when SimpleCov fails the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<Version> <Date>
+===================
+
+## Enhancements
+
+* Print the exit status explicitly when it's not a successful build so it's easier figure out SimpleCov failed the build in the output.
+
+
 0.16.1 (2018-03-16)
 ===================
 

--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -17,6 +17,7 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should not be 0
     And the output should contain "Coverage (88.10%) is below the expected minimum coverage (90.00%)."
+    And the output should contain "SimpleCov failed build with exit 2"
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:
@@ -31,6 +32,7 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should not be 0
     And the output should contain "Coverage (88.10%) is below the expected minimum coverage (88.11%)."
+    And the output should contain "SimpleCov failed build with exit 2"
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:

--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -17,7 +17,7 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should not be 0
     And the output should contain "Coverage (88.10%) is below the expected minimum coverage (90.00%)."
-    And the output should contain "SimpleCov failed build with exit 2"
+    And the output should contain "SimpleCov failed with exit 2"
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:
@@ -32,7 +32,7 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should not be 0
     And the output should contain "Coverage (88.10%) is below the expected minimum coverage (88.11%)."
-    And the output should contain "SimpleCov failed build with exit 2"
+    And the output should contain "SimpleCov failed with exit 2"
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -203,7 +203,10 @@ module SimpleCov
 
       # Force exit with stored status (see github issue #5)
       # unless it's nil or 0 (see github issue #281)
-      Kernel.exit exit_status if exit_status && exit_status > 0
+      if exit_status && exit_status > 0
+        $stderr.printf("SimpleCov failed build with exit %d", exit_status)
+        Kernel.exit exit_status
+      end
     end
 
     # @api private

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -204,7 +204,7 @@ module SimpleCov
       # Force exit with stored status (see github issue #5)
       # unless it's nil or 0 (see github issue #281)
       if exit_status && exit_status > 0
-        $stderr.printf("SimpleCov failed build with exit %d", exit_status)
+        $stderr.printf("SimpleCov failed with exit %d", exit_status)
         Kernel.exit exit_status
       end
     end


### PR DESCRIPTION
## What's up? 

My team uses SimpleCov at work. Thank you for the work. We have a Jenkins setup that runs specs using [parallel_tests](https://github.com/grosser/parallel_tests). 

Recently we  turned on `SimpleCov.minimum_coverage` and sometimes we started getting random failures. Eventually, we found out that it was because of the way minimum coverage is calculated, certain `parallel_tests` groupings had coverage below the minimum. We got final output like this: 

> 13752 examples, 0 failures, 120 pendings
> Tests have failed for a parallel_test group.

With parallel_tests and our Jenkins setup, the message about "expected minimum coverage..." wasn't at the end, so it's isn't clear. 

During the debugging process, I spent some time looking for words like `failed`, `failure`, `exit` to try to see if the build was failed by a non exit 0. 



## What this does

With this, I thought it might be a good addition to SimpleCov to explicitly print out exit statuses and that it is failing the build. When there is a non-zero exit, this message is printed during the `run_exit_tasks!` method. 

> SimpleCov failed build with exit <status> 

It would have helped me discover earlier that SimpleCov was exiting non zero.  So hopping that this default message will help other users spot the cause of an exit earlier. 