### PR TITLE
Run unstable workflow daily

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,11 +1,8 @@
 name: unstable
 
 on:
-  pull_request:
-
-  push:
-    branches:
-      - master
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   test:
@@ -45,11 +42,9 @@ jobs:
           source $HOME/.rvm/scripts/rvm
           bundle exec rake
         if: matrix.ruby == 'ruby-head'
-        continue-on-error: true
 
       - name: Run tests (JRuby)
         run: |
           source $HOME/.rvm/scripts/rvm
           JRUBY_OPTS=--debug bundle exec rake
         if: matrix.ruby == 'jruby-head'
-        continue-on-error: true


### PR DESCRIPTION
I think this is better because:

* We get faster feedback for PRs.
* We get less hidden failures under then "Actions" tab, instead of having them hidden under a green check on PRs.

Thoughts?