### PR TITLE
Fix regexp for filtering out non-root results being set too early

### DIFF
--- a/features/config_root.feature
+++ b/features/config_root.feature
@@ -1,0 +1,26 @@
+@rspec @disable-bundler
+
+Feature:
+
+  The root of the project can be customized.
+
+  Background:
+    Given I'm working on the project "monorepo"
+
+  Scenario: A coverage result is considered if it falls inside the root of the project
+    Given I install dependencies
+    And a file named ".simplecov" with:
+      """
+      SimpleCov.start do
+        root __dir__
+      end
+      """
+    When I open the coverage report generated with `bin/rspec_binstub_that_chdirs extra/spec/extra_spec.rb`
+    Then I should see the groups:
+      | name      | coverage | files |
+      | All Files | 100.0%   | 2     |
+
+    And I should see the source files:
+      | name                        | coverage |
+      | base/lib/monorepo/base.rb   | 100.00 % |
+      | extra/lib/monorepo/extra.rb | 100.00 % |

--- a/lib/simplecov/useless_results_remover.rb
+++ b/lib/simplecov/useless_results_remover.rb
@@ -5,12 +5,14 @@ module SimpleCov
   # Select the files that related to working scope directory of SimpleCov
   #
   module UselessResultsRemover
-    ROOT_REGX = /\A#{Regexp.escape(SimpleCov.root + File::SEPARATOR)}/io.freeze
-
     def self.call(coverage_result)
       coverage_result.select do |path, _coverage|
-        path =~ ROOT_REGX
+        path =~ root_regx
       end
+    end
+
+    def self.root_regx
+      @root_regx ||= /\A#{Regexp.escape(SimpleCov.root + File::SEPARATOR)}/i.freeze
     end
   end
 end

--- a/test_projects/monorepo/Gemfile
+++ b/test_projects/monorepo/Gemfile
@@ -1,0 +1,15 @@
+source "https://rubygems.org"
+
+gem "rspec"
+
+gem "base", path: "base"
+gem "extra", path: "extra"
+
+# when the tests are executed the project is in tmp/aruba/project
+# which is a different nesting from its usual place
+root = File.expand_path("../..", __dir__)
+unless File.exist?("#{root}/simplecov.gemspec")
+  root = File.expand_path("../../..", __dir__)
+end
+
+gem "simplecov", path: root

--- a/test_projects/monorepo/Gemfile.lock
+++ b/test_projects/monorepo/Gemfile.lock
@@ -1,0 +1,49 @@
+PATH
+  remote: ../..
+  specs:
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+
+PATH
+  remote: base
+  specs:
+    base (0.0.1)
+
+PATH
+  remote: extra
+  specs:
+    extra (0.0.1)
+      base
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    docile (1.3.2)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    simplecov-html (0.12.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  base!
+  extra!
+  rspec
+  simplecov!
+
+BUNDLED WITH
+   2.1.4

--- a/test_projects/monorepo/base/base.gemspec
+++ b/test_projects/monorepo/base/base.gemspec
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |gem|
+  gem.name        = "base"
+  gem.version     = "0.0.1"
+  gem.authors     = ["Someone"]
+  gem.email       = ["someonesemail"]
+  gem.homepage    = "https://example.org"
+  gem.summary     = "Base stuff"
+  gem.description = %(Base stuff, really)
+  gem.license     = "MIT"
+  gem.files       = ["lib/monorepo/base.rb"]
+end

--- a/test_projects/monorepo/base/lib/monorepo/base.rb
+++ b/test_projects/monorepo/base/lib/monorepo/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Monorepo
+  class Base
+    def initialize(label)
+      @label = label
+    end
+
+    def reverse
+      @label.reverse
+    end
+  end
+end

--- a/test_projects/monorepo/bin/rspec_binstub_that_chdirs
+++ b/test_projects/monorepo/bin/rspec_binstub_that_chdirs
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+if ARGV[0]
+  cleaned_file_path = ARGV[0].split("./").last
+  argument_parts = cleaned_file_path.split("/")
+
+  first_part = argument_parts[0]
+
+  if File.directory?(first_part)
+    Dir.chdir(first_part)
+
+    other_parts = argument_parts[1..-1]
+
+    new_args = [!other_parts.empty? ? other_parts.join("/") : nil, *ARGV[1..-1]].compact
+
+    ARGV.replace(new_args)
+  end
+end
+
+load Gem.bin_path("rspec-core", "rspec")

--- a/test_projects/monorepo/extra/extra.gemspec
+++ b/test_projects/monorepo/extra/extra.gemspec
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |gem|
+  gem.name        = "extra"
+  gem.version     = "0.0.1"
+  gem.authors     = ["Someone"]
+  gem.email       = ["someonesemail"]
+  gem.homepage    = "https://example.org"
+  gem.summary     = "Extra stuff"
+  gem.description = %(Extra stuff, really)
+  gem.license     = "MIT"
+  gem.add_dependency "base"
+  gem.files       = ["lib/monorepo/extra.rb"]
+end

--- a/test_projects/monorepo/extra/lib/monorepo/extra.rb
+++ b/test_projects/monorepo/extra/lib/monorepo/extra.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "monorepo/base"
+
+module Monorepo
+  class Extra
+    def initialize(label)
+      @label = label
+    end
+
+    def identity
+      Base.new(Base.new(@label).reverse).reverse
+    end
+  end
+end

--- a/test_projects/monorepo/extra/spec/extra_spec.rb
+++ b/test_projects/monorepo/extra/spec/extra_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "monorepo/extra"
+
+RSpec.describe Monorepo::Extra do
+  describe "#identity" do
+    it "returns the same string" do
+      expect(described_class.new("foo").identity).to eq("foo")
+    end
+  end
+end

--- a/test_projects/monorepo/extra/spec/spec_helper.rb
+++ b/test_projects/monorepo/extra/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "simplecov"
+
+require "monorepo/base"


### PR DESCRIPTION
If user configures a custom `SimpleCov.root`, results outside of the new root wouldn't be properly filtered out since the regexp for filtering was being set at require time, before the `SimpleCov.root` configuration had been applied.

Instead, lazily set this regexp, so that by the time it is used, the new `SimpleCov.root` value is already setup.

Fixes #885.