### PR TITLE
add branch coverage functionality with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,15 @@ You can also entirely refuse dropping coverage between test runs:
 SimpleCov.refuse_coverage_drop
 ```
 
+## Branch coverage (ruby '~> 2.5')
+Add branch coverage measurement statistics to your results
+
+```ruby
+SimpleCov.start do
+  use_branchable_report true
+end
+```
+
 ## Using your own formatter
 
 You can use your own formatter with:

--- a/lib/simplecov/branches_per_file.rb
+++ b/lib/simplecov/branches_per_file.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SimpleCov
+  #
+  # Get coverage report on certain file
+  #
+  module BranchesPerFile
+    #
+    # @param [String] source_file_path
+    #
+    # @return [Hash]
+    #
+    def self.start(source_file_path)
+      return {} unless SimpleCov.branchable_report
+      Coverage.start(:all)
+      require source_file_path
+      Coverage.result[source_file_path][:branches]
+    end
+  end
+end

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -10,7 +10,7 @@ require "simplecov/formatter/multi_formatter"
 #
 module SimpleCov
   module Configuration # rubocop:disable ModuleLength
-    attr_writer :filters, :groups, :formatter
+    attr_writer :filters, :groups, :formatter, :branchable_report
 
     #
     # The root for the project. This defaults to the
@@ -69,6 +69,15 @@ module SimpleCov
     #
     def filters
       @filters ||= []
+    end
+
+    # Coverage results report behaviour definition.
+    # False => Give default behaviour, only lines measurement report on the coverage results.
+    # True  => Give all available kinds of measurement report lines, branches and methods coverage results.
+    # This feature is only supported with ruby version >= 2.5
+    #
+    def branchable_report
+      @branchable_report ||= false
     end
 
     # The name of the command (a.k.a. Test Suite) currently running. Used for result
@@ -285,6 +294,15 @@ module SimpleCov
     #
     def add_group(group_name, filter_argument = nil, &filter_proc)
       groups[group_name] = parse_filter(filter_argument, &filter_proc)
+    end
+
+    # Define if the report should include any other standarts of coverage measurement except
+    # :lines which is the default
+    #
+    # @param [Boolean] target
+    #
+    def use_branchable_report(target = false)
+      @branchable_report = target
     end
 
   private

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -327,7 +327,7 @@ module SimpleCov
     # lines coverage report on not supportable versions.
     #
     def target_capability(target)
-      if (RUBY_VERSION.to_f < 2.5) && target
+      if Coverage.method(:start).arity.zero? && target
         $stderr.printf <<-FYI
           Branch coverage report available only on ruby >= 2.5,
           please remove use_branchable_report option or set it to false

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -302,7 +302,7 @@ module SimpleCov
     # @param [Boolean] target
     #
     def use_branchable_report(target = false)
-      @branchable_report = target
+      @branchable_report = target_capability(target)
     end
 
   private
@@ -318,6 +318,24 @@ module SimpleCov
       else
         raise ArgumentError, "Please specify either a filter or a block to filter with"
       end
+    end
+
+    #
+    # Check if use_branchable_report is called on a ruby version
+    # which not supporting it (< 2.5).
+    # Shows notify meessage and continue the process as normal
+    # lines coverage report on not supportable versions.
+    #
+    def target_capability(target)
+      if (RUBY_VERSION.to_f < 2.5) && target
+        $stderr.printf <<-FYI
+          Branch coverage report available only on ruby >= 2.5,
+          please remove use_branchable_report option or set it to false
+        FYI
+
+        return false
+      end
+      target
     end
   end
 end

--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -57,5 +57,23 @@ module SimpleCov
       return 0.0 if empty? || lines_of_code.zero?
       Float(map { |f| f.covered_strength * f.lines_of_code }.inject(:+) / lines_of_code)
     end
+
+    # Return total count of branches in all files
+    def total_branches
+      return 0 if empty?
+      map { |file| file.total_branches.count }.inject(:+)
+    end
+
+    # Return total count of covered branches
+    def covered_branches
+      return 0 if empty?
+      map { |file| file.covered_branches.count }.inject(:+)
+    end
+
+    # Return total count of missed branches
+    def missed_branches
+      return 0 if empty?
+      map { |file| file.missed_branches.count }.inject(:+)
+    end
   end
 end

--- a/lib/simplecov/raw_coverage.rb
+++ b/lib/simplecov/raw_coverage.rb
@@ -16,16 +16,25 @@ module SimpleCov
       (result1.keys | result2.keys).each_with_object({}) do |filename, merged|
         file1 = result1[filename]
         file2 = result2[filename]
+
         merged[filename] = merge_file_coverage(file1, file2)
       end
     end
 
     def merge_file_coverage(file1, file2)
       return (file1 || file2).dup unless file1 && file2
+      {
+        :lines => merge_lines_coverage(file1[:lines], file2[:lines]),
+        :branches => merge_branches_coverage(file1[:branches], file2[:branches]) || {},
+      }
+    end
 
-      file1.map.with_index do |count1, index|
-        count2 = file2[index]
-        merge_line_coverage(count1, count2)
+    def merge_lines_coverage(lines1, lines2)
+      return (lines1 || lines2) unless lines1 && lines2
+
+      lines1.map.with_index do |first_coverage_val, index|
+        second_coverage_val = lines2[index]
+        merge_line_coverage(first_coverage_val, second_coverage_val)
       end
     end
 
@@ -36,6 +45,26 @@ module SimpleCov
       else
         sum
       end
+    end
+
+    #
+    # Merge branch coverage result by sum the branch access times count.
+    # Branches coverage report have same structure for any file
+    #
+    def merge_branches_coverage(branch1, branch2)
+      return (branch1 || branch2) unless branch1 && branch2
+
+      combined_result = branch1.clone
+
+      branch1.each do |(condition, branches_inside)|
+        branches_inside.each do |(branch_key, branch_coverage_value)|
+          compared_branch_coverage = branch2[condition][branch_key]
+
+          combined_result[condition][branch_key] = branch_coverage_value + compared_branch_coverage
+        end
+      end
+
+      combined_result
     end
   end
 end

--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -78,7 +78,7 @@ module SimpleCov
     end
 
     # Manage symbolize the keys of coverage hash.
-    # JSON.prase gives coverage hash with stringified keys what breaks some logics
+    # JSON.parse gives coverage hash with stringified keys what breaks some logics
     # inside the process that expects them as symboles.
     #
     # @return [Hash]

--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -20,7 +20,7 @@ module SimpleCov
     # Explicitly set the command name that was used for this coverage result. Defaults to SimpleCov.command_name
     attr_writer :command_name
 
-    def_delegators :files, :covered_percent, :covered_percentages, :least_covered_file, :covered_strength, :covered_lines, :missed_lines
+    def_delegators :files, :covered_percent, :covered_percentages, :least_covered_file, :covered_strength, :covered_lines, :missed_lines, :total_branches, :covered_branches, :missed_branches
     def_delegator :files, :lines_of_code, :total_lines
 
     # Initialize a new SimpleCov::Result from given Coverage.result (a Hash of filenames each containing an array of
@@ -67,10 +67,27 @@ module SimpleCov
     # Loads a SimpleCov::Result#to_hash dump
     def self.from_hash(hash)
       command_name, data = hash.first
-      result = SimpleCov::Result.new(data["coverage"])
+
+      result = SimpleCov::Result.new(
+        symbolize_names_of_coverage_results(data["coverage"])
+      )
+
       result.command_name = command_name
       result.created_at = Time.at(data["timestamp"])
       result
+    end
+
+    # Manage symbolize the keys of coverage hash.
+    # JSON.prase gives coverage hash with stringified keys what breaks some logics
+    # inside the process that expects them as symboles.
+    #
+    # @return [Hash]
+    def self.symbolize_names_of_coverage_results(coverage_data)
+      coverage_data.each_with_object({}) do |(file_name, file_coverage_result), coverage_results|
+        coverage_results[file_name] = file_coverage_result.each_with_object({}) do |(k, v), cov_elem|
+          cov_elem[k.to_sym] = v
+        end
+      end
     end
 
   private

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -85,10 +85,15 @@ module SimpleCov
 
       attr_accessor :coverage, :root_id
 
-      def initialize(*branch_attrs, root_id)
-        @type, @id, @start_line, @start_col, @end_col, @end_col = *branch_attrs
+      def initialize(*args)
+        @type       = args[0]
+        @id         = args[1]
+        @start_line = args[2]
+        @start_col  = args[3]
+        @end_line   = args[4]
+        @end_col    = args[5]
+        @root_id    = args[6]
         @coverage   = 0
-        @root_id    = root_id
       end
 
       #
@@ -135,7 +140,7 @@ module SimpleCov
       #
       def positive?
         return true if type == :when
-        1 + root_id == id
+        1 + root_id.to_i == id
       end
 
       #
@@ -260,7 +265,7 @@ module SimpleCov
 
     # Warning to identify condition from Issue #56
     def coverage_exceeding_source_warn
-      $stderr.puts "Warning: coverage data provided by Coverage [#{coverage.size}] exceeds number of lines in #{filename} [#{src.size}]"
+      $stderr.puts "Warning: coverage data provided by Coverage [#{coverage[:lines].size}] exceeds number of lines in #{filename} [#{src.size}]"
     end
 
     # Access SimpleCov::SourceFile::Line source lines by line number
@@ -392,7 +397,8 @@ module SimpleCov
       @branches_collection ||= []
 
       given_branches.each do |branch_args, value|
-        branch = Branch.new(*branch_args, root_id)
+        branch_args << root_id
+        branch = Branch.new(*branch_args)
 
         if value.is_a?(Integer)
           branch.coverage = value

--- a/spec/file_list_spec.rb
+++ b/spec/file_list_spec.rb
@@ -6,9 +6,9 @@ if SimpleCov.usable?
   describe SimpleCov::Result do
     subject do
       original_result = {
-        source_fixture("sample.rb") => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-        source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-        source_fixture("app/controllers/sample_controller.rb") => [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil],
+        source_fixture("sample.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+        source_fixture("app/models/user.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+        source_fixture("app/controllers/sample_controller.rb") => {:lines => [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil]},
       }
       SimpleCov::Result.new(original_result).files
     end

--- a/spec/raw_coverage_spec.rb
+++ b/spec/raw_coverage_spec.rb
@@ -7,27 +7,36 @@ if SimpleCov.usable?
     describe "with two faked coverage resultsets" do
       before do
         @resultset1 = {
-          source_fixture("sample.rb") => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-          source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-          source_fixture("app/controllers/sample_controller.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-          source_fixture("resultset1.rb") => [1, 1, 1, 1],
-          source_fixture("parallel_tests.rb") => [nil, 0, nil, 0],
-          source_fixture("conditionally_loaded_1.rb") => [nil, 0, 1],  # loaded only in the first resultset
-          source_fixture("three.rb") => [nil, 1, 1],
+          source_fixture("sample.rb") => {
+            :lines => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
+            :branches => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}},
+          },
+          source_fixture("app/models/user.rb") => {
+            :lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+            :branches => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}},
+          },
+          source_fixture("app/controllers/sample_controller.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+          source_fixture("resultset1.rb") => {:lines => [1, 1, 1, 1]},
+          source_fixture("parallel_tests.rb") => {:lines => [nil, 0, nil, 0]},
+          source_fixture("conditionally_loaded_1.rb") => {:lines => [nil, 0, 1]},  # loaded only in the first resultset
+          source_fixture("three.rb") => {:lines => [nil, 1, 1]},
         }
 
         @resultset2 = {
-          source_fixture("sample.rb") => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil],
-          source_fixture("app/models/user.rb") => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
-          source_fixture("app/controllers/sample_controller.rb") => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil],
-          source_fixture("resultset2.rb") => [nil, 1, 1, nil],
-          source_fixture("parallel_tests.rb") => [nil, nil, 0, 0],
-          source_fixture("conditionally_loaded_2.rb") => [nil, 0, 1],  # loaded only in the second resultset
-          source_fixture("three.rb") => [nil, 1, 4],
+          source_fixture("sample.rb") => {:lines => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]},
+          source_fixture("app/models/user.rb") => {
+            :lines => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
+            :branches => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 1, [:else, 5, 8, 6, 8, 36] => 2}},
+          },
+          source_fixture("app/controllers/sample_controller.rb") => {:lines => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil]},
+          source_fixture("resultset2.rb") => {:lines => [nil, 1, 1, nil]},
+          source_fixture("parallel_tests.rb") => {:lines => [nil, nil, 0, 0]},
+          source_fixture("conditionally_loaded_2.rb") => {:lines => [nil, 0, 1]},  # loaded only in the second resultset
+          source_fixture("three.rb") => {:lines => [nil, 1, 4]},
         }
 
         @resultset3 = {
-          source_fixture("three.rb") => [nil, 1, 2],
+          source_fixture("three.rb") => {:lines => [nil, 1, 2]},
         }
       end
 
@@ -37,58 +46,60 @@ if SimpleCov.usable?
         end
 
         it "has proper results for sample.rb" do
-          expect(subject[source_fixture("sample.rb")]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
+          expect(subject[source_fixture("sample.rb")][:lines]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
+          expect(subject[source_fixture("sample.rb")][:branches]).to eq([:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24})
         end
 
         it "has proper results for user.rb" do
-          expect(subject[source_fixture("app/models/user.rb")]).to eq([nil, 2, 6, 2, nil, nil, 2, 0, nil, nil])
+          expect(subject[source_fixture("app/models/user.rb")][:lines]).to eq([nil, 2, 6, 2, nil, nil, 2, 0, nil, nil])
+          expect(subject[source_fixture("app/models/user.rb")][:branches]).to eq([:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 48, [:else, 5, 8, 6, 8, 36] => 26})
         end
 
         it "has proper results for sample_controller.rb" do
-          expect(subject[source_fixture("app/controllers/sample_controller.rb")]).to eq([nil, 4, 2, 1, nil, nil, 2, 0, nil, nil])
+          expect(subject[source_fixture("app/controllers/sample_controller.rb")][:lines]).to eq([nil, 4, 2, 1, nil, nil, 2, 0, nil, nil])
         end
 
         it "has proper results for resultset1.rb" do
-          expect(subject[source_fixture("resultset1.rb")]).to eq([1, 1, 1, 1])
+          expect(subject[source_fixture("resultset1.rb")][:lines]).to eq([1, 1, 1, 1])
         end
 
         it "has proper results for resultset2.rb" do
-          expect(subject[source_fixture("resultset2.rb")]).to eq([nil, 1, 1, nil])
+          expect(subject[source_fixture("resultset2.rb")][:lines]).to eq([nil, 1, 1, nil])
         end
 
         it "has proper results for parallel_tests.rb" do
-          expect(subject[source_fixture("parallel_tests.rb")]).to eq([nil, nil, nil, 0])
+          expect(subject[source_fixture("parallel_tests.rb")][:lines]).to eq([nil, nil, nil, 0])
         end
 
         it "has proper results for conditionally_loaded_1.rb" do
-          expect(subject[source_fixture("conditionally_loaded_1.rb")]).to eq([nil, 0, 1])
+          expect(subject[source_fixture("conditionally_loaded_1.rb")][:lines]).to eq([nil, 0, 1])
         end
 
         it "has proper results for conditionally_loaded_2.rb" do
-          expect(subject[source_fixture("conditionally_loaded_2.rb")]).to eq([nil, 0, 1])
+          expect(subject[source_fixture("conditionally_loaded_2.rb")][:lines]).to eq([nil, 0, 1])
         end
 
         it "has proper results for three.rb" do
-          expect(subject[source_fixture("three.rb")]).to eq([nil, 3, 7])
+          expect(subject[source_fixture("three.rb")][:lines]).to eq([nil, 3, 7])
         end
       end
     end
 
     it "merges frozen resultsets" do
       resultset1 = {
-        source_fixture("sample.rb").freeze => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil].freeze,
-        source_fixture("app/models/user.rb").freeze => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil].freeze,
-      }.freeze
+        source_fixture("sample.rb").freeze => {:lines => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+        source_fixture("app/models/user.rb").freeze => {:lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+      }
 
       resultset2 = {
-        source_fixture("sample.rb").freeze => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil].freeze,
-      }.freeze
+        source_fixture("sample.rb").freeze => {:lines => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]},
+      }
 
       merged_result = SimpleCov::RawCoverage.merge_results(resultset1, resultset2)
       expect(merged_result.keys).to eq(resultset1.keys)
       expect(merged_result.values.map(&:frozen?)).to eq([false, false])
-      expect(merged_result[source_fixture("sample.rb")]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
-      expect(merged_result[source_fixture("app/models/user.rb")]).to eq([nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
+      expect(merged_result[source_fixture("sample.rb")][:lines]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
+      expect(merged_result[source_fixture("app/models/user.rb")][:lines]).to eq([nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
     end
   end
 end

--- a/spec/result_merger_spec.rb
+++ b/spec/result_merger_spec.rb
@@ -14,21 +14,21 @@ if SimpleCov.usable?
     describe "with two faked coverage resultsets" do
       before do
         @resultset1 = {
-          source_fixture("sample.rb") => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-          source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-          source_fixture("app/controllers/sample_controller.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-          source_fixture("resultset1.rb") => [1, 1, 1, 1],
-          source_fixture("parallel_tests.rb") => [nil, 0, nil, 0],
-          source_fixture("conditionally_loaded_1.rb") => [nil, 0, 1],  # loaded only in the first resultset
+          source_fixture("sample.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+          source_fixture("app/models/user.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+          source_fixture("app/controllers/sample_controller.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+          source_fixture("resultset1.rb") => {:lines => [1, 1, 1, 1]},
+          source_fixture("parallel_tests.rb") => {:lines => [nil, 0, nil, 0]},
+          source_fixture("conditionally_loaded_1.rb") => {:lines => [nil, 0, 1]}, # loaded only in the first resultset
         }
 
         @resultset2 = {
-          source_fixture("sample.rb") => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil],
-          source_fixture("app/models/user.rb") => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
-          source_fixture("app/controllers/sample_controller.rb") => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil],
-          source_fixture("resultset2.rb") => [nil, 1, 1, nil],
-          source_fixture("parallel_tests.rb") => [nil, nil, 0, 0],
-          source_fixture("conditionally_loaded_2.rb") => [nil, 0, 1],  # loaded only in the second resultset
+          source_fixture("sample.rb") => {:lines => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]},
+          source_fixture("app/models/user.rb") => {:lines => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil]},
+          source_fixture("app/controllers/sample_controller.rb") => {:lines => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil]},
+          source_fixture("resultset2.rb") => {:lines => [nil, 1, 1, nil]},
+          source_fixture("parallel_tests.rb") => {:lines => [nil, nil, 0, 0]},
+          source_fixture("conditionally_loaded_2.rb") => {:lines => [nil, 0, 1]}, # loaded only in the second resultset
         }
       end
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -22,9 +22,9 @@ if SimpleCov.usable?
 
       let(:original_result) do
         {
-          source_fixture("sample.rb") => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-          source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-          source_fixture("app/controllers/sample_controller.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+          source_fixture("sample.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+          source_fixture("app/models/user.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+          source_fixture("app/controllers/sample_controller.rb") => {:lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
         }
       end
 

--- a/spec/source_file_branch_spec.rb
+++ b/spec/source_file_branch_spec.rb
@@ -13,15 +13,15 @@ if SimpleCov.usable?
     end
 
     let(:root_branch) do
-      SimpleCov::SourceFile::Branch.new(*results[0], nil)
+      SimpleCov::SourceFile::Branch.new(*(results[0] + [nil]))
     end
 
     let(:positive_sub_branch) do
-      SimpleCov::SourceFile::Branch.new(*results[1], 0)
+      SimpleCov::SourceFile::Branch.new(*(results[1] + [0]))
     end
 
     let(:negative_sub_branch) do
-      SimpleCov::SourceFile::Branch.new(*results[2], 0)
+      SimpleCov::SourceFile::Branch.new(*(results[2] + [0]))
     end
 
     let(:branches) do
@@ -30,8 +30,8 @@ if SimpleCov.usable?
 
     let(:inline_branches) do
       [root_branch,
-       SimpleCov::SourceFile::Branch.new(*results[3], 0),
-       SimpleCov::SourceFile::Branch.new(*results[4], 0)]
+       SimpleCov::SourceFile::Branch.new(*(results[3] + [0])),
+       SimpleCov::SourceFile::Branch.new(*(results[4] + [0]))]
     end
 
     context "A source branch if..else" do
@@ -77,25 +77,25 @@ if SimpleCov.usable?
       end
 
       let(:case_branch) do
-        SimpleCov::SourceFile::Branch.new(*results[0], nil)
+        SimpleCov::SourceFile::Branch.new(*(results[0] + [nil]))
       end
 
       let(:branches_without_else) do
         [case_branch,
-         SimpleCov::SourceFile::Branch.new(*results[1], 0),
-         SimpleCov::SourceFile::Branch.new(*results[2], 0),
-         SimpleCov::SourceFile::Branch.new(*results[3], 0)]
+         SimpleCov::SourceFile::Branch.new(*(results[1] + [0])),
+         SimpleCov::SourceFile::Branch.new(*(results[2] + [0])),
+         SimpleCov::SourceFile::Branch.new(*(results[3] + [0]))]
       end
 
       let(:branches_with_else) do
         [case_branch,
-         SimpleCov::SourceFile::Branch.new(*results[1], 0),
-         SimpleCov::SourceFile::Branch.new(*results[2], 0),
-         SimpleCov::SourceFile::Branch.new(*results[4], 0)]
+         SimpleCov::SourceFile::Branch.new(*(results[1] + [0])),
+         SimpleCov::SourceFile::Branch.new(*(results[2] + [0])),
+         SimpleCov::SourceFile::Branch.new(*(results[4] + [0]))]
       end
 
       it "When branche badge is positive" do
-        expect(branches_without_else[1].badge).to be "+"
+        expect(branches_without_else[1].badge.to_sym).to eq(:+)
       end
 
       it "Has right `case` sub branches which having else inside" do
@@ -117,7 +117,7 @@ if SimpleCov.usable?
     context "A source branch with coverage" do
       let(:covered_branch) do
         attrs = [:when, 1, 2, 6, 8, 4]
-        branch = SimpleCov::SourceFile::Branch.new(*attrs, 0)
+        branch = SimpleCov::SourceFile::Branch.new(*(attrs + [0]))
         branch.coverage = 5
         branch
       end
@@ -134,7 +134,7 @@ if SimpleCov.usable?
     context "A source branch with out coverage" do
       let(:covered_branch) do
         attrs = [:when, 1, 2, 6, 8, 4]
-        branch = SimpleCov::SourceFile::Branch.new(*attrs, 0)
+        branch = SimpleCov::SourceFile::Branch.new(*(attrs + [0]))
         branch.coverage = 0
         branch
       end

--- a/spec/source_file_branch_spec.rb
+++ b/spec/source_file_branch_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "helper"
+
+if SimpleCov.usable?
+  describe SimpleCov::SourceFile::Branch do
+    let(:results) do
+      [[:if, 0, 1, 4, 10, 4],
+       [:then, 1, 2, 6, 8, 4],
+       [:else, 2, 2, 6, 8, 4],
+       [:then, 1, 1, 6, 9, 5],
+       [:else, 2, 1, 6, 8, 4]]
+    end
+
+    let(:root_branch) do
+      SimpleCov::SourceFile::Branch.new(*results[0], nil)
+    end
+
+    let(:positive_sub_branch) do
+      SimpleCov::SourceFile::Branch.new(*results[1], 0)
+    end
+
+    let(:negative_sub_branch) do
+      SimpleCov::SourceFile::Branch.new(*results[2], 0)
+    end
+
+    let(:branches) do
+      [root_branch, positive_sub_branch, negative_sub_branch]
+    end
+
+    let(:inline_branches) do
+      [root_branch,
+       SimpleCov::SourceFile::Branch.new(*results[3], 0),
+       SimpleCov::SourceFile::Branch.new(*results[4], 0)]
+    end
+
+    context "A source branch if..else" do
+      it "Is not root branch" do
+        expect(root_branch.root?).to be true
+      end
+
+      it "Is a root branch" do
+        expect(positive_sub_branch.root?).to be       false
+        expect(negative_sub_branch.sub_branch?).to be true
+      end
+
+      it "Has badge + of positive branch" do
+        expect(positive_sub_branch.badge).to eq "+"
+      end
+
+      it "Has badge - of negative branch" do
+        expect(negative_sub_branch.badge).to eq "-"
+      end
+
+      it "Return both sub branches of root branch" do
+        expect(root_branch.sub_branches(branches).count).to eq(2)
+        expect(root_branch.sub_branches(branches).map(&:type)).to eq([:then, :else])
+      end
+
+      it "Detects the if inline branch given" do
+        expect(root_branch.inline_branch?(inline_branches)).to eq(true)
+      end
+
+      it "Correct report branch report" do
+        expect(positive_sub_branch.report).to eq([0, "+"])
+        expect(negative_sub_branch.report).to eq([0, "-"])
+      end
+    end
+
+    context "A source branch case..when..else" do
+      let(:results) do
+        [[:case, 0, 1, 4, 10, 4],
+         [:when, 1, 2, 6, 8, 4],
+         [:when, 2, 3, 8, 10, 4],
+         [:else, 0, 1, 4, 10, 4],
+         [:else, 3, 4, 10, 12, 4]]
+      end
+
+      let(:case_branch) do
+        SimpleCov::SourceFile::Branch.new(*results[0], nil)
+      end
+
+      let(:branches_without_else) do
+        [case_branch,
+         SimpleCov::SourceFile::Branch.new(*results[1], 0),
+         SimpleCov::SourceFile::Branch.new(*results[2], 0),
+         SimpleCov::SourceFile::Branch.new(*results[3], 0)]
+      end
+
+      let(:branches_with_else) do
+        [case_branch,
+         SimpleCov::SourceFile::Branch.new(*results[1], 0),
+         SimpleCov::SourceFile::Branch.new(*results[2], 0),
+         SimpleCov::SourceFile::Branch.new(*results[4], 0)]
+      end
+
+      it "When branche badge is positive" do
+        expect(branches_without_else[1].badge).to be "+"
+      end
+
+      it "Has right `case` sub branches which having else inside" do
+        expect(case_branch.sub_branches(branches_with_else).count).to eq(3)
+        expect(case_branch.sub_branches(branches_with_else).map(&:type)).to eq([:when, :when, :else])
+      end
+
+      it "Has right `case` sub branches which does not have else inside" do
+        expect(case_branch.sub_branches(branches_without_else).count).to eq(2)
+        expect(case_branch.sub_branches(branches_without_else).map(&:type)).to eq([:when, :when])
+      end
+
+      it "Has correct branch report (`when` always positive)" do
+        expect(branches_without_else[1].report).to eq([0, "+"])
+        expect(branches_without_else[2].report).to eq([0, "+"])
+      end
+    end
+
+    context "A source branch with coverage" do
+      let(:covered_branch) do
+        attrs = [:when, 1, 2, 6, 8, 4]
+        branch = SimpleCov::SourceFile::Branch.new(*attrs, 0)
+        branch.coverage = 5
+        branch
+      end
+
+      it "Is covered" do
+        expect(covered_branch).to be_covered
+      end
+
+      it "Is not missed" do
+        expect(covered_branch).not_to be_missed
+      end
+    end
+
+    context "A source branch with out coverage" do
+      let(:covered_branch) do
+        attrs = [:when, 1, 2, 6, 8, 4]
+        branch = SimpleCov::SourceFile::Branch.new(*attrs, 0)
+        branch.coverage = 0
+        branch
+      end
+
+      it "Is covered" do
+        expect(covered_branch).not_to be_covered
+      end
+
+      it "Is not missed" do
+        expect(covered_branch).to be_missed
+      end
+    end
+  end
+end

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -9,6 +9,10 @@ if SimpleCov.usable?
       :branches => {[:if, 0, 17, 6, 23, 9] => {[:then, 1, 18, 8, 18, 81] => 3, [:else, 2, 20, 8, 22, 19] => 0}, [:if, 3, 29, 6, 35, 9] => {[:then, 4, 30, 8, 30, 81] => 3, [:else, 5, 32, 8, 34, 20] => 0}},
     }.freeze
 
+    COVERAGE_FOR_SAMPLE_RB_WITH_MORE_LINES = {
+      :lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil],
+    }.freeze
+
     context "a source file initialized with some coverage data" do
       subject do
         SimpleCov::SourceFile.new(source_fixture("sample.rb"), COVERAGE_FOR_SAMPLE_RB)
@@ -95,8 +99,7 @@ if SimpleCov.usable?
 
     context "simulating potential Ruby 1.9 defect -- see Issue #56" do
       subject do
-        COVERAGE_FOR_SAMPLE_RB[:lines] << nil
-        SimpleCov::SourceFile.new(source_fixture("sample.rb"), COVERAGE_FOR_SAMPLE_RB)
+        SimpleCov::SourceFile.new(source_fixture("sample.rb"), COVERAGE_FOR_SAMPLE_RB_WITH_MORE_LINES)
       end
 
       it "has 16 source lines regardless of extra data in coverage array" do


### PR DESCRIPTION
Add branch coverage measurement statistics (ruby ~> 2.5) 
In this PR:
- Add configuration needed to trigger this new functionality.
```ruby
SimpleCov.start do
  use_branchable_report true
end
```
  If config is set for ruby versions which are < 2.5, It will shows notify message and produce only lines coverage report.
- Unite the results no matter what coverage version used to be there. Now always the coverage result is a hash with keys represents the type of coverage and values represents the coverage result for each type ex: `{:lines => ..., :branches => ..}`.
- Add `Branch` class with related support methods to `SourceFile`
- On simplecov-html side we will have this visual statistics:
![branch1](https://user-images.githubusercontent.com/7699543/43396656-e273be44-940a-11e8-99b3-053929752e3d.png)
 `[0, '-'] => [passing count, branch sign]`
Condition with missed branch will be marked similar to line 70.

Benefits:
- Coverage report gives more information about conditions especially the inline conditions similar to the case specified above.

Frankly, the first time I developed this feature it was a [PR](https://github.com/colszowka/simplecov/pull/694) with 1300 diff lines, I thought it will be quite hard to review it. So this one is about 760 lines and hopes it will be approved.
