### PR TITLE
Add filter for hidden files and folders per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Enhancements
 
+* Per default filter hidden files and folders. See [#721](https://github.com/colszowka/simplecov/pull/721) (thanks [Renuo AG](https://www.renuo.ch))
 * Print the exit status explicitly when it's not a successful build so it's easier figure out SimpleCov failed the build in the output.
 
 ## Bugfixes

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -6,12 +6,14 @@ require "pathname"
 require "simplecov/profiles/root_filter"
 require "simplecov/profiles/test_frameworks"
 require "simplecov/profiles/bundler_filter"
+require "simplecov/profiles/hidden_filter"
 require "simplecov/profiles/rails"
 
 # Default configuration
 SimpleCov.configure do
   formatter SimpleCov::Formatter::HTMLFormatter
   load_profile "bundler_filter"
+  load_profile "hidden_filter"
   # Exclude files outside of SimpleCov.root
   load_profile "root_filter"
 end

--- a/lib/simplecov/profiles/hidden_filter.rb
+++ b/lib/simplecov/profiles/hidden_filter.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+SimpleCov.profiles.define "hidden_filter" do
+  add_filter %r{^/\..*}
+end

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -173,6 +173,18 @@ if SimpleCov.usable?
         it "filters vendor/bundle" do
           expect(SimpleCov.filtered([a_file("vendor/bundle/foo.rb")]).count).to eq(0)
         end
+
+        it "filters hidden folders" do
+          expect(SimpleCov.filtered([a_file(".semaphore-cache/lib.rb")]).count).to eq(0)
+        end
+
+        it "filters hidden files" do
+          expect(SimpleCov.filtered([a_file(".hidden_config.rb")]).count).to eq(0)
+        end
+
+        it "doesn't filter hidden files further down the path" do
+          expect(SimpleCov.filtered([a_file("some_dir/.sneaky.rb")]).count).to eq(1)
+        end
       end
 
       context "outside the project" do


### PR DESCRIPTION
It seems a bit weird, that hidden files and folders are included in the coverage measurement per default. They are hidden for a reason.

I now filter per default hidden folders and files in the root folder.

@colszowka do you have a strong opinion about that?