### PR TITLE
Clarify support drop changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This release is still beta because we'd love for you to test out branch coverage
 On a personal note from [@PragTob](https://github.com/PragTob/) thanks to [ruby together](https://rubytogether.org/) for sponsoring this work on SimpleCov making it possible to deliver this and subsequent releases.
 
 ## Breaking
-* Dropped official support for all EOL'ed rubies meaning we only officially support 2.4+ - older rubies might still work but are not guaranteed to do so. Older release should still work. (thanks [@deivid-rodriguez](https://github.com/deivid-rodriguez))
+* Dropped support for all EOL'ed rubies meaning we only support 2.4+. Simplecov can no longer be installed on older rubies, but older simplecov releases should still work. (thanks [@deivid-rodriguez](https://github.com/deivid-rodriguez))
 * Dropped the `rake simplecov` task that "magically" integreated with rails. It was always undocumented, caused some issues and [had some issues](https://github.com/colszowka/simplecov/issues/689#issuecomment-561572327). Use the integration as described in the README please :)
 
 ## Enhancements


### PR DESCRIPTION
Since we bumped the minimum required ruby version in the gemspec file, simplecov is no longer installable on older rubies. Not sure if the previous wording intended to say that you could fork the gem, manually edit the gemspec, and maybe get the gem to work on older rubies. In any case, I think it's better to say that you can no longer install the gem on those rubies.