### PR TITLE
Move comments to attach to correct module/class [skip ci]

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -2,9 +2,6 @@
 
 require "English"
 
-#
-# Code coverage for ruby. Please check out README for a full introduction.
-#
 # Coverage may be inaccurate under JRUBY.
 if defined?(JRUBY_VERSION) && defined?(JRuby)
 
@@ -20,6 +17,10 @@ if defined?(JRUBY_VERSION) && defined?(JRuby)
       ' or set the "debug.fullTrace=true" option in your .jrubyrc'
   end
 end
+
+#
+# Code coverage for ruby. Please check out README for a full introduction.
+#
 module SimpleCov
   class << self
     attr_accessor :running

--- a/lib/simplecov/command_guesser.rb
+++ b/lib/simplecov/command_guesser.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-#
-# Helper that tries to find out what test suite is running (for SimpleCov.command_name)
-#
 module SimpleCov
+
+  #
+  # Helper that tries to find out what test suite is running (for SimpleCov.command_name)
+  #
   module CommandGuesser
     class << self
       # Storage for the original command line call that invoked the test suite.

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -3,12 +3,14 @@
 require "fileutils"
 require "docile"
 require "simplecov/formatter/multi_formatter"
-#
-# Bundles the configuration options used for SimpleCov. All methods
-# defined here are usable from SimpleCov directly. Please check out
-# SimpleCov documentation for further info.
-#
+
 module SimpleCov
+
+  #
+  # Bundles the configuration options used for SimpleCov. All methods
+  # defined here are usable from SimpleCov directly. Please check out
+  # SimpleCov documentation for further info.
+  #
   module Configuration # rubocop:disable Metrics/ModuleLength
     attr_writer :filters, :groups, :formatter, :print_error_status
 

--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# An array of SimpleCov SourceFile instances with additional collection helper
-# methods for calculating coverage across them etc.
 module SimpleCov
+
+  # An array of SimpleCov SourceFile instances with additional collection helper
+  # methods for calculating coverage across them etc.
   class FileList < Array
     # Returns the count of lines that have coverage
     def covered_lines

--- a/lib/simplecov/formatter/simple_formatter.rb
+++ b/lib/simplecov/formatter/simple_formatter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-#
-# A ridiculously simple formatter for SimpleCov results.
-#
 module SimpleCov
   module Formatter
+
+    #
+    # A ridiculously simple formatter for SimpleCov results.
+    #
     class SimpleFormatter
       # Takes a SimpleCov::Result and generates a string out of it
       def format(result)

--- a/lib/simplecov/profiles.rb
+++ b/lib/simplecov/profiles.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-#
-# Profiles are SimpleCov configuration procs that can be easily
-# loaded using SimpleCov.start :rails and defined using
-#   SimpleCov.profiles.define :foo do
-#     # SimpleCov configuration here, same as in  SimpleCov.configure
-#   end
-#
 module SimpleCov
+
+  #
+  # Profiles are SimpleCov configuration procs that can be easily
+  # loaded using SimpleCov.start :rails and defined using
+  #   SimpleCov.profiles.define :foo do
+  #     # SimpleCov configuration here, same as in  SimpleCov.configure
+  #   end
+  #
   class Profiles < Hash
     #
     # Define a SimpleCov profile:

--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -2,12 +2,13 @@
 
 require "json"
 
-#
-# Singleton that is responsible for caching, loading and merging
-# SimpleCov::Results into a single result for coverage analysis based
-# upon multiple test suites.
-#
 module SimpleCov
+
+  #
+  # Singleton that is responsible for caching, loading and merging
+  # SimpleCov::Results into a single result for coverage analysis based
+  # upon multiple test suites.
+  #
   module ResultMerger
     class << self
       # The path to the .resultset.json cache file


### PR DESCRIPTION
lib/simplecov/command_guesser.rb
lib/simplecov/configuration.rb
lib/simplecov/file_list.rb
lib/simplecov/profiles.rb
lib/simplecov/result_merger.rb
lib/simplecov/formatter/simple_formatter.rb

In some doc systems, comments as below will be attached to module A:
```ruby
# Class B comments
#
module A
  class B
  end
end
```
Moved inside `module A`:
```ruby 
module A

  # Class B comments
  #
  class B
  end
end
```
