### PR TITLE
Use latest aruba

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "simplecov-html", github: "colszowka/simplecov-html"
 
 group :development do
   gem "aruba", "~> 0.14"
-  gem "capybara", :github => "teamcapybara/capybara"
+  gem "capybara", github: "teamcapybara/capybara"
   gem "cucumber", "~> 3.1"
   gem "cuprite", "0.8"
   gem "rake", "~> 13.0"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source "https://rubygems.org"
 gem "simplecov-html", github: "colszowka/simplecov-html"
 
 group :development do
-  gem "aruba", "~> 0.14"
+  gem "aruba", github: "cucumber/aruba"
   gem "capybara", github: "teamcapybara/capybara"
   gem "cucumber", "~> 3.1"
   gem "cuprite", "0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,18 @@ GIT
     simplecov-html (0.11.0.beta2)
 
 GIT
+  remote: https://github.com/cucumber/aruba.git
+  revision: 8b7dc956daf47051237700488e8d866fb229db29
+  specs:
+    aruba (1.0.0.pre.alpha.5)
+      childprocess (~> 3.0)
+      contracts (~> 0.16.0)
+      cucumber (>= 2.4, < 4.0)
+      ffi (~> 1.9)
+      rspec-expectations (~> 3.4)
+      thor (~> 1.0)
+
+GIT
   remote: https://github.com/teamcapybara/capybara.git
   revision: c8bceae5ac95b607b58acd723d647deb98e49cc3
   specs:
@@ -29,13 +41,6 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    aruba (0.14.14)
-      childprocess (>= 0.6.3, < 4.0.0)
-      contracts (~> 0.9)
-      cucumber (>= 1.3.19)
-      ffi (~> 1.9)
-      rspec-expectations (>= 2.99)
-      thor (>= 0.19, < 2.0)
     ast (2.4.0)
     backports (3.15.0)
     benchmark-ips (2.7.2)
@@ -142,7 +147,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aruba (~> 0.14)
+  aruba!
   benchmark-ips
   capybara!
   cucumber (~> 3.1)

--- a/features/support/aruba_bundler_run_command_fix.rb
+++ b/features/support/aruba_bundler_run_command_fix.rb
@@ -5,10 +5,10 @@
 # See: https://github.com/cucumber/aruba/issues/699
 # This is then taken/adjusted from: https://github.com/rspec/rspec-rails/blob/64b2712da9d12c03a582bb26b62337504f8d1b76/features/support/env.rb
 
-raise "Check if we still need this freedom patch" if Aruba::VERSION[0] == "1"
+# TODO: Check if we still need this freedom patch in Aruba 1.0.0 final
 
 module ArubaExt
-  def run_command(*_)
+  def run_command_and_stop(*_)
     unset_bundler_env_vars
     in_current_directory do
       Bundler.with_unbundled_env do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -63,6 +63,8 @@ Before do
 end
 
 Aruba.configure do |config|
+  config.allow_absolute_paths = true
+
   # JRuby needs a bit longer to get going
   config.exit_timeout = RUBY_ENGINE == "jruby" ? 60 : 20
 end


### PR DESCRIPTION
I'd like to use aruba's master for our specs because I added [a change](https://github.com/cucumber/aruba/pull/675) that I'm finding useful when working with simplecov's cucumber scenarios.

I also removed an extension recently added to aruba, because otherwise specs won't run against aruba 1.0. I thought Aruba 1.0 was fixing the issues, but then I noticed that even without upgrading aruba, the scenarios will pass anwyays without the extension. So, I'm not sure why the aruba extension is needed.