### PR TITLE
Fix missing delegator for Result#lines_of_code

### DIFF
--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -20,8 +20,7 @@ module SimpleCov
     # Explicitly set the command name that was used for this coverage result. Defaults to SimpleCov.command_name
     attr_writer :command_name
 
-    def_delegators :files, :covered_percent, :covered_percentages, :least_covered_file, :covered_strength, :covered_lines, :missed_lines
-    def_delegator :files, :lines_of_code, :total_lines
+    def_delegators :files, :covered_percent, :covered_percentages, :least_covered_file, :covered_strength, :covered_lines, :missed_lines, :lines_of_code, :total_lines
 
     # Initialize a new SimpleCov::Result from given Coverage.result (a Hash of filenames each containing an array of
     # coverage data)


### PR DESCRIPTION
I think because the line read `def_delegator :files, :lines_of_code, :total_lines` instead of def_delegator**s**, this caused a NoMethodError when calling `Result#lines_of_code`.