### PR TITLE
Support nocov comment at the end of a line

### DIFF
--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -12,12 +12,12 @@ module SimpleCov
     COMMENT_LINE = /^\s*#/.freeze
     WHITESPACE_OR_COMMENT_LINE = Regexp.union(WHITESPACE_LINE, COMMENT_LINE)
 
-    def self.no_cov_block
+    def self.no_cov_line
       /^(\s*)#(\s*)(:#{SimpleCov.nocov_token}:)/o
     end
 
-    def self.no_cov_line
-      /#(\s*)(:#{SimpleCov.nocov_token}:)(\s*)$/o
+    def self.no_cov_inline
+      /\S.*#\s*:#{SimpleCov.nocov_token}:\s*$/o
     end
 
     def self.no_cov_line?(line)
@@ -27,8 +27,8 @@ module SimpleCov
       false
     end
 
-    def self.no_cov_block?(line)
-      no_cov_block.match?(line)
+    def self.no_cov_inline?(line)
+      no_cov_inline.match?(line)
     rescue ArgumentError
       # E.g., line contains an invalid byte sequence in UTF-8
       false
@@ -45,10 +45,10 @@ module SimpleCov
       skipping = false
 
       lines.map do |line|
-        if self.class.no_cov_block?(line)
+        if self.class.no_cov_line?(line)
           skipping = !skipping
           NOT_RELEVANT
-        elsif skipping || self.class.no_cov_line?(line) || self.class.whitespace_line?(line)
+        elsif skipping || self.class.no_cov_inline?(line) || self.class.whitespace_line?(line)
           NOT_RELEVANT
         else
           RELEVANT

--- a/spec/lines_classifier_spec.rb
+++ b/spec/lines_classifier_spec.rb
@@ -65,6 +65,20 @@ describe SimpleCov::LinesClassifier do
         end
       end
 
+      describe ":nocov: one liner" do
+        it "determines :nocov: lines are not-relevant" do
+          classified_lines = subject.classify [
+            "def hi",
+            "raise NotImplementedError # :nocov:",
+            "end",
+            ""
+          ]
+
+          expect(classified_lines.length).to eq 4
+          expect(classified_lines[1]).to be_irrelevant
+        end
+      end
+
       describe ":nocov: blocks" do
         it "determines :nocov: blocks are not-relevant" do
           classified_lines = subject.classify [
@@ -80,21 +94,23 @@ describe SimpleCov::LinesClassifier do
 
         it "determines all lines after a non-closing :nocov: as not-relevant" do
           classified_lines = subject.classify [
+            "puts 'Not relevant' # :nocov:",
             "# :nocov:",
             "puts 'Not relevant'",
             "# :nocov:",
             "puts 'Relevant again'",
             "puts 'Still relevant'",
             "# :nocov:",
-            "puts 'Not relevant till the end'",
+            "puts 'Not relevant till the end' # :nocov:",
             "puts 'Ditto'"
           ]
 
-          expect(classified_lines.length).to eq 8
+          expect(classified_lines.length).to eq 9
 
-          expect(classified_lines[0..2]).to all be_irrelevant
-          expect(classified_lines[3..4]).to all be_relevant
-          expect(classified_lines[5..7]).to all be_irrelevant
+          expect(classified_lines[0]).to be_irrelevant
+          expect(classified_lines[1..3]).to all be_irrelevant
+          expect(classified_lines[4..5]).to all be_relevant
+          expect(classified_lines[6..8]).to all be_irrelevant
         end
       end
     end


### PR DESCRIPTION
Support `nocov` comments at the end of a line to mark it as irrelevant, it's a bit less verbose than blocks to ignore some benign things, i.e:

```ruby
case value
when String
  StringFilter
when Array
  ArrayFilter
else
  raise "Absurd case" # :nocov: 
end
```