### PR TITLE
(Hopefully) fix #776 by returning empty responses on not found file

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,10 +11,24 @@ require "capybara/apparition"
 Capybara.app = lambda { |env|
   request_path = env["REQUEST_PATH"] || "/"
   request_path = "/index.html" if request_path == "/"
+  corresponding_file_path =
+    File.join(File.dirname(__FILE__), "../../tmp/aruba/project/coverage", request_path)
+
+  content =
+    if File.exist?(corresponding_file_path)
+      File.read(corresponding_file_path)
+    else
+      # See #776 for whatever reason sometimes JRuby in one feature couldn't
+      # find the loading.gif - which isn't essential so answering empty string
+      # should be good enough
+      warn "Couldn't find #{corresponding_file_path} generating empty response"
+      ""
+    end
+
   [
     200,
     {"Content-Type" => "text/html"},
-    [File.read(File.join(File.dirname(__FILE__), "../../tmp/aruba/project/coverage", request_path))]
+    [content]
   ]
 }
 


### PR DESCRIPTION
Couldn't reproduce locally.
As the failure was only ever JRuby, one test and the gif at that
(which shouldn't matter for the result of the test as a whole)
decided to just roll with it with an empty response and log
when it happens so that we could track other failures back to it.

fixes #776 