### PR TITLE
Convert source file encoding to UTF-8

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   Exclude:
     - "spec/fixtures/iso-8859.rb"
+    - "spec/fixtures/utf-8.rb"
+    - "spec/fixtures/utf-8-magic.rb"
+    - "spec/fixtures/euc-jp.rb"
     - "tmp/**/*"
     - "vendor/bundle/**/*"
     - "vendor/bundle/**/.*"

--- a/spec/fixtures/euc-jp.rb
+++ b/spec/fixtures/euc-jp.rb
@@ -1,0 +1,2 @@
+# encoding: EUC-JP
+puts "135быC"

--- a/spec/fixtures/utf-8-magic.rb
+++ b/spec/fixtures/utf-8-magic.rb
@@ -1,0 +1,2 @@
+# encoding: UTF-8
+puts "135°C"

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -695,4 +695,42 @@ describe SimpleCov::SourceFile do
       end
     end
   end
+
+  context "a file contains non-ASCII characters" do
+    COVERAGE_FOR_SINGLE_LINE = {"lines" => [nil]}.freeze
+    COVERAGE_FOR_DOUBLE_LINES = {"lines" => [nil]}.freeze
+
+    shared_examples_for "converting to UTF-8" do
+      it "has all source lines of encoding UTF-8" do
+        subject.lines.each do |line|
+          expect(line.source.encoding).to eq(Encoding::UTF_8)
+          expect(line.source).to be_valid_encoding
+        end
+      end
+    end
+
+    describe "UTF-8 without magic comment" do
+      subject do
+        SimpleCov::SourceFile.new(source_fixture("utf-8.rb"), COVERAGE_FOR_SINGLE_LINE)
+      end
+
+      it_behaves_like "converting to UTF-8"
+    end
+
+    describe "UTF-8 with magic comment" do
+      subject do
+        SimpleCov::SourceFile.new(source_fixture("utf-8-magic.rb"), COVERAGE_FOR_DOUBLE_LINES)
+      end
+
+      it_behaves_like "converting to UTF-8"
+    end
+
+    describe "EUC-JP with magic comment" do
+      subject do
+        SimpleCov::SourceFile.new(source_fixture("euc-jp.rb"), COVERAGE_FOR_DOUBLE_LINES)
+      end
+
+      it_behaves_like "converting to UTF-8"
+    end
+  end
 end


### PR DESCRIPTION
Fixes colszowka/simplecov-html#91

## Summary
- Open the source file in encoding UTF-8 instead of ASCII-8BIT.
- Check for magic comment and call `IO#set_encoding` to convert encoding to UTF-8.

## Background
`File.open(..., "rb")` will set its encoding to ASCII-8BIT instead of script encoding (UTF-8).
This means all lines are ASCII-8BIT.

In simplecov-html, following line
https://github.com/colszowka/simplecov-html/blob/7540373ed44ccd43d1347b775a69673297cc8f90/views/source_file.erb#L48
will try to convert `src` from ASCII-8BIT to UTF-8!
Therefore, all non-ASCII characters will be replaced by Unicode Replacement Character.
