### PR TITLE
Only turn on requested coverage criteria on the Ruby Coverage side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.18.0.beta2 (2020-01-05)
+===================
+
+## Enhancements
+* only turn on the requested coverage criteria (when activating branch coverage before SimpleCov would also instruct Ruby to take Method coverage)
+
 0.18.0.beta1 (2020-01-05)
 ===================
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -306,8 +306,8 @@ module SimpleCov
       :branch => :branches,
       :line => :lines
     }.freeze
-    def lookup_corresponding_ruby_coverage_name(cirterion)
-      CRITERION_TO_RUBY_COVERAGE.fetch(cirterion)
+    def lookup_corresponding_ruby_coverage_name(criterion)
+      CRITERION_TO_RUBY_COVERAGE.fetch(criterion)
     end
 
     #

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -52,7 +52,7 @@ module SimpleCov
       self.running = true
       self.pid = Process.pid
 
-      start_coverage_measurment
+      start_coverage_measurement
     end
 
     #
@@ -259,7 +259,7 @@ module SimpleCov
     # With Positive branch it supports all coverage measurement types
     # With Negative branch it supports only line coverage measurement type
     #
-    def start_coverage_measurment
+    def start_coverage_measurement
       # This blog post gives a good run down of the coverage criterias introduced
       # in Ruby 2.5: https://blog.bigbinary.com/2018/04/11/ruby-2-5-supports-measuring-branch-and-method-coverages.html
       # There is also a nice writeup of the different coverage criteria made in this
@@ -287,11 +287,27 @@ module SimpleCov
       # :oneshot_lines - can not be combined with lines
       # :all - same as lines + branches + methods
       #
-      if branch_coverage?
-        Coverage.start(:all)
+      if coverage_start_arguments_supported?
+        start_coverage_with_criteria
       else
         Coverage.start
       end
+    end
+
+    def start_coverage_with_criteria
+      start_arguments = coverage_criteria.map do |criterion|
+        [lookup_corresponding_ruby_coverage_name(criterion), true]
+      end.to_h
+
+      Coverage.start(start_arguments)
+    end
+
+    CRITERION_TO_RUBY_COVERAGE = {
+      :branch => :branches,
+      :line => :lines
+    }.freeze
+    def lookup_corresponding_ruby_coverage_name(cirterion)
+      CRITERION_TO_RUBY_COVERAGE.fetch(cirterion)
     end
 
     #

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -335,14 +335,20 @@ module SimpleCov
       @coverage_criteria ||= Set[DEFAULT_COVERAGE_CRITERION]
     end
 
+    def clear_coverage_criteria
+      @coverage_criteria = nil
+    end
+
     def branch_coverage?
       branch_coverage_supported? && coverage_criteria.member?(:branch)
     end
 
-    def branch_coverage_supported?
+    def coverage_start_arguments_supported?
       require "coverage"
       !Coverage.method(:start).arity.zero?
     end
+
+    alias branch_coverage_supported? coverage_start_arguments_supported?
 
   private
 

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -229,4 +229,27 @@ describe SimpleCov do
       end
     end
   end
+
+  # Normally wouldn't test private methods but just start has side effects that
+  # cause errors so for time this is pragmatic (tm)
+  describe ".start_coverage_measurement", :if => SimpleCov.coverage_start_arguments_supported? do
+    before :each do
+      # global state, yay!
+      SimpleCov.clear_coverage_criteria
+    end
+
+    it "starts coverage in lines mode by default" do
+      expect(Coverage).to receive(:start).with(:lines => true)
+
+      SimpleCov.send :start_coverage_measurement
+    end
+
+    it "starts coverage with lines and branches if branches is activated" do
+      expect(Coverage).to receive(:start).with(:lines => true, :branches => true)
+
+      SimpleCov.enable_coverage :branch
+
+      SimpleCov.send :start_coverage_measurement
+    end
+  end
 end

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -234,7 +234,9 @@ describe SimpleCov do
   # cause errors so for time this is pragmatic (tm)
   describe ".start_coverage_measurement", :if => SimpleCov.coverage_start_arguments_supported? do
     before :each do
-      # global state, yay!
+      # SimpleCov is a Singleton/global object so once any test enables
+      # any kind of coverage data it stays there.
+      # Hence, we use clear_coverage_data to create a "clean slate" for these tests
       SimpleCov.clear_coverage_criteria
     end
 


### PR DESCRIPTION
when activating branch coverage before SimpleCov would also instruct Ruby to take Method coverage

#781 