### PR TITLE
ignore nil branches during parallel combine

### DIFF
--- a/lib/simplecov/combine/files_combiner.rb
+++ b/lib/simplecov/combine/files_combiner.rb
@@ -16,7 +16,10 @@ module SimpleCov
       #
       def combine(coverage_a, coverage_b)
         combination = {"lines" => Combine.combine(LinesCombiner, coverage_a["lines"], coverage_b["lines"])}
-        combination["branches"] = Combine.combine(BranchesCombiner, coverage_a["branches"], coverage_b["branches"]) if SimpleCov.branch_coverage?
+        if SimpleCov.branch_coverage?
+          branches = Combine.combine(BranchesCombiner, coverage_a["branches"], coverage_b["branches"])
+          combination["branches"] = branches unless branches.nil?
+        end
         combination
       end
     end

--- a/spec/combine/results_combiner_spec.rb
+++ b/spec/combine/results_combiner_spec.rb
@@ -75,31 +75,31 @@ describe SimpleCov::Combine::ResultsCombiner do
       end
 
       it "has proper results for sample_controller.rb" do
-        expect(subject[source_fixture("app/controllers/sample_controller.rb")]["lines"]).to eq([nil, 4, 2, 1, nil, nil, 2, 0, nil, nil])
+        expect(subject[source_fixture("app/controllers/sample_controller.rb")]).to eq({"lines" => [nil, 4, 2, 1, nil, nil, 2, 0, nil, nil]})
       end
 
       it "has proper results for resultset1.rb" do
-        expect(subject[source_fixture("resultset1.rb")]["lines"]).to eq([1, 1, 1, 1])
+        expect(subject[source_fixture("resultset1.rb")]).to eq({"lines" => [1, 1, 1, 1]})
       end
 
       it "has proper results for resultset2.rb" do
-        expect(subject[source_fixture("resultset2.rb")]["lines"]).to eq([nil, 1, 1, nil])
+        expect(subject[source_fixture("resultset2.rb")]).to eq({"lines" => [nil, 1, 1, nil]})
       end
 
       it "has proper results for parallel_tests.rb" do
-        expect(subject[source_fixture("parallel_tests.rb")]["lines"]).to eq([nil, nil, nil, 0])
+        expect(subject[source_fixture("parallel_tests.rb")]).to eq({"lines" => [nil, nil, nil, 0]})
       end
 
       it "has proper results for conditionally_loaded_1.rb" do
-        expect(subject[source_fixture("conditionally_loaded_1.rb")]["lines"]).to eq([nil, 0, 1])
+        expect(subject[source_fixture("conditionally_loaded_1.rb")]).to eq({"lines" => [nil, 0, 1]})
       end
 
       it "has proper results for conditionally_loaded_2.rb" do
-        expect(subject[source_fixture("conditionally_loaded_2.rb")]["lines"]).to eq([nil, 0, 1])
+        expect(subject[source_fixture("conditionally_loaded_2.rb")]).to eq({"lines" => [nil, 0, 1]})
       end
 
       it "has proper results for three.rb" do
-        expect(subject[source_fixture("three.rb")]["lines"]).to eq([nil, 3, 7])
+        expect(subject[source_fixture("three.rb")]).to eq({"lines" => [nil, 3, 7]})
       end
     end
   end


### PR DESCRIPTION
This issue had very similar cause of another pending [PR](https://github.com/simplecov-ruby/simplecov/pull/972): , but it is caused by parallel test. My project is based on ruby 3.1.4
If a parallel test (2 processes) generates two results on the same file:
Result A
`      "/Users/shixian.yang/workspace/test.rb": {
        "lines": [
          1,
          1,
          null
        ]
      },`
Result B
`      "/Users/shixian.yang/workspace/test.rb": {
        "lines": [
          0,
          0,
          null
        ]
      },`
Neither of results have "branches", the merge will generate a `"branches": nil` as a result. Finally it ends up in the error
NoMethodError: undefined method `flat_map' for nil:NilClass.

My plan is to ignore the "branches" field if neither A and B have "branches" exist.

