### PR TITLE
attempt at fixing flaky

### DIFF
--- a/features/step_definitions/html_steps.rb
+++ b/features/step_definitions/html_steps.rb
@@ -58,7 +58,7 @@ Then /^I should see a (.+) coverage summary of (\d+)\/(\d+)( for the file)?$/ do
 end
 
 When /^I open the detailed view for "(.+)"$/ do |file_path|
-  click_on(file_path)
+  click_link(file_path, class: "src_link", title: file_path)
 
   expect(page).to have_css(".header h3", visible: true, text: file_path)
 end


### PR DESCRIPTION
This is the flaky:

```
expected to find visible css ".header h3" with text "lib/faked_project/some_class.rb" but there were no matches. Also found "lib/faked_project/framework_specific.rb", "lib/faked_project/meta_magic.rb", "lib/faked_project/some_class.rb", "spec/forking_spec.rb", "spec/meta_magic_spec.rb", "spec/some_class_spec.rb", "lib/faked_project.rb", which matched the selector but not all filters.  (RSpec::Expectations::ExpectationNotMetError)
./features/step_definitions/html_steps.rb:63:in `/^I open the detailed view for "(.+)"$/'
features/branch_coverage.feature:30:in `When I open the detailed view for "lib/faked_project/some_class.rb"'

Failing Scenarios:
cucumber features/branch_coverage.feature:6 # Scenario: 
```

Couldn't reproduce locally. As all steps before the one that fails succeed and they just do basic checks/no interactions I assume the page is in a good state.

Which then comes down to:

```
When /^I open the detailed view for "(.+)"$/ do |file_path|
  click_on(file_path)

  expect(page).to have_css(".header h3", visible: true, text: file_path)
end
```

It's already using the right/lazy way to do assertions. As the error message says it found matches for `.header h3` with the text I'm expecting I'm guessing this comes down to being visible or not - which is fair because it's only visible after it's been clicked. 

So assumption: click went wrong.

Fix: ???

I tried making the matching more precise (not allow buttons, take the class into account as well). Not sure if that will help though.

If this keeps failing we have 2 options I guess:

* don't care if it's visible just check it's correctly in the DOM (a huge part of our tests works like that btw)
* make a retrying version that clicks and checks and clicks and checks a couple of times

@deivid-rodriguez any further ideas are welcome :grin: 