### PR TITLE
Delete condition for ActionCable group in Rails profile.

### DIFF
--- a/lib/simplecov/profiles/rails.rb
+++ b/lib/simplecov/profiles/rails.rb
@@ -7,7 +7,7 @@ SimpleCov.profiles.define "rails" do
   add_filter %r{^/db/}
 
   add_group "Controllers", "app/controllers"
-  add_group "Channels", "app/channels" if defined?(ActionCable)
+  add_group "Channels", "app/channels"
   add_group "Models", "app/models"
   add_group "Mailers", "app/mailers"
   add_group "Helpers", "app/helpers"


### PR DESCRIPTION
ActionCable is enabled in a default Rails project. (There may be few projects using ActionCable...)
In general, simplecov reads before Rails starts up, so ActionCable is not defined at this time.
That is, since the group in the ActionCable is not always true, I submitted this pull request.