### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2, jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ matrix:
       gemfile: gemfiles/ruby_22.gemfile
     - rvm: 2.3.8
       gemfile: gemfiles/ruby_22.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       gemfile: gemfiles/ruby_22.gemfile
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       gemfile: gemfiles/ruby_22.gemfile
-    - rvm: 2.6.0
+    - rvm: 2.6.2
       gemfile: gemfiles/ruby_22.gemfile
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
       gemfile: gemfiles/jruby.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/ruby_22.gemfile


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known