### PR TITLE
Add missing quote to example in comments

### DIFF
--- a/lib/simplecov/filter.rb
+++ b/lib/simplecov/filter.rb
@@ -51,7 +51,7 @@ module SimpleCov
 
   class StringFilter < SimpleCov::Filter
     # Returns true when the given source file's filename matches the
-    # string configured when initializing this Filter with StringFilter.new('somestring)
+    # string configured when initializing this Filter with StringFilter.new('somestring')
     def matches?(source_file)
       source_file.project_filename.include?(filter_argument)
     end


### PR DESCRIPTION
Just saw that while checking up on filters.
Thanks for the great work!