### PR TITLE
Make ParallelTests available and change waiting mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 * Changing the `SimpleCov.root` combined with the root filtering didn't work. Now they do! Thanks to [@deivid-rodriguez](https://github.com/deivid-rodriguez) and see [#894](https://github.com/colszowka/simplecov/pull/894)
 * in parallel test execution it could happen that the last coverage result was written when it didn't complete yet, changed to only write it once it's the final result
 * if you run parallel tests only the final process will report violations of the configured test coverage, not all previous processes
+* changed the parallel_tests merging mechanisms to do the waiting always in the last process, should reduce race conditions
 
 0.18.5 (2020-02-25)
 ===================

--- a/features/parallel_tests.feature
+++ b/features/parallel_tests.feature
@@ -8,8 +8,6 @@ Feature:
   Background:
     Given I'm working on the project "parallel_tests"
 
-  # see #815
-  @wip
   Scenario: Running it through parallel_tests produces the same results as a normal rspec run
     Given I install dependencies
     And SimpleCov for RSpec is configured with:
@@ -20,8 +18,8 @@ Feature:
     When I open the coverage report generated with `bundle exec parallel_rspec spec`
     Then I should see the line coverage results for the parallel tests project
 
-  # Note it's better not to do them in the same scenario as
-  # then merging of results might kick in
+  # Note it's better not to test this in the same scenario as before.
+  # Merging of results might kick in and ruin this.
   Scenario: Running the project with normal rspec
     Given I install dependencies
     And SimpleCov for RSpec is configured with:
@@ -45,8 +43,6 @@ Feature:
     When I open the coverage report generated with `bundle exec rspec spec`
     Then I should see the branch coverage results for the parallel tests project
 
-  # see #815
-  @wip
   @branch_coverage
   Scenario: Running the project with normal rspec and branch coverage
     Given I install dependencies
@@ -60,8 +56,6 @@ Feature:
     When I open the coverage report generated with `bundle exec parallel_rspec spec`
     Then I should see the branch coverage results for the parallel tests project
 
-  # Our detection doesn't work at the moment see https://github.com/grosser/parallel_tests/issues/772
-  @wip
   Scenario: Coverage violations aren't printed until the end
     Given I install dependencies
     And SimpleCov for RSpec is configured with:


### PR DESCRIPTION
As we found out ParallelTests isn't necessarily always available.
Hence the new require logic.

Also added a different mechanism for waiting that should get
rid off at least one race condition.

I just managed to run the parallel_test tests without fail
for 50 times. I had a failure before so we'll see how robust
these are on CI.

Ref: https://github.com/grosser/parallel_tests/issues/772#issuecomment-672010347

Code probably still needs some work and restructuring as when
does "result" get called and the waiting is definitely somewhat
flaky.