### PR TITLE
Change wording of branch coverage to coverage_criterion

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ Add branch coverage measurement statistics to your results
 
 ```ruby
 SimpleCov.start do
-  use_branchable_report true
+  coverage_criterion :branch
 end
 ```
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -253,13 +253,13 @@ module SimpleCov
   private
 
     #
-    # Trigger Coverage.start depends on given config use_branchable_report
+    # Trigger Coverage.start depends on given config coverage_criterion
     #
     # With Positive branch it supports all coverage measurement types
     # With Negative branch it supports only line coverage measurement type
     #
     def start_coverage_measurment
-      if branchable_report
+      if branch_coverage?
         Coverage.start(:all)
       else
         Coverage.start

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -59,7 +59,7 @@ describe SimpleCov::Configuration do
       end
     end
 
-    describe "minimum_coverage_by_file" do
+    describe "#minimum_coverage_by_file" do
       it "does not warn you about your usage" do
         expect(config).not_to receive(:warn)
         config.minimum_coverage_by_file(100.00)
@@ -68,6 +68,44 @@ describe SimpleCov::Configuration do
       it "warns you about your usage" do
         expect(config).to receive(:warn).with("The coverage you set for minimum_coverage_by_file is greater than 100%")
         config.minimum_coverage_by_file(100.01)
+      end
+    end
+
+    describe "#coverage_criterion" do
+      it "defaults to line" do
+        expect(config.coverage_criterion).to eq :line
+      end
+
+      it "works fine with line" do
+        config.coverage_criterion :line
+
+        expect(config.coverage_criterion).to eq :line
+      end
+
+      it "works fine with :branch" do
+        config.coverage_criterion :branch
+
+        expect(config.coverage_criterion).to eq :branch
+      end
+
+      it "errors out on unknown coverage" do
+        expect do
+          config.coverage_criterion :unknown
+        end.to raise_error(/unsupported.*unknown.*line/i)
+      end
+    end
+
+    describe "#branch_coverage?" do
+      it "returns true of branch coverage is being measured" do
+        config.coverage_criterion :branch
+
+        expect(config).to be_branch_coverage
+      end
+
+      it "returns false for line coverage" do
+        config.coverage_criterion :line
+
+        expect(config).not_to be_branch_coverage
       end
     end
   end


### PR DESCRIPTION
This is more flexible as it also accommodates for all the other
coverage types. It would also allow us to use an array like
`[:branch, :lines, :methods]` or something in the future.

It's also arguable a better name, let me know if you disagree :) Criteria is what wikipedia and other sources call/called it: https://en.wikipedia.org/wiki/Code_coverage

I'm also half-way sure that this will intermittently break
branch coverage but that's why adding an integration test there
is next on the list!

#781 