### PR TITLE
Modernize test tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,10 @@ source "https://rubygems.org"
 # gem 'simplecov-html', :github => 'colszowka/simplecov-html'
 
 group :development do
+  gem "apparition", "0.4.0"
   gem "aruba", "~> 0.14"
   gem "capybara", "~> 3.29"
   gem "cucumber", "~> 3.1"
-  gem "phantomjs"
-  gem "poltergeist"
   gem "rake", "~> 12.0"
   gem "rspec", "~> 3.2"
   gem "rubocop", "0.53.0"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ source "https://rubygems.org"
 
 group :development do
   gem "aruba", "~> 0.14"
-  gem "capybara", "< 3"
+  gem "capybara", "~> 3.29"
   gem "cucumber", "~> 3.1"
   gem "phantomjs"
   gem "poltergeist"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,13 +21,14 @@ GEM
     backports (3.15.0)
     benchmark-ips (2.7.2)
     builder (3.2.3)
-    capybara (2.18.0)
+    capybara (3.29.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     childprocess (3.0.0)
     cliver (0.3.2)
     contracts (0.16.0)
@@ -73,6 +74,7 @@ GEM
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (12.3.3)
+    regexp_parser (1.6.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -111,7 +113,7 @@ PLATFORMS
 DEPENDENCIES
   aruba (~> 0.14)
   benchmark-ips
-  capybara (< 3)
+  capybara (~> 3.29)
   cucumber (~> 3.1)
   phantomjs
   poltergeist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,9 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    apparition (0.4.0)
+      capybara (~> 3.13, < 4)
+      websocket-driver (>= 0.6.5)
     aruba (0.14.12)
       childprocess (>= 0.6.3, < 4.0.0)
       contracts (~> 0.9)
@@ -30,7 +33,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    cliver (0.3.2)
     contracts (0.16.0)
     cucumber (3.1.2)
       builder (>= 2.1.2)
@@ -61,11 +63,6 @@ GEM
     parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
-    phantomjs (2.1.1.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     power_assert (1.1.5)
     powerpack (0.1.2)
     public_suffix (4.0.1)
@@ -111,12 +108,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  apparition (= 0.4.0)
   aruba (~> 0.14)
   benchmark-ips
   capybara (~> 3.29)
   cucumber (~> 3.1)
-  phantomjs
-  poltergeist
   rake (~> 12.0)
   rspec (~> 3.2)
   rubocop (= 0.53.0)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ require "aruba/cucumber"
 require "aruba/config/jruby" if RUBY_ENGINE == "jruby"
 require_relative "aruba_freedom_patch"
 require "capybara/cucumber"
-require "phantomjs/poltergeist"
+require "capybara/apparition"
 
 # Fake rack app for capybara that just returns the latest coverage report from aruba temp project dir
 Capybara.app = lambda { |env|
@@ -19,7 +19,7 @@ Capybara.app = lambda { |env|
   ]
 }
 
-Capybara.default_driver = Capybara.javascript_driver = :poltergeist
+Capybara.default_driver = Capybara.javascript_driver = :apparition
 
 Capybara.server = :webrick
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,6 +21,8 @@ Capybara.app = lambda { |env|
 
 Capybara.default_driver = Capybara.javascript_driver = :poltergeist
 
+Capybara.server = :webrick
+
 Capybara.configure do |config|
   config.ignore_hidden_elements = false
 end


### PR DESCRIPTION
Bump `capybara` to the latest version and replace `phantomjs` + `poltergeist` with [`apparition`](https://github.com/twalpole/apparition).