### PR TITLE
Make activation of branch coverage more sensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,8 +626,9 @@ SimpleCov.refuse_coverage_drop
 Add branch coverage measurement statistics to your results
 
 ```ruby
+# or in configure or just SimpleCov.enable_coverage :branch
 SimpleCov.start do
-  coverage_criterion :branch
+  enable_coverage :branch
 end
 ```
 

--- a/features/branch_coverage.feature
+++ b/features/branch_coverage.feature
@@ -8,7 +8,7 @@ Feature:
       """
       require 'simplecov'
       SimpleCov.start do
-        coverage_criterion :branch
+        enable_coverage :branch
       end
       """
     When I open the coverage report generated with `bundle exec rspec spec`

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -354,6 +354,7 @@ module SimpleCov
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__)))
+require "set"
 require "simplecov/configuration"
 SimpleCov.extend SimpleCov::Configuration
 require "simplecov/exit_codes"

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -305,6 +305,7 @@ module SimpleCov
     end
 
     SUPPORTED_COVERAGE_CRITERIA = %i[line branch].freeze
+    DEFAULT_COVERAGE_CRITERION = :line
     #
     # Define which coverage criterion should be evaluated.
     #
@@ -317,14 +318,25 @@ module SimpleCov
     # @param [Symbol] criterion
     #
     def coverage_criterion(criterion = nil)
-      criterion ||= :line
-      raise_criterion_not_supported(criterion) unless SUPPORTED_COVERAGE_CRITERIA.member?(criterion)
+      return @coverage_criterion ||= DEFAULT_COVERAGE_CRITERION unless criterion
 
-      @coverage_criterion ||= criterion
+      raise_if_criterion_unsupported(criterion)
+
+      @coverage_criterion = criterion
+    end
+
+    def enable_coverage(criterion)
+      raise_if_criterion_unsupported(criterion)
+
+      coverage_criteria << criterion
+    end
+
+    def coverage_criteria
+      @coverage_criteria ||= Set[DEFAULT_COVERAGE_CRITERION]
     end
 
     def branch_coverage?
-      branch_coverage_supported? && coverage_criterion == :branch
+      branch_coverage_supported? && coverage_criteria.member?(:branch)
     end
 
     def branch_coverage_supported?
@@ -334,7 +346,11 @@ module SimpleCov
 
   private
 
-    def raise_criterion_not_supported(criterion)
+    def raise_if_criterion_unsupported(criterion)
+      raise_criterion_unsupported(criterion) unless SUPPORTED_COVERAGE_CRITERIA.member?(criterion)
+    end
+
+    def raise_criterion_unsupported(criterion)
       raise "Unsupported coverage criterion #{criterion}, supported values are #{SUPPORTED_COVERAGE_CRITERIA}"
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -88,6 +88,13 @@ describe SimpleCov::Configuration do
         expect(config.coverage_criterion).to eq :branch
       end
 
+      it "works fine setting it back and forth" do
+        config.coverage_criterion :branch
+        config.coverage_criterion :line
+
+        expect(config.coverage_criterion).to eq :line
+      end
+
       it "errors out on unknown coverage" do
         expect do
           config.coverage_criterion :unknown
@@ -95,9 +102,35 @@ describe SimpleCov::Configuration do
       end
     end
 
+    describe "#coverage_criteria" do
+      it "defaults to line" do
+        expect(config.coverage_criteria).to contain_exactly :line
+      end
+    end
+
+    describe "#enable_coverage" do
+      it "can enable branch coverage" do
+        config.enable_coverage :branch
+
+        expect(config.coverage_criteria).to contain_exactly :line, :branch
+      end
+
+      it "can enable line again" do
+        config.enable_coverage :line
+
+        expect(config.coverage_criteria).to contain_exactly :line
+      end
+
+      it "can't enable arbitrary things" do
+        expect do
+          config.enable_coverage :unknown
+        end.to raise_error(/unsupported.*unknown.*line/i)
+      end
+    end
+
     describe "#branch_coverage?", :if => SimpleCov.branch_coverage_supported? do
       it "returns true of branch coverage is being measured" do
-        config.coverage_criterion :branch
+        config.enable_coverage :branch
 
         expect(config).to be_branch_coverage
       end


### PR DESCRIPTION
Branch coverage is best to accompany line coverage as branch
coverage itself has some gaping holes in it (namely that it
doesn't care about code without conditionals).

coverage_criterion will most likely evolve to be the "primary
coverage criterion" for the full release.

This API right now should be future proof but also easier.

#781 