### PR TITLE
Fix flaky by utilizing capybara waiting behaviour

### DIFF
--- a/features/step_definitions/html_steps.rb
+++ b/features/step_definitions/html_steps.rb
@@ -60,8 +60,7 @@ end
 When /^I open the detailed view for "(.+)"$/ do |file_path|
   click_on(file_path)
 
-  header_text = page.find(".header h3", visible: true).text
-  expect(header_text).to eq file_path
+  expect(page).to have_css(".header h3", visible: true, text: file_path)
 end
 
 Then /^I should see coverage branch data like "(.+)"$/ do |text|


### PR DESCRIPTION
In the previous version we got the node and its text and then
did a manual check. The title might not have changed at that
time.
Using the special method we use capybara's built in waiting
capabilities and shouldn't be flaky anymore.