### PR TITLE
Stop generally symbolizing all the keys

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,9 +13,7 @@ end
 Rake::Task[:build].prerequisites.unshift :fix_permissions
 
 require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new(:spec) do |spec|
-  spec.pattern = FileList["spec/*_spec.rb"]
-end
+RSpec::Core::RakeTask.new(:spec)
 
 begin
   require "rubocop/rake_task"

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -79,7 +79,7 @@ module SimpleCov
 
       results = result_filenames.flat_map do |filename|
         # Re-create each included instance of SimpleCov::Result from the stored run data.
-        (JSON.parse(File.read(filename), symbolize_names: true) || {}).map do |command_name, coverage|
+        (JSON.parse(File.read(filename)) || {}).map do |command_name, coverage|
           SimpleCov::Result.from_hash(command_name => coverage)
         end
       end
@@ -362,7 +362,7 @@ module SimpleCov
         result = result.dup
         Dir[tracked_files].each do |file|
           absolute_path = File.expand_path(file)
-          result[absolute_path.to_sym] ||= SimulateCoverage.call(absolute_path)
+          result[absolute_path] ||= SimulateCoverage.call(absolute_path)
         end
       end
 

--- a/lib/simplecov/combine/files_combiner.rb
+++ b/lib/simplecov/combine/files_combiner.rb
@@ -15,8 +15,8 @@ module SimpleCov
       # @return [Hash]
       #
       def combine(coverage_a, coverage_b)
-        combination = {lines: Combine.combine(LinesCombiner, coverage_a[:lines], coverage_b[:lines])}
-        combination[:branches] = Combine.combine(BranchesCombiner, coverage_a[:branches], coverage_b[:branches]) if SimpleCov.branch_coverage?
+        combination = {"lines" => Combine.combine(LinesCombiner, coverage_a["lines"], coverage_b["lines"])}
+        combination["branches"] = Combine.combine(BranchesCombiner, coverage_a["branches"], coverage_b["branches"]) if SimpleCov.branch_coverage?
         combination
       end
     end

--- a/lib/simplecov/combine/results_combiner.rb
+++ b/lib/simplecov/combine/results_combiner.rb
@@ -28,8 +28,8 @@ module SimpleCov
       #
       # Manage combining results on files level
       #
-      # @param [Hash] result_a
-      # @param [Hash] result_b
+      # @param [Hash] combined_results
+      # @param [Hash] result
       #
       # @return [Hash]
       #
@@ -56,7 +56,7 @@ module SimpleCov
       # otherwise ignore it. See #820
       #
       # Currently correct format is:
-      # { symbol_file_path => {coverage_criterion => coverage_date}}
+      # { file_path_string => {coverage_criterion => coverage_date}}
       #
       # Internal use/reliance only.
       def correct_format?(result)
@@ -67,10 +67,10 @@ module SimpleCov
         # I so wish I could already use pattern matching
         key, data = result.first
 
-        key.is_a?(Symbol) && second_level_choice_of_criterion?(data)
+        key.is_a?(String) && second_level_choice_of_criterion?(data)
       end
 
-      SECOND_LEVEL_KEYS = %i[lines branches].freeze
+      SECOND_LEVEL_KEYS = %w[lines branches].freeze
       def second_level_choice_of_criterion?(data)
         second_level_key, = data.first
 

--- a/lib/simplecov/result_adapter.rb
+++ b/lib/simplecov/result_adapter.rb
@@ -20,9 +20,9 @@ module SimpleCov
 
       result.each_with_object({}) do |(file_name, cover_statistic), adapted_result|
         if cover_statistic.is_a?(Array)
-          adapted_result.merge!(file_name.to_sym => {lines: cover_statistic})
+          adapted_result.merge!(file_name => {"lines" => cover_statistic})
         else
-          adapted_result.merge!(file_name.to_sym => cover_statistic)
+          adapted_result.merge!(file_name => cover_statistic)
         end
       end
     end

--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -26,7 +26,7 @@ module SimpleCov
           data = stored_data
           if data
             begin
-              JSON.parse(data, symbolize_names: true) || {}
+              JSON.parse(data) || {}
             rescue StandardError
               {}
             end
@@ -72,7 +72,7 @@ module SimpleCov
       # coverage data and the command_name for the result consisting of a join
       # on all source result's names
       def merge_results(*results)
-        parsed_results = JSON.parse(JSON.dump(results.map(&:original_result)), symbolize_names: true)
+        parsed_results = JSON.parse(JSON.dump(results.map(&:original_result)))
         combined_result = SimpleCov::Combine::ResultsCombiner.combine(*parsed_results)
         result = SimpleCov::Result.new(combined_result)
         # Specify the command name

--- a/lib/simplecov/simulate_coverage.rb
+++ b/lib/simplecov/simulate_coverage.rb
@@ -19,10 +19,10 @@ module SimpleCov
       lines = File.foreach(absolute_path)
 
       {
-        lines: LinesClassifier.new.classify(lines),
+        "lines" => LinesClassifier.new.classify(lines),
         # we don't want to parse branches ourselves...
         # requiring files can have side effects and we don't want to trigger that
-        branches: {}
+        "branches" => {}
       }
     end
   end

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -12,7 +12,7 @@ module SimpleCov
     attr_reader :coverage
 
     def initialize(filename, coverage)
-      @filename = filename.to_s
+      @filename = filename
       @coverage = coverage
     end
 
@@ -64,9 +64,9 @@ module SimpleCov
     end
 
     def build_lines
-      coverage_exceeding_source_warn if coverage[:lines].size > src.size
+      coverage_exceeding_source_warn if coverage["lines"].size > src.size
       lines = src.map.with_index(1) do |src, i|
-        SimpleCov::SourceFile::Line.new(src, i, coverage[:lines][i - 1])
+        SimpleCov::SourceFile::Line.new(src, i, coverage["lines"][i - 1])
       end
       process_skipped_lines(lines)
     end
@@ -97,7 +97,7 @@ module SimpleCov
 
     # Warning to identify condition from Issue #56
     def coverage_exceeding_source_warn
-      warn "Warning: coverage data provided by Coverage [#{coverage[:lines].size}] exceeds number of lines in #{filename} [#{src.size}]"
+      warn "Warning: coverage data provided by Coverage [#{coverage['lines'].size}] exceeds number of lines in #{filename} [#{src.size}]"
     end
 
     # Access SimpleCov::SourceFile::Line source lines by line number
@@ -168,7 +168,7 @@ module SimpleCov
     # @return [Array]
     #
     def build_branches
-      coverage_branch_data = coverage.fetch(:branches, {})
+      coverage_branch_data = coverage.fetch("branches", {})
       branches = coverage_branch_data.flat_map do |condition, coverage_branches|
         build_branches_from(condition, coverage_branches)
       end
@@ -187,7 +187,7 @@ module SimpleCov
     end
 
     # Since we are dumping to and loading from JSON, and we have arrays as keys those
-    # don't make their way back to us intact e.g. just as a string or a symbol (currently keys are symbolized).
+    # don't make their way back to us intact e.g. just as a string
     #
     # We should probably do something different here, but as it stands these are
     # our data structures that we write so eval isn't _too_ bad.
@@ -199,9 +199,8 @@ module SimpleCov
       # put them through here.
       return structure if structure.is_a?(Array)
 
-      # as of right now the keys are still symbolized
       # rubocop:disable Security/Eval
-      eval structure.to_s
+      eval structure
       # rubocop:enable Security/Eval
     end
 

--- a/lib/simplecov/useless_results_remover.rb
+++ b/lib/simplecov/useless_results_remover.rb
@@ -2,7 +2,7 @@
 
 module SimpleCov
   #
-  # Selection the files that related to working scope directory of SimpleCov
+  # Select the files that related to working scope directory of SimpleCov
   #
   module UselessResultsRemover
     ROOT_REGX = /\A#{Regexp.escape(SimpleCov.root + File::SEPARATOR)}/io.freeze

--- a/spec/combine/results_combiner_spec.rb
+++ b/spec/combine/results_combiner_spec.rb
@@ -13,34 +13,34 @@ describe SimpleCov::Combine::ResultsCombiner do
 
       @resultset1 = {
         source_fixture("sample.rb") => {
-          lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-          branches: {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
+          "lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
+          "branches" => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
         },
         source_fixture("app/models/user.rb") => {
-          lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-          branches: {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
+          "lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+          "branches" => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
         },
-        source_fixture("app/controllers/sample_controller.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
-        source_fixture("resultset1.rb") => {lines: [1, 1, 1, 1]},
-        source_fixture("parallel_tests.rb") => {lines: [nil, 0, nil, 0]},
-        source_fixture("conditionally_loaded_1.rb") => {lines: [nil, 0, 1]},  # loaded only in the first resultset
-        source_fixture("three.rb") => {lines: [nil, 1, 1]}
+        source_fixture("app/controllers/sample_controller.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+        source_fixture("resultset1.rb") => {"lines" => [1, 1, 1, 1]},
+        source_fixture("parallel_tests.rb") => {"lines" => [nil, 0, nil, 0]},
+        source_fixture("conditionally_loaded_1.rb") => {"lines" => [nil, 0, 1]},  # loaded only in the first resultset
+        source_fixture("three.rb") => {"lines" => [nil, 1, 1]}
       }
 
       @resultset2 = {
-        source_fixture("sample.rb") => {lines: [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]},
+        source_fixture("sample.rb") => {"lines" => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]},
         source_fixture("app/models/user.rb") => {
-          lines: [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
-          branches: {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 1, [:else, 5, 8, 6, 8, 36] => 2}}
+          "lines" => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil],
+          "branches" => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 1, [:else, 5, 8, 6, 8, 36] => 2}}
         },
-        source_fixture("app/controllers/sample_controller.rb") => {lines: [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil]},
-        source_fixture("resultset2.rb") => {lines: [nil, 1, 1, nil]},
-        source_fixture("parallel_tests.rb") => {lines: [nil, nil, 0, 0]},
-        source_fixture("conditionally_loaded_2.rb") => {lines: [nil, 0, 1]},  # loaded only in the second resultset
-        source_fixture("three.rb") => {lines: [nil, 1, 4]}
+        source_fixture("app/controllers/sample_controller.rb") => {"lines" => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil]},
+        source_fixture("resultset2.rb") => {"lines" => [nil, 1, 1, nil]},
+        source_fixture("parallel_tests.rb") => {"lines" => [nil, nil, 0, 0]},
+        source_fixture("conditionally_loaded_2.rb") => {"lines" => [nil, 0, 1]},  # loaded only in the second resultset
+        source_fixture("three.rb") => {"lines" => [nil, 1, 4]}
       }
 
-      @resultset3 = {source_fixture("three.rb") => {lines: [nil, 1, 2]}}
+      @resultset3 = {source_fixture("three.rb") => {"lines" => [nil, 1, 2]}}
     end
 
     context "a merge" do
@@ -49,61 +49,61 @@ describe SimpleCov::Combine::ResultsCombiner do
       end
 
       it "has proper results for sample.rb" do
-        expect(subject[source_fixture("sample.rb")][:lines]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
-        expect(subject[source_fixture("sample.rb")][:branches][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(47)
+        expect(subject[source_fixture("sample.rb")]["lines"]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
+        expect(subject[source_fixture("sample.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(47)
       end
 
       it "has proper results for user.rb" do
-        expect(subject[source_fixture("app/models/user.rb")][:lines]).to eq([nil, 2, 6, 2, nil, nil, 2, 0, nil, nil])
-        expect(subject[source_fixture("app/models/user.rb")][:branches][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(48)
-        expect(subject[source_fixture("app/models/user.rb")][:branches][[:if, 3, 8, 6, 8, 36]][[:else, 5, 8, 6, 8, 36]]).to eq(26)
+        expect(subject[source_fixture("app/models/user.rb")]["lines"]).to eq([nil, 2, 6, 2, nil, nil, 2, 0, nil, nil])
+        expect(subject[source_fixture("app/models/user.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(48)
+        expect(subject[source_fixture("app/models/user.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:else, 5, 8, 6, 8, 36]]).to eq(26)
       end
 
       it "has proper results for sample_controller.rb" do
-        expect(subject[source_fixture("app/controllers/sample_controller.rb")][:lines]).to eq([nil, 4, 2, 1, nil, nil, 2, 0, nil, nil])
+        expect(subject[source_fixture("app/controllers/sample_controller.rb")]["lines"]).to eq([nil, 4, 2, 1, nil, nil, 2, 0, nil, nil])
       end
 
       it "has proper results for resultset1.rb" do
-        expect(subject[source_fixture("resultset1.rb")][:lines]).to eq([1, 1, 1, 1])
+        expect(subject[source_fixture("resultset1.rb")]["lines"]).to eq([1, 1, 1, 1])
       end
 
       it "has proper results for resultset2.rb" do
-        expect(subject[source_fixture("resultset2.rb")][:lines]).to eq([nil, 1, 1, nil])
+        expect(subject[source_fixture("resultset2.rb")]["lines"]).to eq([nil, 1, 1, nil])
       end
 
       it "has proper results for parallel_tests.rb" do
-        expect(subject[source_fixture("parallel_tests.rb")][:lines]).to eq([nil, nil, nil, 0])
+        expect(subject[source_fixture("parallel_tests.rb")]["lines"]).to eq([nil, nil, nil, 0])
       end
 
       it "has proper results for conditionally_loaded_1.rb" do
-        expect(subject[source_fixture("conditionally_loaded_1.rb")][:lines]).to eq([nil, 0, 1])
+        expect(subject[source_fixture("conditionally_loaded_1.rb")]["lines"]).to eq([nil, 0, 1])
       end
 
       it "has proper results for conditionally_loaded_2.rb" do
-        expect(subject[source_fixture("conditionally_loaded_2.rb")][:lines]).to eq([nil, 0, 1])
+        expect(subject[source_fixture("conditionally_loaded_2.rb")]["lines"]).to eq([nil, 0, 1])
       end
 
       it "has proper results for three.rb" do
-        expect(subject[source_fixture("three.rb")][:lines]).to eq([nil, 3, 7])
+        expect(subject[source_fixture("three.rb")]["lines"]).to eq([nil, 3, 7])
       end
     end
   end
 
   it "merges frozen resultsets" do
     resultset1 = {
-      source_fixture("sample.rb").freeze => {lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
-      source_fixture("app/models/user.rb").freeze => {lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
+      source_fixture("sample.rb").freeze => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+      source_fixture("app/models/user.rb").freeze => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
     }
 
     resultset2 = {
-      source_fixture("sample.rb").freeze => {lines: [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]}
+      source_fixture("sample.rb").freeze => {"lines" => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]}
     }
 
     merged_result = SimpleCov::Combine::ResultsCombiner.combine(resultset1, resultset2)
     expect(merged_result.keys).to eq(resultset1.keys)
     expect(merged_result.values.map(&:frozen?)).to eq([false, false])
 
-    expect(merged_result[source_fixture("sample.rb")][:lines]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
-    expect(merged_result[source_fixture("app/models/user.rb")][:lines]).to eq([nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
+    expect(merged_result[source_fixture("sample.rb")]["lines"]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
+    expect(merged_result[source_fixture("app/models/user.rb")]["lines"]).to eq([nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
   end
 end

--- a/spec/combine/results_combiner_spec.rb
+++ b/spec/combine/results_combiner_spec.rb
@@ -56,13 +56,22 @@ describe SimpleCov::Combine::ResultsCombiner do
 
       it "has proper results for sample.rb" do
         expect(subject[source_fixture("sample.rb")]["lines"]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
-        expect(subject[source_fixture("sample.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(47)
+
+        # gotta configure max line so it doesn't get ridiculous
+        # rubocop:disable Style/IfUnlessModifier
+        if SimpleCov.branch_coverage_supported?
+          expect(subject[source_fixture("sample.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(47)
+        end
+        # rubocop:enable Style/IfUnlessModifier
       end
 
       it "has proper results for user.rb" do
         expect(subject[source_fixture("app/models/user.rb")]["lines"]).to eq([nil, 2, 6, 2, nil, nil, 2, 0, nil, nil])
-        expect(subject[source_fixture("app/models/user.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(48)
-        expect(subject[source_fixture("app/models/user.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:else, 5, 8, 6, 8, 36]]).to eq(26)
+
+        if SimpleCov.branch_coverage_supported?
+          expect(subject[source_fixture("app/models/user.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:then, 4, 8, 6, 8, 12]]).to eq(48)
+          expect(subject[source_fixture("app/models/user.rb")]["branches"][[:if, 3, 8, 6, 8, 36]][[:else, 5, 8, 6, 8, 36]]).to eq(26)
+        end
       end
 
       it "has proper results for sample_controller.rb" do

--- a/spec/file_list_spec.rb
+++ b/spec/file_list_spec.rb
@@ -5,9 +5,9 @@ require "helper"
 describe SimpleCov::Result do
   subject do
     original_result = {
-      source_fixture("sample.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
-      source_fixture("app/models/user.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
-      source_fixture("app/controllers/sample_controller.rb") => {lines: [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil]}
+      source_fixture("sample.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+      source_fixture("app/models/user.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+      source_fixture("app/controllers/sample_controller.rb") => {"lines" => [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil]}
     }
     SimpleCov::Result.new(original_result).files
   end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,7 +10,7 @@ require "simplecov"
 SimpleCov.coverage_dir("tmp/coverage")
 
 def source_fixture(filename)
-  File.expand_path(File.join(File.dirname(__FILE__), "fixtures", filename)).to_sym
+  File.expand_path(File.join(File.dirname(__FILE__), "fixtures", filename))
 end
 
 # Taken from http://stackoverflow.com/questions/4459330/how-do-i-temporarily-redirect-stderr-in-ruby

--- a/spec/result_merger_spec.rb
+++ b/spec/result_merger_spec.rb
@@ -13,21 +13,21 @@ describe SimpleCov::ResultMerger do
   describe "with two faked coverage resultsets" do
     before do
       @resultset1 = {
-        source_fixture("sample.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
-        source_fixture("app/models/user.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
-        source_fixture("app/controllers/sample_controller.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
-        source_fixture("resultset1.rb") => {lines: [1, 1, 1, 1]},
-        source_fixture("parallel_tests.rb") => {lines: [nil, 0, nil, 0]},
-        source_fixture("conditionally_loaded_1.rb") => {lines: [nil, 0, 1]} # loaded only in the first resultset
+        source_fixture("sample.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+        source_fixture("app/models/user.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+        source_fixture("app/controllers/sample_controller.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+        source_fixture("resultset1.rb") => {"lines" => [1, 1, 1, 1]},
+        source_fixture("parallel_tests.rb") => {"lines" => [nil, 0, nil, 0]},
+        source_fixture("conditionally_loaded_1.rb") => {"lines" => [nil, 0, 1]} # loaded only in the first resultset
       }
 
       @resultset2 = {
-        source_fixture("sample.rb") => {lines: [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]},
-        source_fixture("app/models/user.rb") => {lines: [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil]},
-        source_fixture("app/controllers/sample_controller.rb") => {lines: [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil]},
-        source_fixture("resultset2.rb") => {lines: [nil, 1, 1, nil]},
-        source_fixture("parallel_tests.rb") => {lines: [nil, nil, 0, 0]},
-        source_fixture("conditionally_loaded_2.rb") => {lines: [nil, 0, 1]} # loaded only in the second resultset
+        source_fixture("sample.rb") => {"lines" => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]},
+        source_fixture("app/models/user.rb") => {"lines" => [nil, 1, 5, 1, nil, nil, 1, 0, nil, nil]},
+        source_fixture("app/controllers/sample_controller.rb") => {"lines" => [nil, 3, 1, nil, nil, nil, 1, 0, nil, nil]},
+        source_fixture("resultset2.rb") => {"lines" => [nil, 1, 1, nil]},
+        source_fixture("parallel_tests.rb") => {"lines" => [nil, nil, 0, 0]},
+        source_fixture("conditionally_loaded_2.rb") => {"lines" => [nil, 0, 1]} # loaded only in the second resultset
       }
     end
 
@@ -63,7 +63,7 @@ describe SimpleCov::ResultMerger do
         end
 
         it "returns a hash containing keys ['result1' and 'result2'] for resultset" do
-          expect(SimpleCov::ResultMerger.resultset.keys.sort).to eq %i[result1 result2]
+          expect(SimpleCov::ResultMerger.resultset.keys.sort).to eq %w[result1 result2]
         end
 
         it "returns proper values for merged_result" do
@@ -96,7 +96,7 @@ describe SimpleCov::ResultMerger do
       SimpleCov::ResultMerger.store_result("a" => [1])
       SimpleCov::ResultMerger.clear_resultset
       new_set = SimpleCov::ResultMerger.resultset
-      expect(new_set).to eq(a: [1])
+      expect(new_set).to eq("a" => [1])
     end
 
     it "synchronizes writes" do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -21,9 +21,9 @@ describe "result" do
 
     let(:original_result) do
       {
-        source_fixture("sample.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
-        source_fixture("app/models/user.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
-        source_fixture("app/controllers/sample_controller.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
+        source_fixture("sample.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+        source_fixture("app/models/user.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+        source_fixture("app/controllers/sample_controller.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
       }
     end
 

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -232,11 +232,11 @@ describe SimpleCov do
 
   describe ".collate" do
     let(:resultset1) do
-      {source_fixture("sample.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]}}
+      {source_fixture("sample.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]}}
     end
 
     let(:resultset2) do
-      {source_fixture("sample.rb") => {lines: [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]}}
+      {source_fixture("sample.rb") => {"lines" => [1, nil, 1, 1, nil, nil, 1, 1, nil, nil]}}
     end
 
     let(:resultset_path) { SimpleCov::ResultMerger.resultset_path }
@@ -270,8 +270,8 @@ describe SimpleCov do
           glob = Dir.glob("#{resultset_folder}/*.final", File::FNM_DOTMATCH)
           SimpleCov.collate glob
 
-          expected = {"result1": {coverage: {source_fixture("sample.rb") => {lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]}}}}
-          collated = JSON.parse(File.read(resultset_path), symbolize_names: true).transform_values { |v| v.reject { |k| k == :timestamp } }
+          expected = {"result1" => {"coverage" => {source_fixture("sample.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]}}}}
+          collated = JSON.parse(File.read(resultset_path)).transform_values { |v| v.reject { |k| k == "timestamp" } }
           expect(collated).to eq(expected)
         end
       end
@@ -290,8 +290,8 @@ describe SimpleCov do
           glob = Dir.glob("#{resultset_folder}/*.final", File::FNM_DOTMATCH)
           SimpleCov.collate glob
 
-          expected = {"result1, result2": {coverage: {source_fixture("sample.rb") => {lines: [1, 1, 2, 2, nil, nil, 2, 2, nil, nil]}}}}
-          collated = JSON.parse(File.read(resultset_path), symbolize_names: true).transform_values { |v| v.reject { |k| k == :timestamp } }
+          expected = {"result1, result2" => {"coverage" => {source_fixture("sample.rb") => {"lines" => [1, 1, 2, 2, nil, nil, 2, 2, nil, nil]}}}}
+          collated = JSON.parse(File.read(resultset_path)).transform_values { |v| v.reject { |k| k == "timestamp" } }
           expect(collated).to eq(expected)
         end
       end

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -4,12 +4,12 @@ require "helper"
 
 describe SimpleCov::SourceFile do
   COVERAGE_FOR_SAMPLE_RB = {
-    lines:       [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, 1, 0, nil, nil, nil],
-    branches: {}
+    "lines" =>       [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, 1, 0, nil, nil, nil],
+    "branches" => {}
   }.freeze
 
   COVERAGE_FOR_SAMPLE_RB_WITH_MORE_LINES = {
-    lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil]
+    "lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil]
   }.freeze
 
   context "a source file initialized with some coverage data" do
@@ -94,8 +94,8 @@ describe SimpleCov::SourceFile do
 
   context "file with branches" do
     COVERAGE_FOR_BRANCHES_RB = {
-      lines:         [1, 1, 1, nil, 1, nil, 1, 0, nil, 1, nil, nil, nil],
-      branches: {
+      "lines" =>         [1, 1, 1, nil, 1, nil, 1, 0, nil, 1, nil, nil, nil],
+      "branches" => {
         [:if, 0, 3, 4, 3, 21] =>
           {[:then, 1, 3, 4, 3, 10] => 0, [:else, 2, 3, 4, 3, 21] => 1},
         [:if, 3, 5, 4, 5, 26] =>
@@ -184,8 +184,8 @@ describe SimpleCov::SourceFile do
 
   context "A file that has inline branches" do
     COVERAGE_FOR_INLINE = {
-      lines:         [1, 1, 1, nil, 1, 1, 0, nil, 1, nil, nil, nil, nil],
-      branches: {
+      "lines" =>         [1, 1, 1, nil, 1, 1, 0, nil, 1, nil, nil, nil, nil],
+      "branches" => {
         [:if, 0, 3, 11, 3, 33] =>
           {[:then, 1, 3, 23, 3, 27] => 1, [:else, 2, 3, 30, 3, 33] => 0},
         [:if, 3, 6, 6, 10, 9] =>
@@ -216,7 +216,7 @@ describe SimpleCov::SourceFile do
   end
 
   context "a file that is never relevant" do
-    COVERAGE_FOR_NEVER_RB = {lines: [nil, nil], branches: {}}.freeze
+    COVERAGE_FOR_NEVER_RB = {"lines" => [nil, nil], "branches" => {}}.freeze
 
     subject do
       SimpleCov::SourceFile.new(source_fixture("never.rb"), COVERAGE_FOR_NEVER_RB)
@@ -236,7 +236,7 @@ describe SimpleCov::SourceFile do
   end
 
   context "a file where nothing is ever executed mixed with skipping #563" do
-    COVERAGE_FOR_SKIPPED_RB = {lines: [nil, nil, nil, nil]}.freeze
+    COVERAGE_FOR_SKIPPED_RB = {"lines" => [nil, nil, nil, nil]}.freeze
 
     subject do
       SimpleCov::SourceFile.new(source_fixture("skipped.rb"), COVERAGE_FOR_SKIPPED_RB)
@@ -252,7 +252,7 @@ describe SimpleCov::SourceFile do
   end
 
   context "a file where everything is skipped and missed #563" do
-    COVERAGE_FOR_SKIPPED_RB_2 = {lines: [nil, nil, 0, nil]}.freeze
+    COVERAGE_FOR_SKIPPED_RB_2 = {"lines" => [nil, nil, 0, nil]}.freeze
 
     subject do
       SimpleCov::SourceFile.new(source_fixture("skipped.rb"), COVERAGE_FOR_SKIPPED_RB_2)
@@ -269,8 +269,8 @@ describe SimpleCov::SourceFile do
 
   context "a file where everything is skipped/irrelevant but executed #563" do
     COVERAGE_FOR_SKIPPED_AND_EXECUTED_RB = {
-      lines: [nil, nil, 1, 1, 0, 0, nil, 0, nil, nil, nil, nil],
-      branches: {
+      "lines" => [nil, nil, 1, 1, 0, 0, nil, 0, nil, nil, nil, nil],
+      "branches" => {
         [:if, 0, 5, 4, 9, 7] =>
           {[:then, 1, 6, 6, 6, 7] => 1, [:else, 2, 8, 6, 8, 7] => 0}
       }
@@ -325,8 +325,8 @@ describe SimpleCov::SourceFile do
 
   context "a file with more complex skipping" do
     COVERAGE_FOR_NOCOV_COMPLEX_RB = {
-      lines:         [nil, nil, 1, 1, nil, 1, nil, nil, nil, 1, nil, nil, 1, nil, nil, 0, nil, 1, nil, 0, nil, nil, 1, nil, nil, nil, nil],
-      branches: {
+      "lines" =>         [nil, nil, 1, 1, nil, 1, nil, nil, nil, 1, nil, nil, 1, nil, nil, 0, nil, 1, nil, 0, nil, nil, 1, nil, nil, nil, nil],
+      "branches" => {
         [:if, 0, 6, 4, 11, 7] =>
           {[:then, 1, 7, 6, 7, 7] => 0, [:else, 2, 10, 6, 10, 7] => 1},
         [:if, 3, 13, 4, 13, 24] =>
@@ -386,8 +386,8 @@ describe SimpleCov::SourceFile do
 
   context "a file with nested branches" do
     COVERAGE_FOR_NESTED_BRANCHES_RB = {
-      lines:         [nil, nil, 1, 1, 1, 1, 1, 1, nil, nil, 0, nil, nil, nil, nil],
-      branches: {
+      "lines" =>         [nil, nil, 1, 1, 1, 1, 1, 1, nil, nil, 0, nil, nil, nil, nil],
+      "branches" => {
         [:while, 0, 7, 8, 7, 31] =>
           {[:body, 1, 7, 8, 7, 16] => 2},
         [:if, 2, 6, 6, 9, 9] =>
@@ -422,8 +422,8 @@ describe SimpleCov::SourceFile do
 
   context "a file with case" do
     COVERAGE_FOR_CASE_STATEMENT_RB = {
-      lines:         [1, 1, 1, nil, 0, nil, 1, nil, 0, nil, 0, nil, nil, nil],
-      branches: {
+      "lines" =>         [1, 1, 1, nil, 0, nil, 1, nil, 0, nil, 0, nil, nil, nil],
+      "branches" => {
         [:case, 0, 3, 4, 12, 7] => {
           [:when, 1, 5, 6, 5, 10] => 0,
           [:when, 2, 7, 6, 7, 10] => 1,
@@ -465,8 +465,8 @@ describe SimpleCov::SourceFile do
 
   context "a file with case without else" do
     COVERAGE_FOR_CASE_WITHOUT_ELSE_STATEMENT_RB = {
-      lines:         [1, 1, 1, nil, 0, nil, 1, nil, 0, nil, nil, nil],
-      branches: {
+      "lines" =>         [1, 1, 1, nil, 0, nil, 1, nil, 0, nil, nil, nil],
+      "branches" => {
         [:case, 0, 3, 4, 10, 7] => {
           [:when, 1, 5, 6, 5, 10] => 0,
           [:when, 2, 7, 6, 7, 10] => 1,
@@ -512,8 +512,8 @@ describe SimpleCov::SourceFile do
 
   context "a file with if/elsif" do
     COVERAGE_FOR_ELSIF_RB = {
-      lines: [1, 1, 1, 0, 1, 0, 1, 1, nil, 0, nil, nil, nil],
-      branches: {
+      "lines" => [1, 1, 1, 0, 1, 0, 1, 1, nil, 0, nil, nil, nil],
+      "branches" => {
         [:if, 0, 7, 4, 10, 10] =>
           {[:then, 1, 8, 6, 8, 10] => 1, [:else, 2, 10, 6, 10, 10] => 0},
         [:if, 3, 5, 4, 10, 10] =>
@@ -550,8 +550,8 @@ describe SimpleCov::SourceFile do
 
   context "the branch tester script" do
     COVERAGE_FOR_BRANCH_TESTER_RB = {
-      lines:         [nil, nil, 1, 1, nil, 1, nil, 1, 1, nil, nil, 1, 0, nil, nil, 1, 0, nil, 1, nil, nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, 1, 1, nil, 0, nil, 1, 1, 0, 0, 1, 5, 0, 0, nil, 0, nil, 0, nil, nil, nil],
-      branches: {
+      "lines" =>         [nil, nil, 1, 1, nil, 1, nil, 1, 1, nil, nil, 1, 0, nil, nil, 1, 0, nil, 1, nil, nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, 1, 1, nil, 0, nil, 1, 1, 0, 0, 1, 5, 0, 0, nil, 0, nil, 0, nil, nil, nil],
+      "branches" => {
         [:if, 0, 4, 0, 4, 19] =>
           {[:then, 1, 4, 12, 4, 15] => 0, [:else, 2, 4, 18, 4, 19] => 1},
         [:unless, 3, 6, 0, 6, 23] =>

--- a/spec/useless_results_remover_spec.rb
+++ b/spec/useless_results_remover_spec.rb
@@ -8,12 +8,12 @@ describe SimpleCov::UselessResultsRemover do
   let(:result_set) do
     {
       gem_file_path => {
-        lines: [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-        branches: {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
+        "lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
+        "branches" => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
       },
       source_fixture("app/models/user.rb") => {
-        lines: [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-        branches: {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
+        "lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+        "branches" => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
       }
     }
   end

--- a/spec/useless_results_remover_spec.rb
+++ b/spec/useless_results_remover_spec.rb
@@ -4,6 +4,7 @@ require "helper"
 
 describe SimpleCov::UselessResultsRemover do
   let(:gem_file_path) { "usr/bin/lib/2.5.0/gems/sample-gem/sample.rb" }
+  let(:source_path) { source_fixture("app/models/user.rb") }
 
   let(:result_set) do
     {
@@ -11,7 +12,7 @@ describe SimpleCov::UselessResultsRemover do
         "lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
         "branches" => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
       },
-      source_fixture("app/models/user.rb") => {
+      source_path => {
         "lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
         "branches" => {[:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 47, [:else, 5, 8, 6, 8, 36] => 24}}
       }
@@ -24,6 +25,11 @@ describe SimpleCov::UselessResultsRemover do
 
   it "Result ignore gem file path from result set" do
     expect(result_set[gem_file_path]).to be_kind_of(Hash)
-    expect(subject[gem_file_path]).to be_nil
+    expect(subject).not_to have_key(gem_file_path)
+  end
+
+  it "still retains the app path" do
+    expect(subject).to have_key(source_path)
+    expect(subject[source_path]["lines"]).to be_kind_of(Array)
   end
 end


### PR DESCRIPTION
A lot of them we convered back to strings anyhow, plus with
frozen string literal the gains are negligible anyhow.

Also, always symbolizing everything in the JSON.parse was a bit
of an overkill especially when you imagine a code base with lots
of files and lots of branches we could easily contribute to
blowing up memory considerably/beyond an accepatable threshhold.