### PR TITLE
Warn the user if the minimum coverage is set greater than 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unrealeased
+===================
+
+## Enhancements
+
+* If the minimum coverage is set to be greater than 100, a warning will be shown. See [#737](https://github.com/colszowka/simplecov/pull/737)
+
 0.17.0 (2019-07-02)
 ===================
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -224,6 +224,7 @@ module SimpleCov
     # Default is 0% (disabled)
     #
     def minimum_coverage(coverage = nil)
+      minimum_possible_coverage_exceeded("minimum_coverage") if coverage && coverage > 100
       @minimum_coverage ||= (coverage || 0).to_f.round(2)
     end
 
@@ -245,6 +246,7 @@ module SimpleCov
     # Default is 0% (disabled)
     #
     def minimum_coverage_by_file(coverage = nil)
+      minimum_possible_coverage_exceeded("minimum_coverage_by_file") if coverage && coverage > 100
       @minimum_coverage_by_file ||= (coverage || 0).to_f.round(2)
     end
 
@@ -287,6 +289,10 @@ module SimpleCov
     end
 
   private
+
+    def minimum_possible_coverage_exceeded(coverage_option)
+      warn "The coverage you set for #{coverage_option} is greater than 100%"
+    end
 
     #
     # The actual filter processor. Not meant for direct use

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -33,5 +33,29 @@ describe SimpleCov::Configuration do
         expect(config.tracked_files).to be_nil
       end
     end
+
+    describe "#minimum_coverage" do
+      it "does not warn you about your usage" do
+        expect(config).not_to receive(:warn)
+        config.minimum_coverage(100.00)
+      end
+
+      it "warns you about your usage" do
+        expect(config).to receive(:warn).with("The coverage you set for minimum_coverage is greater than 100%")
+        config.minimum_coverage(100.01)
+      end
+    end
+
+    describe "minimum_coverage_by_file" do
+      it "does not warn you about your usage" do
+        expect(config).not_to receive(:warn)
+        config.minimum_coverage_by_file(100.00)
+      end
+
+      it "warns you about your usage" do
+        expect(config).to receive(:warn).with("The coverage you set for minimum_coverage_by_file is greater than 100%")
+        config.minimum_coverage_by_file(100.01)
+      end
+    end
   end
 end


### PR DESCRIPTION
I was trying something out, and I thought that it would be funny/useful to point this out to the user