### PR TITLE
Adapt old resultset.jsons instead of just warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.18.0.beta3 (unreleased)
+========================
+
+## Enhancements
+* Instead of ignoring old `.resultset.json`s that are inside the merge timeout, adapt and respect them
+
+## Bugfixes
+* Remove the constant warning printing if you still have a `.resultset.json` in pre 0.18 layout that is within your merge timeout
+
 0.18.0.beta2 (2020-01-19)
 ===================
 

--- a/features/old_version_json.feature
+++ b/features/old_version_json.feature
@@ -22,4 +22,3 @@ Feature:
       | name      | coverage | files |
       | All Files | 88.89%    | 2     |
     And I should see a line coverage summary of 8/9
-    And the mismatched format warning should have been printed

--- a/features/step_definitions/old_coverage_json_steps.rb
+++ b/features/step_definitions/old_coverage_json_steps.rb
@@ -19,7 +19,3 @@ Given "the timestamp in the .resultset.json is current" do
     File.write(RESULTSET_JSON_PATH, JSON.pretty_generate(resultset_hash))
   end
 end
-
-Then "the mismatched format warning should have been printed" do
-  expect(all_stderr).to match /Merg.*format.*ignore.*bug/im
-end

--- a/lib/simplecov/combine/results_combiner.rb
+++ b/lib/simplecov/combine/results_combiner.rb
@@ -34,11 +34,6 @@ module SimpleCov
       # @return [Hash]
       #
       def combine_result_sets(combined_results, result)
-        unless correct_format?(result)
-          warn_wrong_format
-          return combined_results
-        end
-
         results_files = combined_results.keys | result.keys
 
         results_files.each_with_object({}) do |file_name, file_combination|
@@ -47,41 +42,6 @@ module SimpleCov
             result[file_name]
           )
         end
-      end
-
-      # We might start a run of a new simplecov version with a new format stored while
-      # there is still a recent file like this lying around. If it's recent enough (
-      # see merge_timeout) it will end up here. In order not to crash against this
-      # we need to do some basic checking of the format of data we expect and
-      # otherwise ignore it. See #820
-      #
-      # Currently correct format is:
-      # { file_path_string => {coverage_criterion => coverage_date}}
-      #
-      # Internal use/reliance only.
-      def correct_format?(result)
-        result.empty? || matches_current_format?(result)
-      end
-
-      def matches_current_format?(result)
-        # I so wish I could already use pattern matching
-        key, data = result.first
-
-        key.is_a?(String) && second_level_choice_of_criterion?(data)
-      end
-
-      SECOND_LEVEL_KEYS = %w[lines branches].freeze
-      def second_level_choice_of_criterion?(data)
-        second_level_key, = data.first
-
-        SECOND_LEVEL_KEYS.member?(second_level_key)
-      end
-
-      def warn_wrong_format
-        warn "Merging results, encountered an incorrectly formatted value. "\
-          "This value was ignored.\nIf you just upgraded simplecov this is "\
-          "likely due to a changed file format. If this happens again please "\
-          "file a bug. https://github.com/colszowka/simplecov/issues"
       end
 
       #

--- a/spec/combine/results_combiner_spec.rb
+++ b/spec/combine/results_combiner_spec.rb
@@ -121,26 +121,4 @@ describe SimpleCov::Combine::ResultsCombiner do
     expect(merged_result[source_fixture("sample.rb")]["lines"]).to eq([1, 1, 2, 2, nil, nil, 2, 2, nil, nil])
     expect(merged_result[source_fixture("app/models/user.rb")]["lines"]).to eq([nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
   end
-
-  context "outdated file formats" do
-    it "warns when trying to work with outdated file formats but returns a good value" do
-      old_resultset = {source_fixture("three.rb") => [nil, 1, 2]}
-      expect(described_class).to receive(:warn_wrong_format)
-
-      merged_result = described_class.combine(old_resultset)
-
-      expect(merged_result).to eq({})
-    end
-
-    it "warns when trying to work with outdated file formats but still merges" do
-      old_resultset = {source_fixture("three.rb") => [nil, 1, 2]}
-      good_resultset = {source_fixture("three.rb") => {"lines" => [1, 0, nil]}}
-
-      expect(described_class).to receive(:warn_wrong_format)
-
-      merged_result = described_class.combine(old_resultset, good_resultset)
-
-      expect(merged_result).to eq(good_resultset)
-    end
-  end
 end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -2,7 +2,7 @@
 
 require "helper"
 
-describe "result" do
+describe SimpleCov::Result do
   context "with a (mocked) Coverage.result" do
     before do
       @prev_filters = SimpleCov.filters
@@ -204,6 +204,16 @@ describe "result" do
           expect(files).to be_a SimpleCov::FileList
         end
       end
+    end
+  end
+
+  context "with outdated result format" do
+    it "adapts pre 0.18 results correctly to a new result format" do
+      old_resultset = {source_fixture("three.rb") => [nil, 1, 2]}
+
+      expect(described_class.new(old_resultset).original_result).to eq(
+        source_fixture("three.rb") => {"lines" => [nil, 1, 2]}
+      )
     end
   end
 end


### PR DESCRIPTION
After discussion with @deivid-rodriguez I realized that adapting
the result isn't actually that difficult and it's actually
a better solution to my current problem (that the warning
gets printed multiple times).

Yes, one could have moved the code around so that wrong format
results wouldn't even be written back, but Deivid was right
it might be useful for some people to keep the result and it's
actually not more complicated than sorting them out.

So this change fixes the multiple warnings as well as keeping
old results around.

Also moved the checking/changing to a fairly central place to
safeguard against old results flying in from somewhere else.