### PR TITLE
Document explicit receiver in .simplecov file

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ starts it:
 ```ruby
 # .simplecov — configuration only
 SimpleCov.profiles.load 'rails'
-skip 'lib/generators'
-group 'Models', 'app/models'
+SimpleCov.skip 'lib/generators'
+SimpleCov.group 'Models', 'app/models'
 
 # spec/spec_helper.rb
 require 'simplecov'


### PR DESCRIPTION
In the next version of simplecov, all method calls in .simplecov must have an explicit `SimpleCov` receiver.

I tested out the recent changes in https://github.com/rubocop/rubocop-rspec/pull/2177 and found that removing the deprecated `SimpleCov.start` and _not_ adding an explicit receiver ended up in warnings about various methods not being defined on `main`.