### PR TITLE
Don't print coverage violations until tests finish

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -247,7 +247,7 @@ module SimpleCov
     def result_exit_status(result, covered_percent)
       covered_percentages = result.covered_percentages.map { |percentage| percentage.floor(2) }
       if (minimum_violations = minimum_coverage_violated(result)).any?
-        report_minimum_violated(minimum_violations)
+        report_minimum_violated(minimum_violations) if final_result_process? # If running tests in parallel, only report coverage violation on the last process to finish.
         SimpleCov::ExitCodes::MINIMUM_COVERAGE
       elsif covered_percentages.any? { |p| p < SimpleCov.minimum_coverage_by_file }
         $stderr.printf(
@@ -259,7 +259,7 @@ module SimpleCov
         SimpleCov::ExitCodes::MINIMUM_COVERAGE
       elsif (last_run = SimpleCov::LastRun.read)
         coverage_diff = last_run[:result][:covered_percent] - covered_percent
-        if coverage_diff > SimpleCov.maximum_coverage_drop
+        if coverage_diff > SimpleCov.maximum_coverage_drop && final_result_process? # If running tests in parallel, only report coverage violation on the last process to finish.
           $stderr.printf(
             "Coverage has dropped by %<drop_percent>.2f%% since the last time (maximum allowed: %<max_drop>.2f%%).\n",
             drop_percent: coverage_diff,


### PR DESCRIPTION
If running tests in parallel (e.g. using `parallel_tests`), coverage and coverage drop violations were being reported prior to the entire test suite finishing.

Two issues with this:

1. You get violations being shown prior to the entire test suite finishing that are not representative of the entire test suite coverage.

2. It makes the test results ugly and distracting.

For example, if your minimum line and branch coverage is 50 and 40, respectively, and your final line and branch coverage is 59 and 47, respectively, you will get violations prior to the full test suite finishing.

This commit ensures that if you are running tests in parallel, it only reports the coverage and coverage drop violations on the final process running, after all the tests have run.

## Before

```bash
Using recorded test runtime
8 processes for 173 specs, ~ 21 specs per process
Line coverage (37.08%) is below the expected minimum coverage (50.00%).
Branch coverage (25.76%) is below the expected minimum coverage (40.00%).
.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................Line coverage (40.68%) is below the expected minimum coverage (50.00%).
Branch coverage (32.02%) is below the expected minimum coverage (40.00%).
.......................................................................................................................................................................................................................................................................................................................................................................................................................................🕒🕒....................................🕒🕒......................................................................................................................................................Line coverage (44.46%) is below the expected minimum coverage (50.00%).
Branch coverage (33.26%) is below the expected minimum coverage (40.00%).
................................................................................................................................................................................................................................................................................................Line coverage (48.28%) is below the expected minimum coverage (50.00%).
Branch coverage (34.44%) is below the expected minimum coverage (40.00%).
....................................................................................................................................................................................................................................................................................................................................................................................................................................🕒Branch coverage (37.17%) is below the expected minimum coverage (40.00%).
...............................................................................................................................................................................................................................................................🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒...............................................................................................................................................................🕒.......................................................................................................................................Coverage has dropped by 4.64% since the last time (maximum allowed: 2.00%).
............................................................................................................................................................................................................................................................................................................................................🕒...........................................................🕒...🕒🕒🕒🕒..🕒.................................................................🕒........................................................................................................................................................................................................................................................................................................................................................................................................................................................................🕒...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................🕒....🕒🕒🕒🕒🕒................................................................................................................................🕒....................................................................................................................................................................................................................................................................

Coverage report generated for (1/8), (2/8), (3/8), (4/8), (5/8), (6/8), (7/8), (8/8) to /Users/joshuapinter/Development/cntral/coverage. 6662 / 11228 LOC (59.33%) covered.
```

## After

```bash
Using recorded test runtime
8 processes for 173 specs, ~ 21 specs per process
..................................................................................................................................................................................🕒🕒🕒🕒.............................................................................................................................................................................................................🕒...........................................................🕒...🕒🕒🕒🕒..............................................................................................................................................................................................................................................................................................................................................................................................................................🕒🕒....................................🕒🕒....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................🕒..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒🕒.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................🕒.........................................................................................................................................

Coverage report generated for (1/8), (2/8), (3/8), (4/8), (5/8), (6/8), (7/8), (8/8) to /Users/user/Development/cntral/coverage. 6661 / 11239 LOC (59.27%) covered.
```