### PR TITLE
Amend 0.18 changelog with notice about code climate test reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ You can run with branch coverage by putting `enable_coverage :branch` into your 
 
 ## Noteworthy
 * `FileList` stopped inheriting from Array, it includes Enumerable so if you didn't use Array specific methods on it in formatters you should be fine
+* We needed to change an internal file format, which we use for merging across processes, to accommodate branch coverage. Sadly CodeClimate chose to use this file to report test coverage. Until a resolution is found the code climate test reporter won't work with SimpleCov for 0.18+, see [this issue on the test reporter](https://github.com/codeclimate/test-reporter/issues/413).
 
 0.18.0.beta3 (2020-01-20)
 ========================


### PR DESCRIPTION
I didn't add this information as to my mind we didn't change any API documented anywhere and hence it shouldn't appear in a Changelog.

However, this affects people and they have to find out for themselves so notifying them of this might be a good thing. I still couldn't bring myself to put it under breaking changes as technically we haven't broken anything that we ever communicated as working.

So a link to https://github.com/codeclimate/test-reporter/issues/413 seems to be helpful.