### PR TITLE
Update references to Minitest constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Unrealeased
 * If the minimum coverage is set to be greater than 100, a warning will be shown. See [#737](https://github.com/colszowka/simplecov/pull/737)
 * Add a configuration option to disable the printing of non-successful exit statuses. See [#747](https://github.com/colszowka/simplecov/pull/746) (thanks [@JacobEvelyn](https://github.com/JacobEvelyn))
 
+## Bugfixes
+
+* Add new instance of `Minitest` constant. The `MiniTest` constant (with the capital T) will be removed in the next major release of Minitest.
+
 0.17.1 (2019-09-16)
 ===================
 

--- a/lib/simplecov/command_guesser.rb
+++ b/lib/simplecov/command_guesser.rb
@@ -48,6 +48,8 @@ module SimpleCov
           "RSpec"
         elsif defined?(Test::Unit)
           "Unit Tests"
+        elsif defined?(Minitest)
+          "Minitest"
         elsif defined?(MiniTest)
           "MiniTest"
         else


### PR DESCRIPTION
The camel-case constant `MiniTest` will be dropped in Minitest 6. It's been `Minitest` for a number of years now so this change should be fairly safe.