### PR TITLE
Fix cucumber deprecations

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,13 +1,13 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags 'not @wip'"
 interp_opts = if defined?(RUBY_ENGINE)
-  " --tags ~@exclude-#{RUBY_ENGINE}"
+  " --tags 'not @exclude-#{RUBY_ENGINE}'"
 else
   ''
 end
 %>
 default: <%= std_opts %><%= interp_opts %> features
 wip: --tags @wip:30 --wip features<%= interp_opts %>
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip<%= interp_opts %>
+rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip' <%= interp_opts %>


### PR DESCRIPTION
Fixes a couple of deprecations when running cucumber scenarios:

```
Deprecated: Found tags option '~@wip'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
Deprecated: Found tags option '~@exclude-ruby'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead
```