### PR TITLE
Show missed else branch of case statements even if not declared

### DIFF
--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -489,14 +489,19 @@ describe SimpleCov::SourceFile do
     end
 
     describe "branch coverage" do
-      it "covers 1/3" do
-        expect(subject.total_branches.size).to eq 3
+      it "covers 1/4 (counting the else branch)" do
+        expect(subject.total_branches.size).to eq 4
         expect(subject.covered_branches.size).to eq 1
-        expect(subject.missed_branches.size).to eq 2
+        expect(subject.missed_branches.size).to eq 3
+      end
+
+      it "marks the non declared else branch as missing at the point of the case" do
+        expect(subject.branches_for_line(3)).to eq [[0, "-"]]
       end
 
       it "covers the branch that includes 42" do
         expect(subject.branches_report).to eq(
+          3 => [[0, "-"]],
           4 => [[0, "+"]],
           6 => [[1, "+"]],
           8 => [[0, "+"]]


### PR DESCRIPTION
I "flip flopped" a lot on this, the initial PR had it implemented
as omitting this. You can make an argument either way.

You can say your case statement already handles the entire range
of input values given your domain. And then testing another
value seems too much as it's not realistic (or caught elsewhere).

However, who are we to hide additional branch coverage data
from users?

It's also more consistent as we also display the else branch
for if statement without an else. I also think it might help
show lapses in coverage.

```ruby
var =
  case arg
  when "functional"
    55
  when "something"
    42
  end

var += 1
```

When we never hit a branch we get an error down there, it's
something peple might reliably forget.

On top of that it's actually more code to ignore it.

So to summarize it why should we display the else branch for case
statements even if we don't have them:

* show all available coverage data
* consistency with other constructs
* actually less code