### PR TITLE
Unify statistics computation and access to coverage data

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -416,6 +416,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__)))
 require "set"
 require "simplecov/configuration"
 SimpleCov.extend SimpleCov::Configuration
+require "simplecov/coverage_data"
 require "simplecov/exit_codes"
 require "simplecov/profiles"
 require "simplecov/source_file/line"

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -414,6 +414,7 @@ end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__)))
 require "set"
+require "forwardable"
 require "simplecov/configuration"
 SimpleCov.extend SimpleCov::Configuration
 require "simplecov/coverage_data"

--- a/lib/simplecov/coverage_data.rb
+++ b/lib/simplecov/coverage_data.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SimpleCov
+  # Holds the individual data of a coverage result.
+  #
+  # This is uniform across coverage criteria as they all have:
+  #
+  # * total - how many things to cover there are (total relevant loc/branches)
+  # * covered - how many of the coverables are hit
+  # * missed - how many of the coverables are missed
+  # * percent - percentage as covered/missed
+  # * strength - average hits per/coverable (will not exist for one shot lines format)
+  class CoverageData
+    attr_reader :total, :covered, :missed, :strength, :percent
+
+    # Requires only covered, missed and strength to be initialized.
+    #
+    # Other values are computed by this class.
+    def initialize(covered:, missed:, strength: nil)
+      @covered  = covered
+      @missed   = missed
+      @strength = strength
+      @total    = covered + missed
+      @percent  = compute_percent(covered, total)
+    end
+
+    def compute_percent(covered, total)
+      return 100.0 if total.zero?
+
+      Float(covered * 100.0 / total)
+    end
+  end
+end

--- a/lib/simplecov/coverage_data.rb
+++ b/lib/simplecov/coverage_data.rb
@@ -44,13 +44,13 @@ module SimpleCov
     def compute_percent(covered, total)
       return 100.0 if total.zero?
 
-      Float(covered * 100.0 / total)
+      covered * 100.0 / total
     end
 
     def compute_strength(total_strength, total)
       return 0.0 if total.zero?
 
-      Float(total_strength.to_f / total)
+      total_strength.to_f / total
     end
   end
 end

--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -3,7 +3,26 @@
 module SimpleCov
   # An array of SimpleCov SourceFile instances with additional collection helper
   # methods for calculating coverage across them etc.
-  class FileList < Array
+  class FileList
+    include Enumerable
+    extend Forwardable
+
+    def_delegators :@files,
+                   # For Enumerable
+                   :each,
+                   # also delegating methods implemented in Enumerable as they have
+                   # custom Array implementations which are presumably better/more
+                   # resource efficient
+                   :size, :map,
+                   # surprisingly not in Enumerable
+                   :empty?, :length,
+                   # still act like we're kinda an array
+                   :to_a, :to_ary
+
+    def initialize(files)
+      @files = files
+    end
+
     def coverage
       {
         **line_coverage,

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -110,7 +110,7 @@ module SimpleCov
     #
     # Return the relevant branches to source file
     def total_branches
-      covered_branches + missed_branches
+      @total_branches ||= covered_branches + missed_branches
     end
 
     #

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -117,7 +117,7 @@ module SimpleCov
     def covered_strength
       return 0.0 if relevant_lines.zero?
 
-      (lines_strength / relevant_lines.to_f).round(1)
+      lines_strength / relevant_lines.to_f
     end
 
     def no_lines?

--- a/spec/coverage_data_spec.rb
+++ b/spec/coverage_data_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "helper"
+
+RSpec.describe SimpleCov::CoverageData do
+  describe ".new" do
+    it "retains statistics and computes new ones" do
+      data = described_class.new(covered: 4, missed: 6, total_strength: 14)
+
+      expect(data.covered).to eq 4
+      expect(data.missed).to eq 6
+
+      expect(data.total).to eq 10
+      expect(data.percent).to eq 40.0
+      expect(data.strength).to eq 1.4
+    end
+
+    it "can omit the total strength defaulting to 0.0" do
+      data = described_class.new(covered: 4, missed: 6, total_strength: 0.0)
+
+      expect(data.strength).to eq 0.0
+    end
+
+    it "can deal with it if everything is 0" do
+      data = described_class.new(covered: 0, missed: 0, total_strength: 0.0)
+
+      expect_all_empty(data)
+    end
+  end
+
+  describe ".from" do
+    it "returns an all 0s coverage data if there is no data" do
+      data = described_class.from([])
+
+      expect_all_empty(data)
+    end
+
+    it "returns all empty data when initialized with a couple of empty results" do
+      data = described_class.from([empty_data, empty_data])
+
+      expect_all_empty(data)
+    end
+
+    it "produces sensible total results" do
+      data = described_class.from(
+        [
+          described_class.new(covered: 3, missed: 4, total_strength: 54),
+          described_class.new(covered: 0, missed: 13, total_strength: 0),
+          described_class.new(covered: 37, missed: 0, total_strength: 682)
+        ]
+      )
+
+      expect(data.covered).to eq 40
+      expect(data.missed).to eq 17
+      expect(data.total).to eq 57
+      expect(data.percent).to be_within(0.01).of(70.18)
+      expect(data.strength).to be_within(0.01).of(12.91)
+    end
+  end
+
+  def empty_data
+    described_class.new(covered: 0, missed: 0, total_strength: 0.0)
+  end
+
+  def expect_all_empty(data)
+    expect(data.covered).to eq 0
+    expect(data.missed).to eq 0
+
+    expect(data.total).to eq 0
+    # might be counter intuitive but think of it as "we covered everything we could"
+    expect(data.percent).to eq 100.0
+    expect(data.strength).to eq 0.0
+  end
+end

--- a/spec/file_list_spec.rb
+++ b/spec/file_list_spec.rb
@@ -5,9 +5,18 @@ require "helper"
 describe SimpleCov::Result do
   subject do
     original_result = {
-      source_fixture("sample.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
-      source_fixture("app/models/user.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
-      source_fixture("app/controllers/sample_controller.rb") => {"lines" => [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil]}
+      source_fixture("sample.rb") => {
+        "lines" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
+        "branches" => {}
+      },
+      source_fixture("app/models/user.rb") => {
+        "lines" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
+        "branches" => {}
+      },
+      source_fixture("app/controllers/sample_controller.rb") => {
+        "lines" => [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil],
+        "branches" => {}
+      }
     }
     SimpleCov::Result.new(original_result).files
   end

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -247,7 +247,7 @@ describe SimpleCov::SourceFile do
     end
 
     it "has 0.0 covered_percent" do
-      expect(subject.covered_percent).to eq 0.0
+      expect(subject.covered_percent).to eq 100.0
     end
   end
 
@@ -263,7 +263,12 @@ describe SimpleCov::SourceFile do
     end
 
     it "has 0.0 covered_percent" do
-      expect(subject.covered_percent).to eq 0.0
+      expect(subject.covered_percent).to eq 100.0
+    end
+
+    it "has no covered or missed lines" do
+      expect(subject.covered_lines).to be_empty
+      expect(subject.missed_lines).to be_empty
     end
   end
 
@@ -302,7 +307,7 @@ describe SimpleCov::SourceFile do
       end
 
       it "has 0.0 covered_percent" do
-        expect(subject.covered_percent).to eq 0.0
+        expect(subject.covered_percent).to eq 100.0
       end
     end
 


### PR DESCRIPTION
The bigger purpose is multi step where the access to coverage data is normalized and hence methods that work with expecting a minimum amount of coverage and formatters can work with the known good same data base as opposed to memoizing all different method names.

This is good enough as an intermediate PR.

By virtue of unifying coverage computation we also get rid of inconsistencies like #565 

While I was there and happily modified things, I also got rid off inheriting from a core class (Array).

* [x] missing unit tests for my new class (but everything should still be tested through the other tests that did this anyhow) - normally I TDD but here I was anxious/unsure how the end result would look like/work (and it indeed changed purpose/scope multiple time)