### PR TITLE
Support parallel_tests with multiple commands

### DIFF
--- a/lib/simplecov/command_guesser.rb
+++ b/lib/simplecov/command_guesser.rb
@@ -14,12 +14,12 @@ module SimpleCov
       attr_accessor :original_run_command
 
       def guess
-        from_env || from_command_line_options || from_defined_constants
+        [from_command_line_options || from_defined_constants, parallel_data].compact.join(" ")
       end
 
     private
 
-      def from_env
+      def parallel_data
         # If being run from inside parallel_tests set the command name according to the process number
         return unless ENV["PARALLEL_TEST_GROUPS"] && ENV["TEST_ENV_NUMBER"]
 

--- a/spec/command_guesser_spec.rb
+++ b/spec/command_guesser_spec.rb
@@ -45,4 +45,11 @@ describe SimpleCov::CommandGuesser do
     subject.original_run_command = "some_arbitrary_command with arguments"
     expect(subject.guess).to eq("RSpec")
   end
+
+  it "appends parallel data" do
+    subject.original_run_command = "/some/path/spec/foo.rb"
+    expect(ENV).to receive(:[]).with("TEST_ENV_NUMBER").at_least(:once).and_return("1")
+    expect(ENV).to receive(:[]).with("PARALLEL_TEST_GROUPS").at_least(:once).and_return("2")
+    expect(subject.guess).to eq("RSpec (1/2)")
+  end
 end


### PR DESCRIPTION
Currently, when using parallel_tests with 2 different test frameworks (eg RSpec + Cucumber), the guess is the same for the both commands and the second command results overwrite the first command results.

This PR change the guess to something like `RSpec (1/2)` instead of just `(1/2)` to have different command names and merge the results correctly.
