### PR TITLE
Add subprocess handling to simplecov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+==========
+
+## Enhancements
+* observe forked processes (configure with SimpleCov.at_fork)
+
 0.18.5 (2020-02-25)
 ===================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Unreleased
 ==========
 
 ## Enhancements
-* observe forked processes (configure with SimpleCov.at_fork)
+* observe forked processes (enable with SimpleCov.enable_for_subprocesses)
 
 0.18.5 (2020-02-25)
 ===================

--- a/README.md
+++ b/README.md
@@ -623,13 +623,13 @@ to the `SimpleCov.command_name`, with results that can be merged together using 
 To configure this, use `.at_fork`.
 
 ```ruby
-SimpleCov.enable_for_subprocesses = true
+SimpleCov.enable_for_subprocesses true
 SimpleCov.at_fork do |pid|
   # This needs a unique name so it won't be ovewritten
   SimpleCov.command_name "#{SimpleCov.command_name} (subprocess: #{pid})"
   # be quiet, the parent process will be in charge of output and checking coverage totals
   SimpleCov.print_error_status = false
-  SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
+  SimpleCov.formatter SimpleCov::Formatter::SimpleFormatter
   SimpleCov.minimum_coverage 0
   # start
   SimpleCov.start

--- a/README.md
+++ b/README.md
@@ -616,16 +616,18 @@ end
 
 ## Running simplecov against subprocesses
 
-SimpleCov will cover code run using `Process.fork` automatically, appending `" (subprocess #{pid})"`
+`SimpleCov.enable_for_subprocesses` will allow SimpleCov to observe subprocesses starting using `Process.fork`.
+This modifies ruby's core Process.fork method so that SimpleCov can see into it, appending `" (subprocess #{pid})"`
 to the `SimpleCov.command_name`, with results that can be merged together using SimpleCov's merging feature.
 
 To configure this, use `.at_fork`.
 
 ```ruby
+SimpleCov.enable_for_subprocesses = true
 SimpleCov.at_fork do |pid|
   # This needs a unique name so it won't be ovewritten
   SimpleCov.command_name "#{SimpleCov.command_name} (subprocess: #{pid})"
-  # be quiet, the parent process will be in charge of using the regular formatter and checking coverage totals
+  # be quiet, the parent process will be in charge of output and checking coverage totals
   SimpleCov.print_error_status = false
   SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
   SimpleCov.minimum_coverage 0

--- a/README.md
+++ b/README.md
@@ -643,13 +643,14 @@ NOTE: SimpleCov must have already been started before `Process.fork` was called.
 Perhaps you're testing a ruby script with `PTY.spawn` or `Open3.popen`, or `Process.spawn` or etc.
 SimpleCov can cover this too.
 
-Add a .simplecov_spawn file to your project root
+Add a .simplecov_spawn.rb file to your project root
 ```ruby
-# .simplecov_spawn
+# .simplecov_spawn.rb
 require 'simplecov' # this will also pick up whatever config is in .simplecov
                     # so ensure it just contains configuration, and doesn't call SimpleCov.start.
-SimpleCov.at_fork.call(Process.pid)
-SimpleCov.start
+SimpleCov.command_name 'spawn' # As this is not for a test runner directly, script doesn't have a pre-defined base command_name
+SimpleCov.at_fork.call(Process.pid) # Use the per-process setup described previously
+SimpleCov.start # only now can we start.
 ```
 Then, instead of calling your script directly, like:
 ```ruby
@@ -657,7 +658,7 @@ PTY.spawn('my_script.rb') do # ...
 ```
 Use bin/ruby to require the new .simplecov_spawn file, then your script
 ```ruby
-PTY.spawn('ruby -r.simplecov_spawn my_script.rb') do # ...
+PTY.spawn('ruby -r./.simplecov_spawn my_script.rb') do # ...
 ```
 
 ## Running coverage only on demand

--- a/features/config_enable_for_subprocesses.feature
+++ b/features/config_enable_for_subprocesses.feature
@@ -1,0 +1,37 @@
+@rspec
+
+Feature:
+  Coverage should include code run by subprocesses
+
+  Background:
+    Given I'm working on the project "subprocesses"
+
+  Scenario: Coverage has seen the subprocess line
+  When I open the coverage report generated with `bundle exec rspec spec/simple_spec.rb`
+  Then I should see the groups:
+    | name      | coverage | files |
+    | All Files | 100.0%   | 1     |
+
+  Scenario: The at_fork proc
+  Given a file named ".simplecov" with:
+    """
+    SimpleCov.enable_for_subprocesses = true
+    SimpleCov.command_name "parent process name"
+    SimpleCov.at_fork do |_pid|
+      SimpleCov.command_name "child process name"
+      SimpleCov.start
+    end
+    """
+  When I open the coverage report generated with `bundle exec rspec spec/simple_spec.rb`
+  Then I should see the groups:
+    | name      | coverage | files |
+    | All Files | 100.0%   | 1     |
+  And the report should be based upon:
+      | child process name  |
+      | parent process name |
+
+  Scenario: The documentation on .simplecov_spawn
+  When I open the coverage report generated with `bundle exec rspec spec/spawn_spec.rb`
+  Then I should see the groups:
+    | name      | coverage | files |
+    | All Files | 100.0%   | 1     |

--- a/features/config_enable_for_subprocesses.feature
+++ b/features/config_enable_for_subprocesses.feature
@@ -1,4 +1,4 @@
-@rspec
+@rspec @process_fork
 
 Feature:
   Coverage should include code run by subprocesses
@@ -15,7 +15,7 @@ Feature:
   Scenario: The at_fork proc
   Given a file named ".simplecov" with:
     """
-    SimpleCov.enable_for_subprocesses = true
+    SimpleCov.enable_for_subprocesses true
     SimpleCov.command_name "parent process name"
     SimpleCov.at_fork do |_pid|
       SimpleCov.command_name "child process name"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -47,9 +47,13 @@ Before("@branch_coverage") do
 end
 
 Before("@rails6") do
-  # Rails 6 only supports Ruby 2.5+ and amazingly because string comparison
-  # goes beginning to end the string comparison _should_ work
-  skip_this_scenario if RUBY_VERSION < "2.5"
+  # Rails 6 only supports Ruby 2.5+
+  skip_this_scenario if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
+end
+
+Before("@process_fork") do
+  # Process.fork is NotImplementedError in jruby
+  skip_this_scenario if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
 end
 
 Aruba.configure do |config|

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "English"
-require_relative "simplecov/process"
 
 # Coverage may be inaccurate under JRUBY.
 if defined?(JRUBY_VERSION) && defined?(JRuby)
@@ -53,6 +52,8 @@ module SimpleCov
     def start(profile = nil, &block)
       require "coverage"
       initial_setup(profile, &block)
+      require_relative "./simplecov/process" if SimpleCov.enable_for_subprocesses
+
       @result = nil
       self.pid = Process.pid
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -52,7 +52,7 @@ module SimpleCov
     def start(profile = nil, &block)
       require "coverage"
       initial_setup(profile, &block)
-      require_relative "./simplecov/process" if SimpleCov.enable_for_subprocesses
+      require_relative "./simplecov/process" if SimpleCov.enabled_for_subprocesses?
 
       @result = nil
       self.pid = Process.pid

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "English"
+require_relative "simplecov/process"
 
 # Coverage may be inaccurate under JRUBY.
 if defined?(JRUBY_VERSION) && defined?(JRuby)

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -12,7 +12,6 @@ module SimpleCov
   #
   module Configuration # rubocop:disable Metrics/ModuleLength
     attr_writer :filters, :groups, :formatter, :print_error_status
-    attr_accessor :enable_for_subprocesses
 
     #
     # The root for the project. This defaults to the
@@ -197,6 +196,18 @@ module SimpleCov
       @at_exit ||= proc { SimpleCov.result.format! }
     end
 
+    # gets or sets the enabled_for_subprocess configuration
+    # when true, this will inject SimpleCov code into Process.fork
+    def enable_for_subprocesses(value = nil)
+      @enable_for_subprocesses = value unless value.nil?
+      @enable_for_subprocesses || false
+    end
+
+    # gets the enabled_for_subprocess configuration
+    def enabled_for_subprocesses?
+      enable_for_subprocesses
+    end
+
     #
     # Gets or sets the behavior to start a new forked Process.
     #
@@ -210,7 +221,7 @@ module SimpleCov
     #         SimpleCov.command_name "#{SimpleCov.command_name} (subprocess: #{pid})"
     #         # be quiet, the parent process will be in charge of using the regular formatter and checking coverage totals
     #         SimpleCov.print_error_status = false
-    #         SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
+    #         SimpleCov.formatter SimpleCov::Formatter::SimpleFormatter
     #         SimpleCov.minimum_coverage 0
     #         # start
     #         SimpleCov.start
@@ -224,7 +235,7 @@ module SimpleCov
         SimpleCov.command_name "#{SimpleCov.command_name} (subprocess: #{pid})"
         # be quiet, the parent process will be in charge of using the regular formatter and checking coverage totals
         SimpleCov.print_error_status = false
-        SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
+        SimpleCov.formatter SimpleCov::Formatter::SimpleFormatter
         SimpleCov.minimum_coverage 0
         # start
         SimpleCov.start

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -12,6 +12,7 @@ module SimpleCov
   #
   module Configuration # rubocop:disable Metrics/ModuleLength
     attr_writer :filters, :groups, :formatter, :print_error_status
+    attr_accessor :enable_for_subprocesses
 
     #
     # The root for the project. This defaults to the

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -197,6 +197,40 @@ module SimpleCov
     end
 
     #
+    # Gets or sets the behavior to start a new forked Process.
+    #
+    # By default, it will add " (Process #{pid})" to the command_name, and start SimpleCov in quiet mode
+    #
+    # Configure with:
+    #
+    #     SimpleCov.at_fork do |pid|
+    #       SimpleCov.start do
+    #         # This needs a unique name so it won't be ovewritten
+    #         SimpleCov.command_name "#{SimpleCov.command_name} (subprocess: #{pid})"
+    #         # be quiet, the parent process will be in charge of using the regular formatter and checking coverage totals
+    #         SimpleCov.print_error_status = false
+    #         SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
+    #         SimpleCov.minimum_coverage 0
+    #         # start
+    #         SimpleCov.start
+    #       end
+    #     end
+    #
+    def at_fork(&block)
+      @at_fork = block if block_given?
+      @at_fork ||= lambda { |pid|
+        # This needs a unique name so it won't be ovewritten
+        SimpleCov.command_name "#{SimpleCov.command_name} (subprocess: #{pid})"
+        # be quiet, the parent process will be in charge of using the regular formatter and checking coverage totals
+        SimpleCov.print_error_status = false
+        SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
+        SimpleCov.minimum_coverage 0
+        # start
+        SimpleCov.start
+      }
+    end
+
+    #
     # Returns the project name - currently assuming the last dirname in
     # the SimpleCov.root is this.
     #

--- a/lib/simplecov/process.rb
+++ b/lib/simplecov/process.rb
@@ -3,7 +3,7 @@
 module Process
   class << self
     def fork_with_simplecov(&block)
-      if SimpleCov.running
+      if defined?(SimpleCov) && SimpleCov.running
         fork_without_simplecov do
           SimpleCov.at_fork.call(Process.pid)
           block.call if block_given?

--- a/lib/simplecov/process.rb
+++ b/lib/simplecov/process.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Process
+  class << self
+    def fork_with_simplecov(&block)
+      if SimpleCov.running
+        fork_without_simplecov do
+          SimpleCov.at_fork.call(Process.pid)
+          block.call if block_given?
+        end
+      else
+        fork_without_simplecov(&block)
+      end
+    end
+
+    alias fork_without_simplecov fork
+    alias fork fork_with_simplecov
+  end
+end

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -270,31 +270,6 @@ describe SimpleCov do
       end
     end
 
-    context "with_reports_to_clear_up" do
-      after do
-        clear_mergeable_reports
-      end
-
-      def a_void_method_call_that_wont_warn
-        true
-      end
-
-      it "starts coverage of subprocesses" do
-        SimpleCov.command_name "RSpec"
-        SimpleCov.start
-
-        a_void_method_call_that_wont_warn # this process
-
-        pid = Process.fork do
-          a_void_method_call_that_wont_warn # that process
-        end
-
-        Process.wait(pid) # timings!
-
-        expect(SimpleCov.result.command_name).to eq "RSpec, RSpec (subprocess: #{pid})"
-      end
-    end
-
     context "when files to be merged" do
       before do
         expect(SimpleCov).to receive(:run_exit_tasks!)
@@ -347,14 +322,14 @@ describe SimpleCov do
         SimpleCov::ResultMerger.store_result(result)
         FileUtils.mv resultset_path, "#{resultset_path}#{name}.final"
       end
-    end
 
-    def clear_mergeable_reports(*names)
-      SimpleCov.clear_result
-      SimpleCov::ResultMerger.clear_resultset
-      FileUtils.rm resultset_path
-      FileUtils.rm "#{resultset_path}.lock"
-      names.each { |name| FileUtils.rm "#{resultset_path}#{name}.final" }
+      def clear_mergeable_reports(*names)
+        SimpleCov.clear_result
+        SimpleCov::ResultMerger.clear_resultset
+        FileUtils.rm resultset_path
+        FileUtils.rm "#{resultset_path}.lock"
+        names.each { |name| FileUtils.rm "#{resultset_path}#{name}.final" }
+      end
     end
   end
 

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -270,6 +270,31 @@ describe SimpleCov do
       end
     end
 
+    context "with_reports_to_clear_up" do
+      after do
+        clear_mergeable_reports
+      end
+
+      def a_void_method_call_that_wont_warn
+        true
+      end
+
+      it "starts coverage of subprocesses" do
+        SimpleCov.command_name "RSpec"
+        SimpleCov.start
+
+        a_void_method_call_that_wont_warn # this process
+
+        pid = Process.fork do
+          a_void_method_call_that_wont_warn # that process
+        end
+
+        Process.wait(pid) # timings!
+
+        expect(SimpleCov.result.command_name).to eq "RSpec, RSpec (subprocess: #{pid})"
+      end
+    end
+
     context "when files to be merged" do
       before do
         expect(SimpleCov).to receive(:run_exit_tasks!)
@@ -322,14 +347,14 @@ describe SimpleCov do
         SimpleCov::ResultMerger.store_result(result)
         FileUtils.mv resultset_path, "#{resultset_path}#{name}.final"
       end
+    end
 
-      def clear_mergeable_reports(*names)
-        SimpleCov.clear_result
-        SimpleCov::ResultMerger.clear_resultset
-        FileUtils.rm resultset_path
-        FileUtils.rm "#{resultset_path}.lock"
-        names.each { |name| FileUtils.rm "#{resultset_path}#{name}.final" }
-      end
+    def clear_mergeable_reports(*names)
+      SimpleCov.clear_result
+      SimpleCov::ResultMerger.clear_resultset
+      FileUtils.rm resultset_path
+      FileUtils.rm "#{resultset_path}.lock"
+      names.each { |name| FileUtils.rm "#{resultset_path}#{name}.final" }
     end
   end
 

--- a/test_projects/subprocesses/.simplecov
+++ b/test_projects/subprocesses/.simplecov
@@ -1,4 +1,4 @@
-SimpleCov.enable_for_subprocesses = true
+SimpleCov.enable_for_subprocesses true
 # different versions of ruby were tracking different numbers of files. idk why.
 # lets only worry about one file.
 SimpleCov.add_filter /command/

--- a/test_projects/subprocesses/.simplecov
+++ b/test_projects/subprocesses/.simplecov
@@ -1,1 +1,5 @@
 SimpleCov.enable_for_subprocesses = true
+# different versions of ruby were tracking different numbers of files. idk why.
+# lets only worry about one file.
+SimpleCov.add_filter /command/
+SimpleCov.add_filter /spawn/

--- a/test_projects/subprocesses/.simplecov
+++ b/test_projects/subprocesses/.simplecov
@@ -1,0 +1,1 @@
+SimpleCov.enable_for_subprocesses = true

--- a/test_projects/subprocesses/.simplecov_spawn.rb
+++ b/test_projects/subprocesses/.simplecov_spawn.rb
@@ -1,0 +1,5 @@
+require 'bundler/setup'
+require 'simplecov'
+SimpleCov.enable_for_subprocesses = true
+SimpleCov.at_fork.call(Process.pid)
+SimpleCov.start

--- a/test_projects/subprocesses/.simplecov_spawn.rb
+++ b/test_projects/subprocesses/.simplecov_spawn.rb
@@ -1,5 +1,5 @@
 require 'bundler/setup'
 require 'simplecov'
-SimpleCov.enable_for_subprocesses = true
+SimpleCov.command_name 'spawn'
 SimpleCov.at_fork.call(Process.pid)
 SimpleCov.start

--- a/test_projects/subprocesses/lib/command
+++ b/test_projects/subprocesses/lib/command
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require_relative './subprocesses'
+
+Subprocesses.new.run
+
+puts 'done'

--- a/test_projects/subprocesses/lib/subprocesses.rb
+++ b/test_projects/subprocesses/lib/subprocesses.rb
@@ -1,0 +1,21 @@
+class Subprocesses
+  def run
+    method_called_in_parent_process
+
+    pid = Process.fork do
+      method_called_by_subprocess
+    end
+
+    Process.wait(pid)
+
+    true
+  end
+
+  def method_called_in_parent_process
+    true
+  end
+
+  def method_called_by_subprocess
+    true
+  end
+end

--- a/test_projects/subprocesses/spec/simple_spec.rb
+++ b/test_projects/subprocesses/spec/simple_spec.rb
@@ -1,0 +1,7 @@
+require_relative "spec_helper"
+
+describe Subprocesses do
+  it "call things" do
+    expect(subject.run).to be true
+  end
+end

--- a/test_projects/subprocesses/spec/spawn_spec.rb
+++ b/test_projects/subprocesses/spec/spawn_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'open3'
+describe 'spawn' do
+  it 'calls things' do
+    stdout, exitstatus = Open3.capture2("ruby -r#{__dir__}/../.simplecov_spawn #{__dir__}/../lib/command")
+    expect(stdout.chomp).to eq 'done'
+  end
+end

--- a/test_projects/subprocesses/spec/spawn_spec.rb
+++ b/test_projects/subprocesses/spec/spawn_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 require 'open3'
 describe 'spawn' do
   it 'calls things' do
-    stdout, exitstatus = Open3.capture2("ruby -r#{__dir__}/../.simplecov_spawn #{__dir__}/../lib/command")
-    expect(stdout.chomp).to eq 'done'
+    Dir.chdir(File.expand_path('..', __dir__)) do
+      stdout, exitstatus = Open3.capture2("ruby -r./.simplecov_spawn lib/command")
+      expect(stdout.chomp).to eq 'done'
+    end
   end
 end

--- a/test_projects/subprocesses/spec/spec_helper.rb
+++ b/test_projects/subprocesses/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start
+
+require_relative "../lib/subprocesses.rb"


### PR DESCRIPTION
Using Process.fork (whether using the Parallel gem or directly)
creates code that was invisible to SimpleCov. by starting SimpleCov
within the subprocess with its own command name and etc we can
see that code :)

This also adds documentation for what to do when using Process.spawn or
similar.

fixes: #414 and probably others

---

This seems the more correct place to fix this than my previous attempt here: https://github.com/grosser/parallel/issues/275

Testing was a bit of a mess, perhaps you have some ideas, 
Also what are your thoughts on this being enabled by default or not?

Thanks :)