### PR TITLE
Avoid ruby 2.7 warnings during tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "simplecov-html", :github => "colszowka/simplecov-html"
 
 group :development do
   gem "aruba", "~> 0.14"
-  gem "capybara", "~> 3.29"
+  gem "capybara", :github => "teamcapybara/capybara"
   gem "cucumber", "~> 3.1"
   gem "cuprite", "0.8"
   gem "rake", "~> 13.0"

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,10 @@ source "https://rubygems.org"
 gem "simplecov-html", :github => "colszowka/simplecov-html"
 
 group :development do
-  gem "apparition", "0.4.0"
   gem "aruba", "~> 0.14"
   gem "capybara", "~> 3.29"
   gem "cucumber", "~> 3.1"
+  gem "cuprite", "0.8"
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.2"
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,19 @@ GIT
   specs:
     simplecov-html (0.11.0.beta2)
 
+GIT
+  remote: https://github.com/teamcapybara/capybara.git
+  revision: c8bceae5ac95b607b58acd723d647deb98e49cc3
+  specs:
+    capybara (3.30.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+
 PATH
   remote: .
   specs:
@@ -27,14 +40,6 @@ GEM
     backports (3.15.0)
     benchmark-ips (2.7.2)
     builder (3.2.4)
-    capybara (3.30.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
-      xpath (~> 3.2)
     childprocess (3.0.0)
     cliver (0.3.2)
     coderay (1.1.2)
@@ -90,8 +95,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
       spoon (~> 0.0)
-    public_suffix (4.0.2)
-    rack (2.0.8)
+    public_suffix (4.0.3)
+    rack (2.1.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
@@ -139,7 +144,7 @@ PLATFORMS
 DEPENDENCIES
   aruba (~> 0.14)
   benchmark-ips
-  capybara (~> 3.29)
+  capybara!
   cucumber (~> 3.1)
   cuprite (= 0.8)
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,6 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    apparition (0.4.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     aruba (0.14.14)
       childprocess (>= 0.6.3, < 4.0.0)
       contracts (~> 0.9)
@@ -39,7 +36,9 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    cliver (0.3.2)
     coderay (1.1.2)
+    concurrent-ruby (1.1.5)
     contracts (0.16.0)
     cucumber (3.1.2)
       builder (>= 2.1.2)
@@ -57,8 +56,16 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+    cuprite (0.8)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.6.0)
     diff-lcs (1.3)
     docile (1.3.2)
+    ferrum (0.6.2)
+      addressable (~> 2.6)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.11.3)
     ffi (1.11.3-java)
     gherkin (5.1.0)
@@ -130,11 +137,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  apparition (= 0.4.0)
   aruba (~> 0.14)
   benchmark-ips
   capybara (~> 3.29)
   cucumber (~> 3.1)
+  cuprite (= 0.8)
   pry
   rake (~> 13.0)
   rspec (~> 3.2)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ require "aruba/cucumber"
 require "aruba/config/jruby" if RUBY_ENGINE == "jruby"
 require_relative "aruba_bundler_run_command_fix"
 require "capybara/cucumber"
-require "capybara/apparition"
+require "capybara/cuprite"
 require "simplecov"
 
 # Fake rack app for capybara that just returns the latest coverage report from aruba temp project dir
@@ -37,7 +37,7 @@ Capybara.app = lambda { |env|
 Capybara.configure do |config|
   config.ignore_hidden_elements = false
   config.server = :webrick
-  config.default_driver = :apparition
+  config.default_driver = :cuprite
 end
 
 Before("@branch_coverage") do


### PR DESCRIPTION
#### Before:

```
$ bundle exec rake
Running RuboCop...
Inspecting 118 files
......................................................................................................................

118 files inspected, no offenses detected
/home/deivid/.rbenv/versions/2.7.0/bin/ruby -I/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.1/lib:/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-support-3.9.2/lib /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.1/exe/rspec spec/command_guesser_spec.rb spec/config_loader_spec.rb spec/configuration_spec.rb spec/defaults_spec.rb spec/deleted_source_spec.rb spec/file_list_spec.rb spec/filters_spec.rb spec/gemspec_spec.rb spec/last_run_spec.rb spec/lines_classifier_spec.rb spec/multi_formatter_spec.rb spec/result_merger_spec.rb spec/result_spec.rb spec/return_codes_spec.rb spec/simplecov_spec.rb spec/source_file_spec.rb spec/useless_results_remover_spec.rb

Randomized with seed 56793
......................................................................................................................................................................................................................................................
Non-app warnings written to tmp/warnings.txt



Finished in 5.8 seconds (files took 0.13937 seconds to load)
246 examples, 0 failures

Randomized with seed 56793

/home/deivid/.rbenv/versions/2.7.0/bin/ruby -S bundle exec cucumber
Using the default profile...
./home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/launcher.rb:11: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/launcher.rb:37: warning: The called method `initialize' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/dev_tools_protocol/session.rb:25: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/dev_tools_protocol/session.rb:38: warning: The called method `send_cmd' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:25: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:35: warning: The called method `initialize' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:511: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:287: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:364: warning: The called method `command' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:529: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:539: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:533: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:543: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:548: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:477: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:524: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:468: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:565: warning: The called method `call' is defined here
./home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:506: warning: The called method `call' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page.rb:482: warning: The called method `call' is defined here
./home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/session.rb:751: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/node/finders.rb:50: warning: The called method `find' is defined here
../home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/session.rb:751: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/node/finders.rb:244: warning: The called method `all' is defined here
./home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/node.rb:199: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/node.rb:286: warning: The called method `element_click_pos' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/node.rb:202: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/node.rb:556: warning: The called method `mouse_event_test' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/node.rb:209: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:12: warning: The called method `click_at' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:17: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:30: warning: The called method `down' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:32: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:46: warning: The called method `mouse_event' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:18: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:37: warning: The called method `up' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:40: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/page/mouse.rb:46: warning: The called method `mouse_event' is defined here
...../home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/driver/chrome_client.rb:211: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/apparition-0.4.0/lib/capybara/apparition/browser.rb:206: warning: The called method `call' is defined here
..................................................................................................................................../home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/node/matchers.rb:835: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/node/matchers.rb:861: warning: The called method `_set_query_session_options' is defined here
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/node/matchers.rb:836: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/queries/selector_query.rb:14: warning: The called method `initialize' is defined here
..............................................................................................................................................................

57 scenarios (57 passed)
301 steps (301 passed)
1m6.162s
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/cucumber-core-3.2.1/lib/cucumber/core/test/result.rb:12: warning: calling private without arguments inside a method may not have the intended effect
```

#### After

```
$ bundle exec rake
Running RuboCop...
Inspecting 118 files
......................................................................................................................

118 files inspected, no offenses detected
/home/deivid/.rbenv/versions/2.7.0/bin/ruby -I/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.1/lib:/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-support-3.9.2/lib /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.1/exe/rspec spec/command_guesser_spec.rb spec/config_loader_spec.rb spec/configuration_spec.rb spec/defaults_spec.rb spec/deleted_source_spec.rb spec/file_list_spec.rb spec/filters_spec.rb spec/gemspec_spec.rb spec/last_run_spec.rb spec/lines_classifier_spec.rb spec/multi_formatter_spec.rb spec/result_merger_spec.rb spec/result_spec.rb spec/return_codes_spec.rb spec/simplecov_spec.rb spec/source_file_spec.rb spec/useless_results_remover_spec.rb

Randomized with seed 38842
......................................................................................................................................................................................................................................................
Non-app warnings written to tmp/warnings.txt



Finished in 6.15 seconds (files took 0.16246 seconds to load)
246 examples, 0 failures

Randomized with seed 38842

/home/deivid/.rbenv/versions/2.7.0/bin/ruby -S bundle exec cucumber
Using the default profile...
..............................................................................................................................................^[[B...............................................................................................................................................................

57 scenarios (57 passed)
301 steps (301 passed)
1m12.915s
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/cucumber-core-3.2.1/lib/cucumber/core/test/result.rb:12: warning: calling private without arguments inside a method may not have the intended effect
```

To fix the issues, I pointed to `capybara`'s master where the warnings are fixed, and I switched to [`cuprite` chrome headless driver](https://github.com/machinio/cuprite) because that library is more ruby 2.7 and shows no warnings.