### PR TITLE
Add an alternative way to work with Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,12 @@ SimpleCov.start 'rails'
 Rails.application.eager_load!
 ```
 
+Alternatively, you could disable Spring while running SimpleCov:
+
+```
+DISABLE_SPRING=1 rake test
+```
+
 Or you could remove `gem 'spring'` from your `Gemfile`.
 
 ## Troubleshooting


### PR DESCRIPTION
Enabling eager loading will mean every test takes additional time to run.
Instead, we can disable Spring using an environment variable.