### PR TITLE
process_result no longer relies on result? as order was changed

### DIFF
--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -176,7 +176,6 @@ if SimpleCov.usable?
     describe ".process_result" do
       before do
         expect(SimpleCov).to receive(:result_exit_status).and_return SimpleCov::ExitCodes::MINIMUM_COVERAGE
-        expect(SimpleCov).to receive(:result?).and_return true
       end
       context "when the final result process" do
         let(:result) { double(SimpleCov::Result, :covered_percent => 0.0) }


### PR DESCRIPTION
This is an error after merging 2 decent PRs that passed in
isolation but not when merged together :)