### PR TITLE
CI: Drop unused Travis option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ before_install:
 
 bundler_args: --without development --jobs=3 --retry=3
 
-sudo: false
-
 matrix:
   include:
     - rvm: 1.8.7


### PR DESCRIPTION
Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

I marked this as CI skip - perhaps that's not how to do it, in this project, but the setting "does nothing", now.