### PR TITLE
Support project roots with special characters

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -84,7 +84,7 @@ module SimpleCov
 
     # The path to this source file relative to the projects directory
     def project_filename
-      @filename.sub(/^#{SimpleCov.root}/, "")
+      @filename.sub(Regexp.new("^#{Regexp.escape(SimpleCov.root)}"), "")
     end
 
     # The source code for this file. Aliased as :source

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -22,6 +22,25 @@ if SimpleCov.usable?
         expect(subject.project_filename).to eq("/spec/fixtures/sample.rb")
       end
 
+      context "when project_root contains special characters" do
+        let(:root) { File.expand_path("foo[]bar") }
+
+        around do |example|
+          old_root = SimpleCov.root
+          SimpleCov.root(root)
+          begin
+            example.run
+          ensure
+            SimpleCov.root(old_root)
+          end
+        end
+
+        it "works" do
+          source_file = SimpleCov::SourceFile.new(File.expand_path("sample.rb", root), COVERAGE_FOR_SAMPLE_RB)
+          expect(source_file.project_filename).to eq("/sample.rb")
+        end
+      end
+
       it "has source_lines equal to lines" do
         expect(subject.lines).to eq(subject.source_lines)
       end


### PR DESCRIPTION
I was configuring simplecov in bundler's specs and I got this crash in one of the specs:

```
       /home/travis/build/bundler/bundler/tmp/gems/base/gems/simplecov-0.16.1/lib/simplecov/source_file.rb:87:in `project_filename': empty char-class: /^\/home\/travis\/build\/bundler\/bundler\/tmp\/foo[]bar/ (RegexpError)
```

This PR should fix that super-edge case.