### PR TITLE
Change misleading wording in exit message

### DIFF
--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -17,7 +17,7 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should not be 0
     And the output should contain "Coverage (88.10%) is below the expected minimum coverage (90.00%)."
-    And the output should contain "SimpleCov failed with exit 2"
+    And the output should contain "Exiting with status 2."
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:
@@ -32,7 +32,7 @@ Feature:
     When I run `bundle exec rake test`
     Then the exit status should not be 0
     And the output should contain "Coverage (88.10%) is below the expected minimum coverage (88.11%)."
-    And the output should contain "SimpleCov failed with exit 2"
+    And the output should contain "Exiting with status 2."
 
   Scenario:
     Given SimpleCov for Test/Unit is configured with:

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -186,7 +186,7 @@ module SimpleCov
       # Force exit with stored status (see github issue #5)
       # unless it's nil or 0 (see github issue #281)
       if exit_status && exit_status.positive?
-        $stderr.printf("SimpleCov failed with exit %d", exit_status)
+        $stderr.printf("Exiting with status %d.\n", exit_status)
         Kernel.exit exit_status
       end
     end


### PR DESCRIPTION
PR #688 added a message when the exit status != 0. However, when the exit status is non-zero because a test failed, the message wording is misleading because it specifically refers to SimpleCov. I personally interpreted it as an error in SimpleCov's report generation, when SimpleCov was actually working just fine!

This PR makes the wording more generic so as to not mislead one into thinking SimpleCov is misbehaving when it isn't. 😄 

Also, the message was missing the trailing "\n", so added that as well.

Old output:
```
SimpleCov failed with exit 1$
```

New output:
```
Exiting with status 1
$
```
