### PR TITLE
Allow simplecov-html 0.12

### DIFF
--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4.0"
 
   gem.add_dependency "docile", "~> 1.1"
-  gem.add_dependency "simplecov-html", "~> 0.11"
+  gem.add_dependency "simplecov-html", [">= 0.11", "< 0.13"]
 
   gem.files         = Dir["{lib}/**/*.*", "bin/*", "LICENSE", "*.md", "doc/*"]
   gem.require_paths = ["lib"]


### PR DESCRIPTION
The [changelog for 0.12](https://github.com/colszowka/simplecov-html/blob/master/CHANGELOG.md#0120-2020-02-12) does not mention any breaking changes.