### PR TITLE
Update cucumber to 3.x

### DIFF
--- a/features/step_definitions/parameter_types.rb
+++ b/features/step_definitions/parameter_types.rb
@@ -7,9 +7,13 @@
 #
 # This is due to the fact that coverage will not include the first loaded spec/test file.
 # To get predictable coverage results, we need to know which one that is...
-#
-Transform "bundle exec rspec spec" do |_|
-  files = nil # Avoid shadowing
-  cd(".") { files = Dir["spec/**/*_spec.rb"] }
-  "bundle exec rspec #{files.sort.join(' ')}"
-end
+
+ParameterType(
+  :name => "rspec",
+  :regexp => /bundle exec rspec spec/,
+  :transformer => lambda { |_|
+    files = nil # Avoid shadowing
+    cd(".") { files = Dir["spec/**/*_spec.rb"] }
+    "bundle exec rspec #{files.sort.join(' ')}"
+  }
+)

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "rspec", "~> 3.2"
   gem.add_development_dependency "test-unit"
-  gem.add_development_dependency "cucumber", "< 3"
+  gem.add_development_dependency "cucumber"
   gem.add_development_dependency "aruba", "~> 0.14"
   gem.add_development_dependency "capybara", "< 3"
   gem.add_development_dependency "phantomjs"


### PR DESCRIPTION
This removes the Transform deprecation warning:
```
WARNING: #Transform is deprecated and will be removed after version 3.0.0. 
         Please follow the upgrade instructions at **https://cucumber.io/blog/2017/09/21/upgrading-to-cucumber-3.**
```
