### PR TITLE
Tighten branch coverage tests & remove inconsistencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/BlockNesting:
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#three-is-the-number-thou-shalt-count
   Max: 2
 
-Metrics/LineLength:
+Layout/LineLength:
   Description: Checks the length of lines in the source code.
   AllowURI: true
   Enabled: false

--- a/spec/fixtures/branches.rb
+++ b/spec/fixtures/branches.rb
@@ -1,0 +1,13 @@
+class Branches
+  def call(arg)
+    return if arg < 0
+
+    arg == 42 ? :yes : :no
+
+    if arg.odd?
+      :yes
+    else
+      :no
+    end
+  end
+end

--- a/spec/fixtures/coverer.rb
+++ b/spec/fixtures/coverer.rb
@@ -2,8 +2,8 @@
 
 require "coverage"
 Coverage.start(:all)
-require_relative "inline"
+require_relative "sample"
 
-Inline.new.call(42)
+Foo.new
 
 p Coverage.result

--- a/spec/fixtures/coverer.rb
+++ b/spec/fixtures/coverer.rb
@@ -2,8 +2,8 @@
 
 require "coverage"
 Coverage.start(:all)
-require_relative "sample"
+require_relative "branches"
 
-Foo.new
+Branches.new.call(42)
 
 p Coverage.result

--- a/spec/fixtures/coverer.rb
+++ b/spec/fixtures/coverer.rb
@@ -1,0 +1,9 @@
+# Script to gather coverage data to use in tests to go along with fixtures
+
+require "coverage"
+Coverage.start(:all)
+require_relative "inline"
+
+Inline.new.call(42)
+
+p Coverage.result

--- a/spec/fixtures/inline.rb
+++ b/spec/fixtures/inline.rb
@@ -1,0 +1,13 @@
+class Inline
+  def call(arg)
+    String(arg == 42 ? :yes : :no)
+
+    String(
+      if arg.odd?
+        :yes
+      else
+        :no
+      end
+    )
+  end
+end

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -48,48 +48,52 @@ describe SimpleCov::SourceFile do
       expect(subject.line(2).source).to eq("class Foo\n")
     end
 
-    it "returns lines number 2, 3, 4, 7 for covered_lines" do
-      expect(subject.covered_lines.map(&:line)).to eq([2, 3, 4, 7])
+    describe "line coverage" do
+      it "returns lines number 2, 3, 4, 7 for covered_lines" do
+        expect(subject.covered_lines.map(&:line)).to eq([2, 3, 4, 7])
+      end
+
+      it "returns lines number 8 for missed_lines" do
+        expect(subject.missed_lines.map(&:line)).to eq([8])
+      end
+
+      it "returns lines number 1, 5, 6, 9, 10, 16 for never_lines" do
+        expect(subject.never_lines.map(&:line)).to eq([1, 5, 6, 9, 10, 16])
+      end
+
+      it "returns line numbers 11, 12, 13, 14, 15 for skipped_lines" do
+        expect(subject.skipped_lines.map(&:line)).to eq([11, 12, 13, 14, 15])
+      end
+
+      it "has 80% covered_percent" do
+        expect(subject.covered_percent).to eq(80.0)
+      end
     end
 
-    it "returns lines number 8 for missed_lines" do
-      expect(subject.missed_lines.map(&:line)).to eq([8])
-    end
+    describe "branch coverage" do
+      it "has total branches count 0" do
+        expect(subject.total_branches.size).to eq(0)
+      end
 
-    it "returns lines number 1, 5, 6, 9, 10, 16 for never_lines" do
-      expect(subject.never_lines.map(&:line)).to eq([1, 5, 6, 9, 10, 16])
-    end
+      it "has covered branches count 0" do
+        expect(subject.covered_branches.size).to eq(0)
+      end
 
-    it "returns line numbers 11, 12, 13, 14, 15 for skipped_lines" do
-      expect(subject.skipped_lines.map(&:line)).to eq([11, 12, 13, 14, 15])
-    end
+      it "has missed branches count 0" do
+        expect(subject.missed_branches.size).to eq(0)
+      end
 
-    it "has 80% covered_percent" do
-      expect(subject.covered_percent).to eq(80.0)
-    end
+      it "has root branches count 0" do
+        expect(subject.root_branches.size).to eq(0)
+      end
 
-    it "Has total branches count 0" do
-      expect(subject.total_branches.size).to eq(0)
-    end
+      it "is considered 100% branches covered" do
+        expect(subject.branches_coverage_percent).to eq(100.0)
+      end
 
-    it "Has covered branches count 0" do
-      expect(subject.covered_branches.size).to eq(0)
-    end
-
-    it "Has missed branches count 0" do
-      expect(subject.missed_branches.size).to eq(0)
-    end
-
-    it "Has root branches count 0" do
-      expect(subject.root_branches.size).to eq(0)
-    end
-
-    it "is considered 100% branches covered" do
-      expect(subject.branches_coverage_percent).to eq(100.0)
-    end
-
-    it "Has coverage report" do
-      expect(subject.branches_report).to eq({})
+      it "has branch coverage report" do
+        expect(subject.branches_report).to eq({})
+      end
     end
   end
 

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -5,7 +5,14 @@ require "helper"
 describe SimpleCov::SourceFile do
   COVERAGE_FOR_SAMPLE_RB = {
     :lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil],
-    :branches => {[:if, 0, 17, 6, 23, 9] => {[:then, 1, 18, 8, 18, 81] => 3, [:else, 2, 20, 8, 22, 19] => 0}, [:if, 3, 29, 6, 35, 9] => {[:then, 4, 30, 8, 30, 81] => 3, [:else, 5, 32, 8, 34, 20] => 0}}
+    :branches => {
+      [:if, 0, 17, 6, 23, 9] => {
+        [:then, 1, 18, 8, 18, 81] => 3, [:else, 2, 20, 8, 22, 19] => 0
+      },
+      [:if, 3, 29, 6, 35, 9] => {
+        [:then, 4, 30, 8, 30, 81] => 3, [:else, 5, 32, 8, 34, 20] => 0
+      }
+    }
   }.freeze
 
   COVERAGE_FOR_SAMPLE_RB_WITH_MORE_LINES = {
@@ -115,36 +122,42 @@ describe SimpleCov::SourceFile do
     end
   end
 
-  context "A file that have inline branches" do
-    COVERAGE_FOR_DUMB_INLINE = {
-      :lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil],
-      :branches => {[:if, 0, 18, 6, 18, 9] => {[:then, 1, 18, 8, 18, 81] => 3, [:else, 2, 18, 8, 18, 19] => 0}, [:if, 3, 29, 6, 35, 9] => {[:then, 4, 30, 8, 30, 81] => 3, [:else, 5, 31, 8, 34, 20] => 0}}
+  context "A file that has inline branches" do
+    COVERAGE_FOR_INLINE = {
+      :lines =>
+        [1, 1, 1, nil, 1, 1, 0, nil, 1, nil, nil, nil, nil],
+      :branches => {
+        [:if, 0, 3, 11, 3, 33] =>
+          {[:then, 1, 3, 23, 3, 27] => 1, [:else, 2, 3, 30, 3, 33] => 0},
+        [:if, 3, 6, 6, 10, 9] =>
+          {[:then, 4, 7, 8, 7, 12] => 0, [:else, 5, 9, 8, 9, 11] => 1}
+      }
     }.freeze
 
     subject do
-      SimpleCov::SourceFile.new(source_fixture("never.rb"), COVERAGE_FOR_DUMB_INLINE)
+      SimpleCov::SourceFile.new(source_fixture("inline.rb"), COVERAGE_FOR_INLINE)
     end
 
-    it "Has branches report on 3 lines " do
+    it "has branches report on 3 lines" do
       expect(subject.branches_report.keys.size).to eq(3)
-      expect(subject.branches_report.keys).to eq([18, 29, 30])
+      expect(subject.branches_report.keys).to eq([3, 6, 8])
     end
 
-    it "Has covered branches count 2 " do
+    it "has covered branches count 2" do
       expect(subject.covered_branches.size).to eq(2)
     end
 
-    it "Has dual element in condition at line 18 report" do
-      expect(subject.branches_report[18]).to eq([[3, "+"], [0, "-"]])
+    it "has dual element in condition at line 3 report" do
+      expect(subject.branches_report[3]).to eq([[1, "+"], [0, "-"]])
     end
 
-    it "Has branches coverage precent 50.00" do
+    it "has branches coverage precent 50.00" do
       expect(subject.branches_coverage_percent).to eq(50.00)
     end
   end
 
   context "a file that is never relevant" do
-    COVERAGE_FOR_NEVER_RB = {:lines => [nil, nil]}.freeze
+    COVERAGE_FOR_NEVER_RB = {:lines => [nil, nil], :branches => {}}.freeze
 
     subject do
       SimpleCov::SourceFile.new(source_fixture("never.rb"), COVERAGE_FOR_NEVER_RB)
@@ -154,8 +167,12 @@ describe SimpleCov::SourceFile do
       expect(subject.covered_strength).to eq 0.0
     end
 
-    it "has 0.0 covered_percent" do
+    it "has 100.0 covered_percent" do
       expect(subject.covered_percent).to eq 100.0
+    end
+
+    it "has 100.0 branch coverage" do
+      expect(subject.branches_coverage_percent).to eq(100.00)
     end
   end
 

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -4,15 +4,9 @@ require "helper"
 
 describe SimpleCov::SourceFile do
   COVERAGE_FOR_SAMPLE_RB = {
-    :lines => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil],
-    :branches => {
-      [:if, 0, 17, 6, 23, 9] => {
-        [:then, 1, 18, 8, 18, 81] => 3, [:else, 2, 20, 8, 22, 19] => 0
-      },
-      [:if, 3, 29, 6, 35, 9] => {
-        [:then, 4, 30, 8, 30, 81] => 3, [:else, 5, 32, 8, 34, 20] => 0
-      }
-    }
+    :lines =>
+      [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, 1, 0, nil, nil, nil],
+    :branches => {}
   }.freeze
 
   COVERAGE_FOR_SAMPLE_RB_WITH_MORE_LINES = {
@@ -74,32 +68,28 @@ describe SimpleCov::SourceFile do
       expect(subject.covered_percent).to eq(80.0)
     end
 
-    it "Has total branches count 4" do
-      expect(subject.total_branches.size).to eq(4)
+    it "Has total branches count 0" do
+      expect(subject.total_branches.size).to eq(0)
     end
 
-    it "Has covered branches count 2" do
-      expect(subject.covered_branches.size).to eq(2)
+    it "Has covered branches count 0" do
+      expect(subject.covered_branches.size).to eq(0)
     end
 
-    it "Has missed branches count 2" do
-      expect(subject.missed_branches.size).to eq(2)
+    it "Has missed branches count 0" do
+      expect(subject.missed_branches.size).to eq(0)
     end
 
-    it "Has root branches count 2" do
-      expect(subject.root_branches.size).to eq(2)
+    it "Has root branches count 0" do
+      expect(subject.root_branches.size).to eq(0)
     end
 
-    it "Has branch on line number 7 with report pr line" do
-      expect(subject.branch_per_line(17)).to eq("[3, \"+\"]")
+    it "is considered 100% branches covered" do
+      expect(subject.branches_coverage_percent).to eq(100.0)
     end
 
     it "Has coverage report" do
-      expect(subject.branches_report).to eq(17 => [[3, "+"]], 19 => [[0, "-"]], 29 => [[3, "+"]], 31 => [[0, "-"]])
-    end
-
-    it "Hash line 31 with missed branches" do
-      expect(subject.line_with_missed_branch?(31)).to eq(true)
+      expect(subject.branches_report).to eq({})
     end
   end
 

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -93,6 +93,86 @@ describe SimpleCov::SourceFile do
     end
   end
 
+  context "file with branches" do
+    COVERAGE_FOR_BRANCHES_RB = {
+      :lines =>
+        [1, 1, 1, nil, 1, nil, 1, 0, nil, 1, nil, nil, nil],
+      :branches => {
+        [:if, 0, 3, 4, 3, 21] =>
+          {[:then, 1, 3, 4, 3, 10] => 0, [:else, 2, 3, 4, 3, 21] => 1},
+        [:if, 3, 5, 4, 5, 26] =>
+          {[:then, 4, 5, 16, 5, 20] => 1, [:else, 5, 5, 23, 5, 26] => 0},
+        [:if, 6, 7, 4, 11, 7] =>
+          {[:then, 7, 8, 6, 8, 10] => 0, [:else, 8, 10, 6, 10, 9] => 1}
+      }
+    }.freeze
+
+    subject do
+      SimpleCov::SourceFile.new(source_fixture("branches.rb"), COVERAGE_FOR_BRANCHES_RB)
+    end
+
+    describe "branch coverage" do
+      it "has 50% branch coverage" do
+        expect(subject.branches_coverage_percent).to eq 50.0
+      end
+
+      it "has total branches count 6" do
+        expect(subject.total_branches.size).to eq(6)
+      end
+
+      it "has covered branches count 3" do
+        expect(subject.covered_branches.size).to eq(3)
+      end
+
+      it "has missed branches count 3" do
+        expect(subject.missed_branches.size).to eq(3)
+      end
+
+      it "has root branches count 3" do
+        expect(subject.root_branches.size).to eq(3)
+      end
+
+      it "has branch on line number 7 with report line" do
+        expect(subject.branch_per_line(7)).to eq('[0, "+"]')
+      end
+
+      it "has coverage report" do
+        expect(subject.branches_report).to eq(
+          3 => [[0, "+"], [1, "-"]],
+          5 => [[1, "+"], [0, "-"]],
+          7 => [[0, "+"]],
+          9 => [[1, "-"]]
+        )
+      end
+
+      it "has line 7 with missed branches branch" do
+        expect(subject.line_with_missed_branch?(7)).to eq(true)
+      end
+
+      it "has line 3 with missed branches branch" do
+        expect(subject.line_with_missed_branch?(3)).to eq(true)
+      end
+    end
+
+    describe "line coverage" do
+      it "has line coverage" do
+        expect(subject.covered_percent).to be_within(0.01).of(85.71)
+      end
+
+      it "has 6 covered lines" do
+        expect(subject.covered_lines.size).to eq 6
+      end
+
+      it "has 1 missed line" do
+        expect(subject.missed_lines.size).to eq 1
+      end
+
+      it "has 7 relevant lines" do
+        expect(subject.relevant_lines).to eq 7
+      end
+    end
+  end
+
   context "simulating potential Ruby 1.9 defect -- see Issue #56" do
     subject do
       SimpleCov::SourceFile.new(source_fixture("sample.rb"), COVERAGE_FOR_SAMPLE_RB_WITH_MORE_LINES)


### PR DESCRIPTION
This PR mainly takes the existing tests and makes the provided coverage data match the files that are being tested so that they are consistent and we have the actual files in the repo to work with them.

Also adds some new tests for some scenarios (as they were previously tested with files that didn't match what they were doing).

#781 