### PR TITLE
No need to explicitly bundle gems included in the gemspec

### DIFF
--- a/gemfiles/jruby.gemfile
+++ b/gemfiles/jruby.gemfile
@@ -23,4 +23,4 @@ group :test do
   gem "json", "~> 2.0"
 end
 
-gemspec path: '../'
+gemspec path: '../', development_group: 'test'

--- a/gemfiles/ruby_19.gemfile
+++ b/gemfiles/ruby_19.gemfile
@@ -8,21 +8,12 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", ">= 10.3"
-
 group :test do
-  gem "rspec", ">= 3.2"
   gem "mime-types", "~> 1.25"
   gem "addressable", "~> 2.3.0"
   gem "rack", "~> 1.6"
-  gem "aruba", "~> 0.14"
-  gem "capybara", "< 3"
   gem "nokogiri", "~> 1.6.0"
-  gem "cucumber", "< 3"
-  gem "phantomjs", "~> 2.1"
-  gem "poltergeist"
-  gem "test-unit"
   gem "json", "~> 1.8"
 end
 
-gemspec path: '../'
+gemspec path: '../', development_group: 'test'

--- a/gemfiles/ruby_20.gemfile
+++ b/gemfiles/ruby_20.gemfile
@@ -8,20 +8,11 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", ">= 10.3"
-
 group :test do
-  gem "rspec", ">= 3.2"
   gem "rack", "~> 1.6"
-  gem "aruba", "~> 0.14"
-  gem "capybara", "< 3"
   gem "nokogiri", "~> 1.6.0"
-  gem "cucumber", "< 3"
-  gem "phantomjs", "~> 2.1"
-  gem "poltergeist"
   gem "rubocop", "0.49.1"
-  gem "test-unit"
   gem "json", "~> 2.0"
 end
 
-gemspec path: '../'
+gemspec path: '../', development_group: 'test'

--- a/gemfiles/ruby_21.gemfile
+++ b/gemfiles/ruby_21.gemfile
@@ -8,20 +8,11 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", ">= 10.3"
-
 group :test do
-  gem "rspec", ">= 3.2"
   gem "rack", "~> 1.6"
-  gem "aruba", "~> 0.14"
-  gem "capybara", "< 3"
   gem "nokogiri", ">= 1.7"
-  gem "cucumber", "< 3"
-  gem "phantomjs", "~> 2.1"
-  gem "poltergeist"
   gem "rubocop", "0.49.1"
-  gem "test-unit"
   gem "json", "~> 2.0"
 end
 
-gemspec path: '../'
+gemspec path: '../', development_group: 'test'

--- a/gemfiles/ruby_22.gemfile
+++ b/gemfiles/ruby_22.gemfile
@@ -8,19 +8,10 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
-gem "rake", ">= 10.3"
-
 group :test do
-  gem "rspec", ">= 3.2"
-  gem "aruba", "~> 0.14"
-  gem "capybara", "< 3"
   gem "nokogiri", ">= 1.7"
-  gem "cucumber", "< 3"
-  gem "phantomjs", "~> 2.1"
-  gem "poltergeist"
   gem "rubocop", "0.49.1"
-  gem "test-unit"
   gem "json", "~> 2.0"
 end
 
-gemspec path: '../'
+gemspec path: '../', development_group: 'test'


### PR DESCRIPTION
This PR restores https://github.com/colszowka/simplecov/commit/0d2fe5b543060335fb6f234421d7a21e45ea98f1, with a small modification: specify `development_group: 'test'` as an argument to `gemspec`, so that it works properly on TravisCI.

