### PR TITLE
Fix crashes with uneven number of nocov instructions

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -164,9 +164,10 @@ module SimpleCov
     def build_no_cov_chunks
       no_cov_lines = src.map.with_index(1).select { |line, _index| LinesClassifier.no_cov_line?(line) }
 
-      warn "uneven number of nocov comments detected" if no_cov_lines.size.odd?
-
       no_cov_lines.each_slice(2).map do |(_line_start, index_start), (_line_end, index_end)|
+        # if we have an uneven number of nocovs we assume they go to the
+        # end of the file
+        index_end ||= src.size
         index_start..index_end
       end
     end

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -162,12 +162,15 @@ module SimpleCov
     end
 
     def build_no_cov_chunks
-      no_cov_lines = src.map.with_index(1).select { |line, _index| LinesClassifier.no_cov_line?(line) }
+      no_cov_lines = src.map.with_index(1).select { |line_src, _index| LinesClassifier.no_cov_line?(line_src) }
 
-      no_cov_lines.each_slice(2).map do |(_line_start, index_start), (_line_end, index_end)|
-        # if we have an uneven number of nocovs we assume they go to the
-        # end of the file
-        index_end ||= src.size
+      # if we have an uneven number of nocovs we assume they go to the
+      # end of the file, the source doesn't really matter
+      # Can't deal with this within the each_slice due to differing
+      # behavior in JRuby: jruby/jruby#6048
+      no_cov_lines << ["", src.size] if no_cov_lines.size.odd?
+
+      no_cov_lines.each_slice(2).map do |(_line_src_start, index_start), (_line_src_end, index_end)|
         index_start..index_end
       end
     end

--- a/spec/fixtures/coverer.rb
+++ b/spec/fixtures/coverer.rb
@@ -2,6 +2,8 @@
 
 require "coverage"
 Coverage.start(:all)
-require_relative "branch_tester_script"
+require_relative "uneven_nocovs"
+
+UnevenNocov.call(42)
 
 p Coverage.result

--- a/spec/fixtures/single_nocov.rb
+++ b/spec/fixtures/single_nocov.rb
@@ -1,0 +1,14 @@
+# :nocov:
+module SingleNocov
+  def self.call(arg)
+    if arg.odd?
+      :odd
+    elsif arg == 30
+      :mop
+    elsif arg == 42
+      :yay
+    else
+      :nay
+    end
+  end
+end

--- a/spec/fixtures/uneven_nocovs.rb
+++ b/spec/fixtures/uneven_nocovs.rb
@@ -1,0 +1,16 @@
+module UnevenNocov
+  def self.call(arg)
+    # :nocov:
+    if arg.odd?
+      :odd
+    elsif arg == 30
+      :mop
+    # :nocov:
+    elsif arg == 42
+      :yay
+    # :nocov:
+    else
+      :nay
+    end
+  end
+end


### PR DESCRIPTION
Fixes #846
We just assume them to go until the end. Test against a full nocov
for the file as well as a small mixture.

If this passes on CI I'll cut a new bugfix release.

cc: @DannyBen 