### PR TITLE
Prevent test_frameworks profile to hide source directories

### DIFF
--- a/lib/simplecov/profiles/test_frameworks.rb
+++ b/lib/simplecov/profiles/test_frameworks.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
 SimpleCov.profiles.define "test_frameworks" do
-  add_filter "/test/"
-  add_filter "/features/"
-  add_filter "/spec/"
-  add_filter "/autotest/"
+  add_filter %r{^/(test|features|spec|autotest)/}
 end


### PR DESCRIPTION
This commit prevents hiding valid production paths like:
- app/models/test/me.rb
- app/models/features/ftw.rb
- app/services/spec/clever.rb
- lib/autotest/forever.rb

Closes https://github.com/simplecov-ruby/simplecov/issues/1016