### PR TITLE
Fix gemspec warning

### DIFF
--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |gem|
   gem.authors     = ["Christoph Olszowka"]
   gem.email       = ["christoph at olszowka de"]
   gem.homepage    = "http://github.com/colszowka/simplecov"
+  gem.summary     = "Code coverage for Ruby"
   gem.description = %(Code coverage for Ruby with a powerful configuration library and automatic merging of coverage across test suites)
-  gem.summary     = gem.description
   gem.license     = "MIT"
 
   gem.required_ruby_version = ">= 2.4.0"

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "open3"
+
+RSpec.describe "gemspec sanity" do
+  after do
+    File.delete(Dir.glob("simplecov-*.gem").first)
+  end
+
+  let(:build) do
+    Bundler.with_original_env do
+      Open3.capture3("gem build simplecov.gemspec")
+    end
+  end
+
+  it "has no warnings" do
+    expect(build[1]).not_to include("WARNING")
+  end
+
+  it "succeeds" do
+    expect(build[2]).to be_success
+  end
+end


### PR DESCRIPTION
I noticed that running `gem build simplecov.gemspec` prints one warning:

```
WARNING:  description and summary are identical
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

This PR fixes it.
