### PR TITLE
Define minimum coverage by coverage criterion

### DIFF
--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -16,7 +16,7 @@ Feature:
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Coverage (88.09%) is below the expected minimum coverage (90.00%)."
+    And the output should contain "Line coverage (88.09%) is below the expected minimum coverage (90.00%)."
     And the output should contain "SimpleCov failed with exit 2"
 
   Scenario:
@@ -31,7 +31,7 @@ Feature:
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Coverage (88.09%) is below the expected minimum coverage (88.10%)."
+    And the output should contain "Line coverage (88.09%) is below the expected minimum coverage (88.10%)."
     And the output should contain "SimpleCov failed with exit 2"
 
   Scenario:
@@ -58,3 +58,21 @@ Feature:
 
     When I run `bundle exec rake test`
     Then the exit status should be 0
+
+  @branch_coverage
+  Scenario: Works together with branch coverage and the new criterion announcing both failures
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        enable_coverage :branch
+        minimum_coverage line: 90, branch: 80
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should contain "Line coverage (88.09%) is below the expected minimum coverage (90.00%)."
+    And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
+    And the output should contain "SimpleCov failed with exit 2"

--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -23,18 +23,18 @@ module SimpleCov
       @files = files
     end
 
-    def coverage
-      @coverage ||= compute_coverage
+    def coverage_statistics
+      @coverage_statistics ||= compute_coverage_statistics
     end
 
     # Returns the count of lines that have coverage
     def covered_lines
-      coverage[:line]&.covered
+      coverage_statistics[:line]&.covered
     end
 
     # Returns the count of lines that have been missed
     def missed_lines
-      coverage[:line]&.missed
+      coverage_statistics[:line]&.missed
     end
 
     # Returns the count of lines that are not relevant for coverage
@@ -64,46 +64,46 @@ module SimpleCov
 
     # Returns the overall amount of relevant lines of code across all files in this list
     def lines_of_code
-      coverage[:line]&.total
+      coverage_statistics[:line]&.total
     end
 
     # Computes the coverage based upon lines covered and lines missed
     # @return [Float]
     def covered_percent
-      coverage[:line]&.percent
+      coverage_statistics[:line]&.percent
     end
 
     # Computes the strength (hits / line) based upon lines covered and lines missed
     # @return [Float]
     def covered_strength
-      coverage[:line]&.strength
+      coverage_statistics[:line]&.strength
     end
 
     # Return total count of branches in all files
     def total_branches
-      coverage[:branch]&.total
+      coverage_statistics[:branch]&.total
     end
 
     # Return total count of covered branches
     def covered_branches
-      coverage[:branch]&.covered
+      coverage_statistics[:branch]&.covered
     end
 
     # Return total count of covered branches
     def missed_branches
-      coverage[:branch]&.missed
+      coverage_statistics[:branch]&.missed
     end
 
     def branch_covered_percent
-      coverage[:branch]&.percent
+      coverage_statistics[:branch]&.percent
     end
 
   private
 
-    def compute_coverage
+    def compute_coverage_statistics
       total_coverage_statistics = @files.each_with_object(line: [], branch: []) do |file, together|
-        together[:line] << file.coverage[:line]
-        together[:branch] << file.coverage[:branch] if SimpleCov.branch_coverage?
+        together[:line] << file.coverage_statistics[:line]
+        together[:branch] << file.coverage_statistics[:branch] if SimpleCov.branch_coverage?
       end
 
       coverage_statistics = {line: CoverageStatistics.from(total_coverage_statistics[:line])}

--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -20,7 +20,7 @@ module SimpleCov
     # Explicitly set the command name that was used for this coverage result. Defaults to SimpleCov.command_name
     attr_writer :command_name
 
-    def_delegators :files, :covered_percent, :covered_percentages, :least_covered_file, :covered_strength, :covered_lines, :missed_lines, :total_branches, :covered_branches, :missed_branches
+    def_delegators :files, :covered_percent, :covered_percentages, :least_covered_file, :covered_strength, :covered_lines, :missed_lines, :total_branches, :covered_branches, :missed_branches, :coverage_statistics
     def_delegator :files, :lines_of_code, :total_lines
 
     # Initialize a new SimpleCov::Result from given Coverage.result (a Hash of filenames each containing an array of

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -29,11 +29,11 @@ module SimpleCov
     end
     alias source src
 
-    def coverage
-      @coverage ||=
+    def coverage_statistics
+      @coverage_statistics ||=
         {
-          **line_coverage,
-          **branch_coverage
+          **line_coverage_statistics,
+          **branch_coverage_statistics
         }
     end
 
@@ -68,7 +68,7 @@ module SimpleCov
 
     # Returns the number of relevant lines (covered + missed)
     def lines_of_code
-      coverage[:line]&.total
+      coverage_statistics[:line]&.total
     end
 
     # Access SimpleCov::SourceFile::Line source lines by line number
@@ -78,11 +78,11 @@ module SimpleCov
 
     # The coverage for this file in percent. 0 if the file has no coverage lines
     def covered_percent
-      coverage[:line]&.percent
+      coverage_statistics[:line]&.percent
     end
 
     def covered_strength
-      coverage[:line]&.strength
+      coverage_statistics[:line]&.strength
     end
 
     def no_lines?
@@ -104,7 +104,7 @@ module SimpleCov
     end
 
     def branches_coverage_percent
-      coverage[:branch]&.percent
+      coverage_statistics[:branch]&.percent
     end
 
     #
@@ -278,7 +278,7 @@ module SimpleCov
       )
     end
 
-    def line_coverage
+    def line_coverage_statistics
       {
         line: CoverageStatistics.new(
           total_strength: lines_strength,
@@ -288,7 +288,7 @@ module SimpleCov
       }
     end
 
-    def branch_coverage
+    def branch_coverage_statistics
       {
         branch: CoverageStatistics.new(
           covered: covered_branches.size,

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -48,6 +48,10 @@ describe SimpleCov::Configuration do
     end
 
     describe "#minimum_coverage" do
+      after :each do
+        config.clear_coverage_criteria
+      end
+
       it "does not warn you about your usage" do
         expect(config).not_to receive(:warn)
         config.minimum_coverage(100.00)
@@ -56,6 +60,44 @@ describe SimpleCov::Configuration do
       it "warns you about your usage" do
         expect(config).to receive(:warn).with("The coverage you set for minimum_coverage is greater than 100%")
         config.minimum_coverage(100.01)
+      end
+
+      it "sets the right converage value when called with a number" do
+        config.minimum_coverage(80)
+
+        expect(config.minimum_coverage).to eq line: 80
+      end
+
+      it "sets the right coverage when called with a hash of just line" do
+        config.minimum_coverage line: 85.0
+
+        expect(config.minimum_coverage).to eq line: 85.0
+      end
+
+      it "sets the right coverage when called with a hash of just branch" do
+        config.enable_coverage :branch
+        config.minimum_coverage branch: 85.0
+
+        expect(config.minimum_coverage).to eq branch: 85.0
+      end
+
+      it "sets the right coverage when called withboth line and branch" do
+        config.enable_coverage :branch
+        config.minimum_coverage branch: 85.0, line: 95.4
+
+        expect(config.minimum_coverage).to eq branch: 85.0, line: 95.4
+      end
+
+      it "raises when trying to set branch coverage but not enabled" do
+        expect do
+          config.minimum_coverage branch: 42
+        end.to raise_error(/branch.*disabled/i)
+      end
+
+      it "raises when unknown coverage criteria provided" do
+        expect do
+          config.minimum_coverage unknown: 42
+        end.to raise_error(/unsupported.*unknown/i)
       end
     end
 


### PR DESCRIPTION
It's missing a feature test for usage with branch coverage and/or branch/line coverage combined (maybe also some unit tests but that exit code handling is kinda gnarly).

cc: @tycooon ;) I think for initial release it's just gonna be this one and we can add in minimum_coverage_by_file/maximum_coverage_drop etc. later

