### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
     "bug_tracker_uri"   => "https://github.com/colszowka/simplecov/issues",
     "changelog_uri"     => "https://github.com/colszowka/simplecov/blob/master/CHANGELOG.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/simplecov/#{gem.version}",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/simplecov",
     "source_code_uri"   => "https://github.com/colszowka/simplecov/tree/v#{gem.version}"
   }
 

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -13,6 +13,12 @@ Gem::Specification.new do |gem|
   gem.description = %(Code coverage for Ruby with a powerful configuration library and automatic merging of coverage across test suites)
   gem.summary     = gem.description
   gem.license     = "MIT"
+  gem.metadata    = {
+    "bug_tracker_uri"   => "https://github.com/colszowka/simplecov/issues",
+    "changelog_uri"     => "https://github.com/colszowka/simplecov/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/simplecov/#{gem.version}",
+    "source_code_uri"   => "https://github.com/colszowka/simplecov/tree/v#{gem.version}"
+  }
 
   gem.required_ruby_version = ">= 2.4.0"
 

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.platform    = Gem::Platform::RUBY
   gem.authors     = ["Christoph Olszowka"]
   gem.email       = ["christoph at olszowka de"]
-  gem.homepage    = "http://github.com/colszowka/simplecov"
+  gem.homepage    = "https://github.com/colszowka/simplecov"
   gem.description = %(Code coverage for Ruby with a powerful configuration library and automatic merging of coverage across test suites)
   gem.summary     = gem.description
   gem.license     = "MIT"


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/simplecov), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.