### PR TITLE
CI: Use 2.6.3, jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
       gemfile: gemfiles/ruby_22.gemfile
     - rvm: 2.5.5
       gemfile: gemfiles/ruby_22.gemfile
-    - rvm: 2.6.2
+    - rvm: 2.6.3
       gemfile: gemfiles/ruby_22.gemfile
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/jruby.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/ruby_22.gemfile


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known