### PR TITLE
Rubocop improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,7 +103,7 @@ Style/StringLiterals:
   Description: Allow double-quoted strings without interpolation.
   EnforcedStyle: double_quotes
 
-Style/FileName:
+Naming/FileName:
   Description: makes sure that Ruby source files have snake_case names.
   Exclude:
     - 'spec/fixtures/utf-8.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,10 +109,10 @@ Style/FileName:
     - 'spec/fixtures/utf-8.rb'
 
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: no_comma
 
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: no_comma
 
 Style/GuardClause:
   Description: Use a guard clause instead of wrapping the code inside a conditional expression.

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ begin
   RuboCop::RakeTask.new
 rescue LoadError
   task :rubocop do
-    $stderr.puts "Rubocop is disabled"
+    warn "Rubocop is disabled"
   end
 end
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -185,7 +185,7 @@ module SimpleCov
 
       # Force exit with stored status (see github issue #5)
       # unless it's nil or 0 (see github issue #281)
-      if exit_status && exit_status.positive?
+      if exit_status&.positive?
         $stderr.printf("SimpleCov failed with exit %d\n", exit_status) if print_error_status
         Kernel.exit exit_status
       end

--- a/lib/simplecov/defaults.rb
+++ b/lib/simplecov/defaults.rb
@@ -42,7 +42,7 @@ loop do
     begin
       load filename
     rescue LoadError, StandardError
-      $stderr.puts "Warning: Error occurred while trying to load #{filename}. " \
+      warn "Warning: Error occurred while trying to load #{filename}. " \
         "Error message: #{$!.message}"
     end
     break

--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -18,7 +18,7 @@ module SimpleCov
       @filter_argument = filter_argument
     end
 
-    def matches?(_)
+    def matches?(_source_file)
       raise "The base filter class is not intended for direct use"
     end
 

--- a/lib/simplecov/formatter/multi_formatter.rb
+++ b/lib/simplecov/formatter/multi_formatter.rb
@@ -8,7 +8,7 @@ module SimpleCov
           formatters.map do |formatter|
             begin
               formatter.new.format(result)
-            rescue => e
+            rescue StandardError => e
               STDERR.puts("Formatter #{formatter} failed with #{e.class}: #{e.message} (#{e.backtrace.first})")
               nil
             end

--- a/lib/simplecov/formatter/simple_formatter.rb
+++ b/lib/simplecov/formatter/simple_formatter.rb
@@ -8,7 +8,7 @@ module SimpleCov
     class SimpleFormatter
       # Takes a SimpleCov::Result and generates a string out of it
       def format(result)
-        output = "".dup
+        output = +""
         result.groups.each do |name, files|
           output << "Group: #{name}\n"
           output << "=" * 40

--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -27,7 +27,7 @@ module SimpleCov
           if data
             begin
               JSON.parse(data) || {}
-            rescue
+            rescue StandardError
               {}
             end
           else

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -114,7 +114,7 @@ module SimpleCov
 
     # Warning to identify condition from Issue #56
     def coverage_exceeding_source_warn
-      $stderr.puts "Warning: coverage data provided by Coverage [#{coverage.size}] exceeds number of lines in #{filename} [#{src.size}]"
+      warn "Warning: coverage data provided by Coverage [#{coverage.size}] exceeds number of lines in #{filename} [#{src.size}]"
     end
 
     # Access SimpleCov::SourceFile::Line source lines by line number

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 require "simplecov/version"
 
 Gem::Specification.new do |gem|
@@ -16,19 +16,19 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4.0"
 
-  gem.add_dependency "simplecov-html", "~> 0.10.0"
   gem.add_dependency "docile", "~> 1.1"
+  gem.add_dependency "simplecov-html", "~> 0.10.0"
 
-  gem.add_development_dependency "bundler"
-  gem.add_development_dependency "rake", "~> 12.0"
-  gem.add_development_dependency "rspec", "~> 3.2"
-  gem.add_development_dependency "test-unit"
-  gem.add_development_dependency "cucumber", "~> 3.1"
   gem.add_development_dependency "aruba", "~> 0.14"
+  gem.add_development_dependency "bundler"
   gem.add_development_dependency "capybara", "< 3"
+  gem.add_development_dependency "cucumber", "~> 3.1"
   gem.add_development_dependency "phantomjs"
   gem.add_development_dependency "poltergeist"
-  gem.add_development_dependency "rubocop", "0.49.1"
+  gem.add_development_dependency "rake", "~> 12.0"
+  gem.add_development_dependency "rspec", "~> 3.2"
+  gem.add_development_dependency "rubocop", "0.53.0"
+  gem.add_development_dependency "test-unit"
 
   gem.files         = Dir["{lib}/**/*.*", "bin/*", "LICENSE", "*.md", "doc/*"]
   gem.require_paths = ["lib"]

--- a/spec/faked_project/features/support/env.rb
+++ b/spec/faked_project/features/support/env.rb
@@ -5,7 +5,7 @@ require "bundler/setup"
 begin
   require File.join(File.dirname(__FILE__), "simplecov_config")
 rescue LoadError
-  $stderr.puts "No SimpleCov config file found!"
+  warn "No SimpleCov config file found!"
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "/../../lib"))

--- a/spec/faked_project/lib/faked_project/some_class.rb
+++ b/spec/faked_project/lib/faked_project/some_class.rb
@@ -12,11 +12,11 @@ class SomeClass
 
   def compare_with(item)
     if item == label
-      return true
+      true
     else
       raise "Item does not match label"
     end
-  rescue
+  rescue StandardError
     false
   end
 

--- a/spec/faked_project/spec/spec_helper.rb
+++ b/spec/faked_project/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require "bundler/setup"
 begin
   require File.join(File.dirname(__FILE__), "simplecov_config")
 rescue LoadError
-  $stderr.puts "No SimpleCov config file found!"
+  warn "No SimpleCov config file found!"
 end
 
 require "faked_project"

--- a/spec/faked_project/test/test_helper.rb
+++ b/spec/faked_project/test/test_helper.rb
@@ -5,7 +5,7 @@ require "bundler/setup"
 begin
   require File.join(File.dirname(__FILE__), "simplecov_config")
 rescue LoadError
-  $stderr.puts "No SimpleCov config file found!"
+  warn "No SimpleCov config file found!"
 end
 
 require "faked_project"

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -91,7 +91,7 @@ describe SimpleCov::SourceFile do
 
   it "matches a new SimpleCov::ArrayFilter when a custom class that returns true is passed as array" do
     filter = Class.new(SimpleCov::Filter) do
-      def matches?(_)
+      def matches?(_source_file)
         true
       end
     end.new(nil)
@@ -100,7 +100,7 @@ describe SimpleCov::SourceFile do
 
   it "doesn't match a new SimpleCov::ArrayFilter when a custom class that returns false is passed as array" do
     filter = Class.new(SimpleCov::Filter) do
-      def matches?(_)
+      def matches?(_source_file)
         false
       end
     end.new(nil)

--- a/spec/fixtures/deleted_source_sample.rb
+++ b/spec/fixtures/deleted_source_sample.rb
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", ".."))
 require "lib/simplecov"
 SimpleCov.start { command_name "Test" }
 
-dir = File.expand_path(File.dirname(__FILE__))
+dir = __dir__
 file = File.join(dir, "generated_buddha.rb")
 code = %{
   def kill_the_buddha(z)

--- a/spec/fixtures/utf-8.rb
+++ b/spec/fixtures/utf-8.rb
@@ -1,3 +1,1 @@
-# encoding: utf-8
-
 puts "135°C"

--- a/spec/lines_classifier_spec.rb
+++ b/spec/lines_classifier_spec.rb
@@ -57,7 +57,7 @@ describe SimpleCov::LinesClassifier do
 
         it "doesn't mistake interpolation as a comment" do
           classified_lines = subject.classify [
-            'puts "#{var}"'
+            'puts "#{var}"' # rubocop:disable Lint/InterpolationCheck
           ]
 
           expect(classified_lines.length).to eq 1

--- a/spec/result_merger_spec.rb
+++ b/spec/result_merger_spec.rb
@@ -160,7 +160,7 @@ describe SimpleCov::ResultMerger do
     it "blocks other processes" do
       file = Tempfile.new("foo")
 
-      other_process = open("|ruby -e " + Shellwords.escape(<<-CODE) + " 2>/dev/null")
+      other_process = open("|ruby -e " + Shellwords.escape(<<-CODE) + " 2>/dev/null") # rubocop:disable Security/Open
         require "simplecov"
         SimpleCov.coverage_dir(#{SimpleCov.coverage_dir.inspect})
 

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -122,7 +122,7 @@ describe SimpleCov do
       it "captures the current exception" do
         begin
           raise error
-        rescue
+        rescue StandardError
           SimpleCov.set_exit_exception
           expect(SimpleCov.exit_exception).to be(error)
         end


### PR DESCRIPTION
#754 introduced several problems in the rubocop setup:

* It updated the configuration to use `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral`. However, those cops [were introduced in rubocop 0.53.0](https://rubocop.readthedocs.io/en/latest/cops_style/#styletrailingcommainarrayliteral), and we're using rubocop 0.49.0.

* The code was changed to enforced exactly the opposite style being configured. The cops were setup to enforce a trailing comma at the end of hash and array literals, but the code was updated to remove that trailing comma.

The reason why the rubocop run is current passing is because the cops are not recognized in rubocop 0.49.0, and get ignored.

In this PR, I update the configuration of these cops to match the current style of the code, and also upgrade rubocop to 0.53.0 so that the cops get applied. Also, I'm fixing/ignoring the new offenses found by the new rubocop version. 

