### PR TITLE
feat: detect QLTY_COVERAGE_TOKEN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,8 +878,8 @@ require "simplecov_json_formatter"
 SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
 ```
 
-> _Note:_ In case you plan to report your coverage results to CodeClimate services, know that SimpleCov will automatically use the
->  JSON formatter along with the HTML formatter when the `CC_TEST_REPORTER_ID` variable is present in the environment.
+> _Note:_ In case you plan to report your coverage results to [Qlty Cloud](https://qlty.sh) services, know that SimpleCov will automatically use the
+>  JSON formatter along with the HTML formatter when the `QLTY_COVERAGE_TOKEN` variable is present in the environment.
 
 ## Available formatters, editor integrations and hosted services
 

--- a/doc/commercial-services.md
+++ b/doc/commercial-services.md
@@ -9,11 +9,6 @@ these integrations with their respective owners.
 
 Upload coverage reports to [codacy.com](https://www.codacy.com/), a hosted (or self-hosted) software quality analysis platform that also includes coverage reporting.
 
-#### [codeclimate](https://github.com/codeclimate/ruby-test-reporter)
-*by [Code Climate](https://codeclimate.com/)*
-
-Upload coverage reports to [codeclimate.com](https://codeclimate.com/), a hosted software quality analysis and that also includes coverage reporting.
-
 #### [codecov](https://github.com/codecov/codecov-ruby)
 *by [Codecov](https://codecov.io/)*
 
@@ -23,3 +18,8 @@ Upload coverage reports to [codecov.io](https://codecov.io/), a hosted coverage 
 *by [Coveralls](https://coveralls.io/)*
 
 Upload coverage reports to [coveralls.io](https://coveralls.io/), a hosted coverage reporting solution.
+
+#### [Qlty Cloud](https://github.com/qltysh/qlty)
+*by [Qlty Software](https://qlty.sh/)*
+
+Upload coverage reports to [Qlty Cloud](https://qlty.sh/), a hosted software quality analysis and that also includes coverage reporting.

--- a/features/config_json_formatter.feature
+++ b/features/config_json_formatter.feature
@@ -26,7 +26,7 @@ Feature:
     Then a JSON coverage report should have been generated in "coverage"
     And the output should contain "JSON Coverage report generated"
 
-  Scenario: When CC_TEST_REPORTER_ID is set in the environment
+  Scenario: When QLTY_COVERAGE_TOKEN is set in the environment
     Given SimpleCov for Test/Unit is configured with:
       """
       require 'simplecov'
@@ -39,7 +39,7 @@ Feature:
       """
     And I set the environment variables to:
       | variable            | value   |
-      | CC_TEST_REPORTER_ID | some-id |
+      | QLTY_COVERAGE_TOKEN | some-id |
 
     When I successfully run `bundle exec rake test`
 

--- a/features/test_unit_basic.feature
+++ b/features/test_unit_basic.feature
@@ -39,7 +39,7 @@ Feature:
   Scenario:
     Given SimpleCov for Test/Unit is configured with:
       """
-      ENV['CC_TEST_REPORTER_ID'] = "9719ac886877886b7e325d1e828373114f633683e429107d1221d25270baeabf"
+      ENV['QLTY_COVERAGE_TOKEN'] = "9719ac886877886b7e325d1e828373114f633683e429107d1221d25270baeabf"
       require 'simplecov'
       SimpleCov.start
       """

--- a/lib/simplecov/default_formatter.rb
+++ b/lib/simplecov/default_formatter.rb
@@ -7,8 +7,14 @@ module SimpleCov
       def from_env(env)
         formatters = [SimpleCov::Formatter::HTMLFormatter]
 
-        # When running under a CI that uses CodeClimate, JSON output is expected
-        if env.fetch("CC_TEST_REPORTER_ID", nil)
+        # When running under a CI that uses Qlty, JSON output is expected
+        # 
+        # CC_TEST_REPORTER_ID is the previous environment variable which was used by
+        # Code Climate's test reporter. QLTY_COVERAGE_TOKEN is the new environment
+        # variable used by Qlty.
+        # 
+        # We retain detection of CC_TEST_REPORTER_ID for backwards compatibility.
+        if env.fetch("CC_TEST_REPORTER_ID", nil) || env.fetch("QLTY_COVERAGE_TOKEN", nil)
           require "simplecov_json_formatter"
           formatters.push(SimpleCov::Formatter::JSONFormatter)
         end

--- a/spec/default_formatter_spec.rb
+++ b/spec/default_formatter_spec.rb
@@ -5,9 +5,9 @@ require "simplecov_json_formatter"
 
 describe SimpleCov::Formatter do
   describe ".from_env" do
-    let(:env) { {"CC_TEST_REPORTER_ID" => "4c9f1de6193f30799e9a5d5c082692abecc1fd2c6aa62c621af7b2a910761970"} }
+    let(:env) { {"QLTY_COVERAGE_TOKEN" => "4c9f1de6193f30799e9a5d5c082692abecc1fd2c6aa62c621af7b2a910761970"} }
 
-    context "when CC_TEST_REPORTER_ID environment variable is set" do
+    context "when QLTY_COVERAGE_TOKEN environment variable is set" do
       it "returns an array containing the HTML and JSON formatters" do
         expect(described_class.from_env(env)).to eq([
                                                       SimpleCov::Formatter::HTMLFormatter,
@@ -16,7 +16,7 @@ describe SimpleCov::Formatter do
       end
     end
 
-    context "when CC_TEST_REPORTER_ID environment variable isn't set" do
+    context "when QLTY_COVERAGE_TOKEN environment variable isn't set" do
       let(:env) { {} }
 
       it "returns an array containing only the HTML formatter" do


### PR DESCRIPTION
Hello and thank you for SimpleCov!

This PR updates the detection for the `CC_TEST_REPORTER_ID` environment variable to also detect the `QLTY_COVERAGE_TOKEN` env var.

Context: As of this year, the Code Climate Quality product has been replaced by the newer [Qlty Cloud](https://qlty.sh/) edition. (Qlty Cloud is operated by the same team previously responsible for Code Climate Quality.)

Qlty Cloud uses the `QLTY_COVERAGE_TOKEN` env var in the same way that Code Climate Quality used `CC_TEST_REPORTER_ID`. This PR ensures JSON code coverage data is automatically generated when it is present.

We discovered that some customers are not aware of the `CC_TEST_REPORTER_ID` behavior and when they switched from `CC_TEST_REPORTER_ID` to `QLTY_COVERAGE_TOKEN` it was confusing that the JSON went missing.

This PR also preserves the `CC_TEST_REPORTER_ID` behavior for backwards compatibility, for anyone where it may be a "load bearing" behavior.

Please let me know if you have any questions about this change!

-Bryan