### PR TITLE
Avoid hanging with parallel_tests

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -236,7 +236,8 @@ module SimpleCov
     # @api private
     #
     def final_result_process?
-      !defined?(ParallelTests) || ParallelTests.last_process?
+      # checking for ENV["TEST_ENV_NUMBER"] to determine if the tess are being run in parallel
+      !defined?(ParallelTests) || !ENV["TEST_ENV_NUMBER"] || ParallelTests.number_of_running_processes <= 1
     end
 
     #


### PR DESCRIPTION
`ParallelTests.last_process?` returns `true` if the process is the last one to start.  We are
interested in the last test to finish so we want to use `ParallelTests.number_of_running_processes`

Because it's possible to have the parallel_tests gem in your project and still run tests serially we
want to also check if tests are currently being run in parallel.  If `ENV['TEST_ENV_NUMBER']` is defined we know tests are currently being run in parallel.