### PR TITLE
Fix CI for ruby-head to be run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,30 @@ bundler_args: --without development --jobs=3 --retry=3
 
 sudo: false
 
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.10
-  - 2.3.7
-  - 2.4.3
-  - 2.5.1
-  - jruby-9.1.17.0
-  - ruby-head
-  - jruby-head
-
 matrix:
+  include:
+    - rvm: 1.8.7
+      gemfile: gemfiles/ruby_18.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/ruby_19.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/ruby_20.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/ruby_21.gemfile
+    - rvm: 2.2.10
+      gemfile: gemfiles/ruby_22.gemfile
+    - rvm: 2.3.7
+      gemfile: gemfiles/ruby_23.gemfile
+    - rvm: 2.4.3
+      gemfile: gemfiles/ruby_24.gemfile
+    - rvm: 2.5.1
+      gemfile: gemfiles/ruby_25.gemfile
+    - rvm: jruby-9.1.17.0
+      gemfile: gemfiles/jruby.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/ruby_trunk.gemfile
+    - rvm: jruby-head
+      gemfile: gemfiles/jruby.gemfile
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -2,43 +2,4 @@
 
 source "https://rubygems.org"
 
-# Uncomment this to use local copy of simplecov-html in development when checked out
-# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
-
-# Uncomment this to use development version of html formatter from github
-# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
-
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
-
-group :test do
-  gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
-end
-
-group :development do
-  gem "benchmark-ips"
-end
-
 gemspec

--- a/gemfiles/jruby.gemfile
+++ b/gemfiles/jruby.gemfile
@@ -8,33 +8,19 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", ">= 1.7"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/jruby.gemfile
+++ b/gemfiles/jruby.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_18.gemfile
+++ b/gemfiles/ruby_18.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec :path => '../'

--- a/gemfiles/ruby_18.gemfile
+++ b/gemfiles/ruby_18.gemfile
@@ -8,33 +8,16 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", "~>10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "activesupport", "~> 3.2.21"
+  gem "i18n", "~> 0.6.11"
+  gem "mime-types", "~> 1.25"
+  gem "addressable", "~> 2.3.0"
+  gem "rack", "~> 1.6"
+  gem "json", "~> 1.8"
 end
 
 group :development do

--- a/gemfiles/ruby_19.gemfile
+++ b/gemfiles/ruby_19.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_19.gemfile
+++ b/gemfiles/ruby_19.gemfile
@@ -8,33 +8,21 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "mime-types", "~> 1.25"
+  gem "addressable", "~> 2.3.0"
+  gem "rack", "~> 1.6"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", "~> 1.6.0"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "test-unit"
+  gem "json", "~> 1.8"
 end
 
 group :development do

--- a/gemfiles/ruby_20.gemfile
+++ b/gemfiles/ruby_20.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_20.gemfile
+++ b/gemfiles/ruby_20.gemfile
@@ -8,33 +8,20 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "rack", "~> 1.6"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", "~> 1.6.0"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/ruby_21.gemfile
+++ b/gemfiles/ruby_21.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_21.gemfile
+++ b/gemfiles/ruby_21.gemfile
@@ -8,33 +8,20 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "rack", "~> 1.6"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", ">= 1.7"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/ruby_22.gemfile
+++ b/gemfiles/ruby_22.gemfile
@@ -8,33 +8,19 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", ">= 1.7"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/ruby_22.gemfile
+++ b/gemfiles/ruby_22.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_23.gemfile
+++ b/gemfiles/ruby_23.gemfile
@@ -8,33 +8,19 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", ">= 1.7"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/ruby_23.gemfile
+++ b/gemfiles/ruby_23.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_24.gemfile
+++ b/gemfiles/ruby_24.gemfile
@@ -8,33 +8,19 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", ">= 1.7"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/ruby_24.gemfile
+++ b/gemfiles/ruby_24.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_25.gemfile
+++ b/gemfiles/ruby_25.gemfile
@@ -8,33 +8,19 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", ">= 1.7"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/ruby_25.gemfile
+++ b/gemfiles/ruby_25.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/gemfiles/ruby_trunk.gemfile
+++ b/gemfiles/ruby_trunk.gemfile
@@ -8,33 +8,19 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+gem "rake", ">= 10.3"
 
 group :test do
   gem "rspec", ">= 3.2"
-  # Older versions of some gems required for Ruby 1.8.7 support
-  platforms :ruby_18 do
-    gem "activesupport", "~> 3.2.21"
-    gem "i18n", "~> 0.6.11"
-  end
-  platforms :ruby_18, :ruby_19 do
-    gem "mime-types", "~> 1.25"
-    gem "addressable", "~> 2.3.0"
-  end
-  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
-    gem "rack", "~> 1.6"
-  end
-  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
-    gem "aruba", "~> 0.14"
-    gem "capybara", "< 3"
-    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-    gem "cucumber", "< 3"
-    gem "phantomjs", "~> 2.1"
-    gem "poltergeist"
-    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
-    gem "test-unit"
-  end
-  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+  gem "aruba", "~> 0.14"
+  gem "capybara", "< 3"
+  gem "nokogiri", ">= 1.7"
+  gem "cucumber", "< 3"
+  gem "phantomjs", "~> 2.1"
+  gem "poltergeist"
+  gem "rubocop", "0.49.1"
+  gem "test-unit"
+  gem "json", "~> 2.0"
 end
 
 group :development do

--- a/gemfiles/ruby_trunk.gemfile
+++ b/gemfiles/ruby_trunk.gemfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Uncomment this to use local copy of simplecov-html in development when checked out
+# gem 'simplecov-html', :path => ::File.dirname(__FILE__) + '/../simplecov-html'
+
+# Uncomment this to use development version of html formatter from github
+# gem 'simplecov-html', :github => 'colszowka/simplecov-html'
+
+gem "rake", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3") ? "~>10.3" : ">= 10.3"
+
+group :test do
+  gem "rspec", ">= 3.2"
+  # Older versions of some gems required for Ruby 1.8.7 support
+  platforms :ruby_18 do
+    gem "activesupport", "~> 3.2.21"
+    gem "i18n", "~> 0.6.11"
+  end
+  platforms :ruby_18, :ruby_19 do
+    gem "mime-types", "~> 1.25"
+    gem "addressable", "~> 2.3.0"
+  end
+  platforms :ruby_18, :ruby_19, :ruby_20, :ruby_21 do
+    gem "rack", "~> 1.6"
+  end
+  platforms :jruby, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24, :ruby_25 do
+    gem "aruba", "~> 0.14"
+    gem "capybara", "< 3"
+    gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+    gem "cucumber", "< 3"
+    gem "phantomjs", "~> 2.1"
+    gem "poltergeist"
+    gem "rubocop", "0.49.1" unless RUBY_VERSION.start_with?("1.")
+    gem "test-unit"
+  end
+  gem "json", RUBY_VERSION.start_with?("1.") ? "~> 1.8" : "~> 2.0"
+end
+
+group :development do
+  gem "benchmark-ips"
+end
+
+gemspec path: '../'

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -21,6 +21,14 @@ Gem::Specification.new do |gem|
   gem.add_dependency "docile", "~> 1.1"
 
   gem.add_development_dependency "bundler", "~> 1.9"
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "test-unit"
+  gem.add_development_dependency "cucumber", "< 3"
+  gem.add_development_dependency "aruba"
+  gem.add_development_dependency "capybara", "< 3"
+  gem.add_development_dependency "phantomjs"
+  gem.add_development_dependency "poltergeist"
 
   gem.files         = Dir["{lib}/**/*.*", "bin/*", "LICENSE", "*.md", "doc/*"]
   gem.require_paths = ["lib"]


### PR DESCRIPTION
We can not specify "trunk" for `#platforms` of Gemfile, so we can not run CI with "ruby-head".
This PR separates each gemfiles to 'gemfiles/*.gemfile'. We can specify arbitrary gem versions by this change.