### PR TITLE
Refactor CoverageStatistics class & specs and fix typos

### DIFF
--- a/lib/simplecov/combine.rb
+++ b/lib/simplecov/combine.rb
@@ -9,8 +9,8 @@ module SimpleCov
     #
     # Combine two coverage based on the given combiner_module.
     #
-    # Combiners should always be called throught his interface,
-    # as it takes care of short circuting of one of the coverages is nil.
+    # Combiners should always be called through this interface,
+    # as it takes care of short-circuiting of one of the coverages is nil.
     #
     # @return [Hash]
     def combine(combiner_module, coverage_a, coverage_b)

--- a/lib/simplecov/combine/branches_combiner.rb
+++ b/lib/simplecov/combine/branches_combiner.rb
@@ -10,9 +10,9 @@ module SimpleCov
     module_function
 
       #
-      # Return merged branches or the existed branche if other is missing.
+      # Return merged branches or the existed brach if other is missing.
       #
-      # Branches inside files are always same if they exists, the difference only in coverage count.
+      # Branches inside files are always same if they exist, the difference only in coverage count.
       # Branch coverage report for any conditional case is built from hash, it's key is a condition and
       # it's body is a hash << keys from condition and value is coverage rate >>.
       # ex: branches =>{ [:if, 3, 8, 6, 8, 36] => {[:then, 4, 8, 6, 8, 12] => 1, [:else, 5, 8, 6, 8, 36]=>2}, other conditions...}

--- a/lib/simplecov/coverage_statistics.rb
+++ b/lib/simplecov/coverage_statistics.rb
@@ -19,7 +19,7 @@ module SimpleCov
           [
             covered + file_coverage_statistics.covered,
             missed + file_coverage_statistics.missed,
-            # gotta remultiply with loc because files have different strenght and loc
+            # gotta remultiply with loc because files have different strength and loc
             # giving them a different "weight" in total
             total_strength + (file_coverage_statistics.strength * file_coverage_statistics.total)
           ]
@@ -35,22 +35,22 @@ module SimpleCov
       @covered  = covered
       @missed   = missed
       @total    = covered + missed
-      @percent  = compute_percent(covered)
-      @strength = compute_strength(total_strength)
+      @percent  = compute_percent(covered, missed, total)
+      @strength = compute_strength(total_strength, total)
     end
 
   private
 
-    def compute_percent(covered)
-      return 100.0 if @missed.zero?
+    def compute_percent(covered, missed, total)
+      return 100.0 if missed.zero?
 
-      covered * 100.0 / @total
+      covered * 100.0 / total
     end
 
-    def compute_strength(total_strength)
-      return 0.0 if @total.zero?
+    def compute_strength(total_strength, total)
+      return 0.0 if total.zero?
 
-      total_strength.to_f / @total
+      total_strength.to_f / total
     end
   end
 end

--- a/lib/simplecov/coverage_statistics.rb
+++ b/lib/simplecov/coverage_statistics.rb
@@ -35,22 +35,22 @@ module SimpleCov
       @covered  = covered
       @missed   = missed
       @total    = covered + missed
-      @percent  = compute_percent(covered, total)
-      @strength = compute_strength(total_strength, @total)
+      @percent  = compute_percent(covered)
+      @strength = compute_strength(total_strength)
     end
 
   private
 
-    def compute_percent(covered, total)
-      return 100.0 if total.zero?
+    def compute_percent(covered)
+      return 100.0 if @missed.zero?
 
-      covered * 100.0 / total
+      covered * 100.0 / @total
     end
 
-    def compute_strength(total_strength, total)
-      return 0.0 if total.zero?
+    def compute_strength(total_strength)
+      return 0.0 if @total.zero?
 
-      total_strength.to_f / total
+      total_strength.to_f / @total
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -62,7 +62,7 @@ describe SimpleCov::Configuration do
         config.minimum_coverage(100.01)
       end
 
-      it "sets the right converage value when called with a number" do
+      it "sets the right coverage value when called with a number" do
         config.minimum_coverage(80)
 
         expect(config.minimum_coverage).to eq line: 80

--- a/spec/coverage_statistics_spec.rb
+++ b/spec/coverage_statistics_spec.rb
@@ -3,7 +3,7 @@
 require "helper"
 
 RSpec.describe SimpleCov::CoverageStatistics do
-  describe "::new" do
+  describe ".new" do
     it "retains statistics and computes new ones" do
       statistics = described_class.new(covered: 4, missed: 6, total_strength: 14)
 
@@ -22,7 +22,7 @@ RSpec.describe SimpleCov::CoverageStatistics do
     end
 
     it "can deal with it if everything is 0" do
-      statistics = empty_statistics
+      statistics = described_class.new(covered: 0, missed: 0, total_strength: 0.0)
 
       expect_all_empty(statistics)
     end

--- a/spec/coverage_statistics_spec.rb
+++ b/spec/coverage_statistics_spec.rb
@@ -3,7 +3,7 @@
 require "helper"
 
 RSpec.describe SimpleCov::CoverageStatistics do
-  describe ".new" do
+  describe "::new" do
     it "retains statistics and computes new ones" do
       statistics = described_class.new(covered: 4, missed: 6, total_strength: 14)
 
@@ -16,20 +16,20 @@ RSpec.describe SimpleCov::CoverageStatistics do
     end
 
     it "can omit the total strength defaulting to 0.0" do
-      statistics = described_class.new(covered: 4, missed: 6, total_strength: 0.0)
+      statistics = described_class.new(covered: 4, missed: 6)
 
       expect(statistics.strength).to eq 0.0
     end
 
     it "can deal with it if everything is 0" do
-      statistics = described_class.new(covered: 0, missed: 0, total_strength: 0.0)
+      statistics = empty_statistics
 
       expect_all_empty(statistics)
     end
   end
 
   describe ".from" do
-    it "returns an all 0s coverage statistics if there is no statistics" do
+    it "returns an all 0s coverage statistics if there are no statistics" do
       statistics = described_class.from([])
 
       expect_all_empty(statistics)
@@ -67,7 +67,7 @@ RSpec.describe SimpleCov::CoverageStatistics do
     expect(statistics.missed).to eq 0
 
     expect(statistics.total).to eq 0
-    # might be counter intuitive but think of it as "we covered everything we could"
+    # might be counter-intuitive but think of it as "we covered everything we could"
     expect(statistics.percent).to eq 100.0
     expect(statistics.strength).to eq 0.0
   end

--- a/spec/fixtures/skipped_and_executed.rb
+++ b/spec/fixtures/skipped_and_executed.rb
@@ -1,4 +1,4 @@
-# So much skippping
+# So much skipping
 # :nocov:
 class Foo
   def bar(arg)

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -160,7 +160,7 @@ describe SimpleCov do
       end
     end
 
-    context "when a non SystemExit occurrs" do
+    context "when a non SystemExit occurs" do
       let(:error) { StandardError.new "NonSystemExit" }
 
       before do

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -210,7 +210,7 @@ describe SimpleCov::SourceFile do
       expect(subject.branches_report[3]).to eq([[:then, 1], [:else, 0]])
     end
 
-    it "has branches coverage precent 50.00" do
+    it "has branches coverage percent 50.00" do
       expect(subject.branches_coverage_percent).to eq(50.00)
     end
   end

--- a/test_projects/faked_project/spec/meta_magic_spec.rb
+++ b/test_projects/faked_project/spec/meta_magic_spec.rb
@@ -11,7 +11,7 @@ describe FakedProject do
     expect(subject.an_instance_method).to eq("this is a mixed-in instance method")
   end
 
-  it "should have added a dyntamically-defined instance method to FakedProject" do
+  it "should have added a dynamically-defined instance method to FakedProject" do
     expect(subject.dynamic).to eq("A dynamically defined instance method")
   end
 end


### PR DESCRIPTION
Simple refactor of `SimpleCov::CoverageStatistics` that makes the code slightly more efficient and readable. Also fixes a spec (along with some clean up).

I also searched for typos using [cspell](https://www.npmjs.com/package/cspell). I manually fixed the obvious typos that were reported (and ignored tons of false positive matches).