### PR TITLE
Include rubocop in the "default" gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ group :development do
   gem "benchmark-ips"
 end
 
+gem "rubocop", "0.49.1"
+
 gemspec


### PR DESCRIPTION
Seems to have been broken during #705 but still worked on CI
cos it's in the different Gemfiles.

Hope this "fix" doesn't break anything else :)