### PR TITLE
Fix problem with coverage merging and total LOC count

### DIFF
--- a/lib/simplecov/raw_coverage.rb
+++ b/lib/simplecov/raw_coverage.rb
@@ -30,11 +30,10 @@ module SimpleCov
     end
 
     def merge_line_coverage(count1, count2)
-      sum = count1.to_i + count2.to_i
-      if sum.zero? && (count1.nil? || count2.nil?)
+      if count1.nil? && count2.nil?
         nil
       else
-        sum
+        count1.to_i + count2.to_i
       end
     end
   end

--- a/spec/raw_coverage_spec.rb
+++ b/spec/raw_coverage_spec.rb
@@ -57,7 +57,7 @@ if SimpleCov.usable?
         end
 
         it "has proper results for parallel_tests.rb" do
-          expect(subject[source_fixture("parallel_tests.rb")]).to eq([nil, nil, nil, 0])
+          expect(subject[source_fixture("parallel_tests.rb")]).to eq([nil, 0, 0, 0])
         end
 
         it "has proper results for conditionally_loaded_1.rb" do


### PR DESCRIPTION
I was seeing the LOC in the merged set coming out less than the LOC in one of the input result sets. That seems illogical. The merged result LOC should be greater than or equal to the LOC in any given input result set. It looks something like this:

Before:

* input 1: covered 5 / 100 LOC
* input 2: covered 3 / 90 LOC
* merged: covered 7 / 80 LOC <== total LOC lower than one of the inputs??

After

* input 1: covered 5 / 100 LOC
* input 2: covered 3 / 90 LOC
* merged: covered 7 / 105 LOC <== greater than or equal to any input's LOC

I tracked it down to the merge logic in the case that the line has 0 hits.

#### Short version

For any given line of code during a merge:

Currently: `merge(never executed, missed) => never executed`
Fixed: `merge(never executed, missed) => missed`

#### Long waffly version

The logic was:

```
  if this line was never loaded in input 1 OR never loaded in input 2
    it was never loaded
  else
    sum the coverage
  end
```

The problem with this is that the line was loaded and missed in one of the input result sets. The merged result set considers this line "never" and one of the inputs considered it "missed". In calculating LOC, missed lines are included and never lines are not included. Hence this line would be included in the input LOC count but not the merged result LOC count.

I think the logic should be:

```
  if this line was never loaded in input 1 AND never loaded in input 2
    it was never loaded
  else
    sum the coverage
  end
```

Then the 0 value will propagate to the merged result, causing this line to be included in LOC in the merged result.

