### PR TITLE
Avoid premature failure with parallel_tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.16.2 (TBD)
+===================
+
+## Bugfixes
+
+* Avoid a premature failure exit code when setting `minimum_coverage` in combination with using [parallel_tests](https://github.com/grosser/parallel_tests)
+
 0.16.1 (2018-03-16)
 ===================
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -90,6 +90,7 @@ module SimpleCov
       # If we're using merging of results, store the current result
       # first (if there is one), then merge the results and return those
       if use_merging
+        wait_for_other_processes
         SimpleCov::ResultMerger.store_result(@result) if result?
         @result = SimpleCov::ResultMerger.merged_result
       end
@@ -220,7 +221,7 @@ module SimpleCov
       if result_exit_status == SimpleCov::ExitCodes::SUCCESS # No result errors
         write_last_run(covered_percent)
       end
-      result_exit_status
+      final_result_process? ? result_exit_status : SimpleCov::ExitCodes::SUCCESS
     end
 
     # @api private
@@ -247,6 +248,21 @@ module SimpleCov
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    #
+    # @api private
+    #
+    def final_result_process?
+      !defined?(ParallelTests) || ParallelTests.last_process?
+    end
+
+    #
+    # @api private
+    #
+    def wait_for_other_processes
+      return unless defined?(ParallelTests) && final_result_process?
+      ParallelTests.wait_for_other_processes_to_finish
+    end
 
     #
     # @api private

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SimpleCov
-  VERSION = "0.16.1".freeze
+  VERSION = "0.16.2".freeze
 end


### PR DESCRIPTION
When running within [parallel_tests](https://github.com/grosser/parallel_tests/wiki), wait until all test processes complete before evaluating coverage statistics. This avoids a premature failure exit code if an early run finishes with coverage that does not meet the configured criteria. I believe this will fix #559. There are a few different approaches I could see to resolve this issue, feedback welcome of course!