### PR TITLE
Add note how to use simplecov with knapsack_pro gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ to use SimpleCov with them. Here's an overview of the known ones:
   </tr>
   <tr>
     <th>
+      knapsack_pro
+    </th>
+    <td>
+      To make SimpleCov work with Knapsack Pro Queue Mode to split tests in parallel on CI jobs you need to [provide CI node index number to the `SimpleCov.command_name`](https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode).
+    </td>
+    <td>
+      <a href="https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode">Tip</a>
+    </td>
+  </tr>
+  <tr>
+    <th>
       RubyMine
     </th>
     <td>

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ to use SimpleCov with them. Here's an overview of the known ones:
       knapsack_pro
     </th>
     <td>
-      To make SimpleCov work with Knapsack Pro Queue Mode to split tests in parallel on CI jobs you need to provide CI node index number to the <code>SimpleCov.command_name</code>.
+      To make SimpleCov work with Knapsack Pro Queue Mode to split tests in parallel on CI jobs you need to provide CI node index number to the <code>SimpleCov.command_name</code> in <code>KnapsackPro::Hooks::Queue.before_queue</code> hook.
     </td>
     <td>
       <a href="https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode">Tip</a>

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ to use SimpleCov with them. Here's an overview of the known ones:
       knapsack_pro
     </th>
     <td>
-      To make SimpleCov work with Knapsack Pro Queue Mode to split tests in parallel on CI jobs you need to [provide CI node index number to the `SimpleCov.command_name`](https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode).
+      To make SimpleCov work with Knapsack Pro Queue Mode to split tests in parallel on CI jobs you need to provide CI node index number to the <code>SimpleCov.command_name</code>.
     </td>
     <td>
       <a href="https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode">Tip</a>


### PR DESCRIPTION
I often get asked by users of my knapsack_pro gem how to make simplecov working with my tool. I noticed you have a section for `Notes on specific frameworks and test utilities` so I've created this PR. Let me know if this looks ok.

Here is preview:
https://github.com/ArturT/simplecov/tree/note-knapsack#notes-on-specific-frameworks-and-test-utilities