### PR TITLE
Only run our minitest plugin code if SimpleCov is indeed defined

### DIFF
--- a/features/minitest_basic.feature
+++ b/features/minitest_basic.feature
@@ -1,4 +1,7 @@
+@minitest
+
 Feature:
+  "Working with minitest"
 
   Background:
     Given I'm working on the project "faked_project"
@@ -15,12 +18,12 @@ Feature:
     When I open the coverage report generated with `bundle exec rake minitest`
     Then I should see the groups:
       | name      | coverage | files |
-      | All Files | 87.5%   | 2     |
+      | All Files | 87.5%    | 2     |
 
     And I should see the source files:
       | name                                    | coverage |
-      | lib/faked_project/some_class.rb         | 80.00 %   |
-      | minitest/some_test.rb                   | 100.00 %  |
+      | lib/faked_project/some_class.rb         | 80.00 %  |
+      | minitest/some_test.rb                   | 100.00 % |
 
   Scenario:
     Given SimpleCov for Minitest is configured with:
@@ -36,4 +39,19 @@ Feature:
 
     And I should see the source files:
       | name                                    | coverage |
-      | lib/faked_project/some_class.rb         | 80.00 %   |
+      | lib/faked_project/some_class.rb         | 80.00 %  |
+
+  Scenario: Not having simplecov loaded/enabled it does not crash #877
+    Given SimpleCov for Minitest is configured with:
+      """
+      # nothing
+      """
+    # What's this? Path requirements in the Gemfile evaluate the gemspec,
+    # which normally loads the version, which defined SimpleCov which leads
+    # to a different failure. This works around that issue.
+    And I set the environment variables to:
+      | variable                     | value   |
+      | SIMPLECOV_NO_REQUIRE_VERSION | 100.0.0 |
+
+    When I successfully run `bundle exec rake minitest`
+    Then no coverage report should have been generated

--- a/lib/minitest/simplecov_plugin.rb
+++ b/lib/minitest/simplecov_plugin.rb
@@ -4,10 +4,12 @@
 # https://github.com/seattlerb/minitest#writing-extensions
 module Minitest
   def self.plugin_simplecov_init(_options)
-    SimpleCov.external_at_exit = true
+    if defined?(SimpleCov)
+      SimpleCov.external_at_exit = true
 
-    Minitest.after_run do
-      SimpleCov.at_exit_behavior if SimpleCov.respond_to?(:at_exit_behavior)
+      Minitest.after_run do
+        SimpleCov.at_exit_behavior
+      end
     end
   end
 end

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.push File.expand_path("lib", __dir__)
-require "simplecov/version"
+
+# Why oh why oh what is this?
+# See the cuke that is setting this.
+# Basically to really reproduce #877 we needed a gemspec that doesn't
+# (indirectly) define a SimpleCov module... so this is the workaround.
+# No one ever but hat test should set that environment variable. Please.
+version =
+  if ENV["SIMPLECOV_NO_REQUIRE_VERSION"]
+    ENV["SIMPLECOV_NO_REQUIRE_VERSION"]
+  else
+    require "simplecov/version"
+    SimpleCov::VERSION
+  end
 
 Gem::Specification.new do |gem|
   gem.name        = "simplecov"
-  gem.version     = SimpleCov::VERSION
+  gem.version     = version
   gem.platform    = Gem::Platform::RUBY
   gem.authors     = ["Christoph Olszowka"]
   gem.email       = ["christoph at olszowka de"]


### PR DESCRIPTION
* Fixes #877
* not quire sure whether we should wrap the entire thing in
if undefined?(..) or not but since the file has all the right
structure otherwise I'm more worried about minitest being
weirded out that it doesn't find what it expects than I am
of letting it execute an empty method
* also yes the version workaround is maybe a bit weird, however
I wanted our test suite to reproduce the exact failure case
because otherwise it'd be to easy to just implement a
respond_to? check which would have everything passing but would
fail in real life.