### PR TITLE
[Documentation] Feature/add simplecov-small-badge

### DIFF
--- a/doc/alternate-formatters.md
+++ b/doc/alternate-formatters.md
@@ -10,6 +10,11 @@ If you have built or found one that is missing here, please send a Pull Request 
 
 A formatter that generates a coverage badge for use in your project's readme using ImageMagick.
 
+#### [simplecov-small-badge](https://github.com/marcgrimme/simplecov-smallbadge)
+*by Marc Grimme*
+
+A formatter that generates a small coverage badge for use in your project's readme using the SVG.
+
 #### [simplecov-cobertura](https://github.com/dashingrocket/simplecov-cobertura)
 *by Jesse Bowes*
 

--- a/doc/alternate-formatters.md
+++ b/doc/alternate-formatters.md
@@ -10,7 +10,7 @@ If you have built or found one that is missing here, please send a Pull Request 
 
 A formatter that generates a coverage badge for use in your project's readme using ImageMagick.
 
-#### [simplecov-small-badge](https://github.com/marcgrimme/simplecov-smallbadge)
+#### [simplecov-small-badge](https://github.com/marcgrimme/simplecov-small-badge)
 *by Marc Grimme*
 
 A formatter that generates a small coverage badge for use in your project's readme using the SVG.


### PR DESCRIPTION
* Add documentation to a simplecov formatter that creates a small-badge similar to the one know from travis and friends (simplecov-small-badge).
* Based on SVG as a format.