### PR TITLE
Fix branch tuple identity mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+main
+====
+
+## Bugfixes
+* Static branch coverage now matches Ruby's runtime branch tuple identities for
+  `unless` and safe-navigation calls, and resultset merges now combine
+  serialized branch tuples by source location instead of by their local
+  sequential ids. This prevents equivalent branches from being duplicated when
+  static and runtime branch extraction assign different ids.
+
 1.0.0.rc3 (2026-06-18)
 ======================
 

--- a/lib/simplecov/combine/branches_combiner.rb
+++ b/lib/simplecov/combine/branches_combiner.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../source_file/ruby_data_parser"
+
 module SimpleCov
   module Combine
     #
@@ -22,14 +24,16 @@ module SimpleCov
       # @return [Hash]
       #
       def combine(coverage_a, coverage_b)
-        [coverage_a, coverage_b].each_with_object({}) do |coverage, combined|
+        combined = [coverage_a, coverage_b].each_with_object({}) do |coverage, memo|
           coverage.each do |condition, branches_inside|
             condition_key = tuple_identity(condition)
-            condition_tuple, merged_branches = combined[condition_key] ||= [condition, {}]
+            condition_tuple, merged_branches = memo[condition_key] ||= [condition, {}]
             merge_branches(merged_branches, branches_inside)
-            combined[condition_key] = [condition_tuple, merged_branches]
+            memo[condition_key] = [condition_tuple, merged_branches]
           end
-        end.values.to_h { |condition, branches| [condition, branches.values.to_h] }
+        end
+
+        combined.values.to_h { |condition, branches| [condition, branches.values.to_h] }
       end
 
       def merge_branches(target, source)
@@ -41,6 +45,7 @@ module SimpleCov
       end
 
       def tuple_identity(tuple)
+        tuple = SourceFile::RubyDataParser.call(tuple)
         type, _id, start_line, start_column, end_line, end_column = tuple
         [type, start_line, start_column, end_line, end_column]
       end

--- a/lib/simplecov/combine/branches_combiner.rb
+++ b/lib/simplecov/combine/branches_combiner.rb
@@ -22,11 +22,27 @@ module SimpleCov
       # @return [Hash]
       #
       def combine(coverage_a, coverage_b)
-        coverage_a.merge(coverage_b) do |_condition, branches_inside_a, branches_inside_b|
-          branches_inside_a.merge(branches_inside_b) do |_branch, a_count, b_count|
-            a_count + b_count
+        [coverage_a, coverage_b].each_with_object({}) do |coverage, combined|
+          coverage.each do |condition, branches_inside|
+            condition_key = tuple_identity(condition)
+            condition_tuple, merged_branches = combined[condition_key] ||= [condition, {}]
+            merge_branches(merged_branches, branches_inside)
+            combined[condition_key] = [condition_tuple, merged_branches]
           end
+        end.values.to_h { |condition, branches| [condition, branches.values.to_h] }
+      end
+
+      def merge_branches(target, source)
+        source.each do |branch, count|
+          branch_key = tuple_identity(branch)
+          branch_tuple, existing_count = target[branch_key]
+          target[branch_key] = [branch_tuple || branch, existing_count ? existing_count + count : count]
         end
+      end
+
+      def tuple_identity(tuple)
+        type, _id, start_line, start_column, end_line, end_column = tuple
+        [type, start_line, start_column, end_line, end_column]
       end
     end
   end

--- a/lib/simplecov/static_coverage_extractor/visitor.rb
+++ b/lib/simplecov/static_coverage_extractor/visitor.rb
@@ -41,12 +41,17 @@ module SimpleCov
       # missing, Coverage synthesizes a `:else` arm attributed to the
       # whole condition's range — we do the same.
       def visit_if_node(node)
-        emit_if_like(node)
+        emit_if_like(node, :if)
         super
       end
 
       def visit_unless_node(node)
-        emit_if_like(node)
+        emit_if_like(node, :unless)
+        super
+      end
+
+      def visit_call_node(node)
+        emit_safe_navigation(node) if node.respond_to?(:safe_navigation?) && node.safe_navigation?
         super
       end
 
@@ -102,12 +107,20 @@ module SimpleCov
       # IfNode and UnlessNode share a shape (predicate + then body +
       # optional else/elsif) but expose the trailing arm under different
       # accessors. `if_like_else_location` hides that split.
-      def emit_if_like(node)
+      def emit_if_like(node, type)
         then_loc = arm_location(node.statements, node.location)
         else_loc = if_like_else_location(node)
-        @branches[build_tuple(:if, node.location)] = {
+        @branches[build_tuple(type, node.location)] = {
           build_tuple(:then, then_loc) => 0,
           build_tuple(:else, else_loc) => 0
+        }
+      end
+
+      def emit_safe_navigation(node)
+        loc = node.location
+        @branches[build_tuple(:"&.", loc)] = {
+          build_tuple(:then, loc) => 0,
+          build_tuple(:else, loc) => 0
         }
       end
 

--- a/lib/simplecov/static_coverage_extractor/visitor.rb
+++ b/lib/simplecov/static_coverage_extractor/visitor.rb
@@ -23,7 +23,7 @@ module SimpleCov
     # the file — `Coverage` uses sequential ids too, so this matches the
     # conventional shape. Only defined when Prism is loadable;
     # `StaticCoverageExtractor.available?` is the runtime gate.
-    class Visitor < ::Prism::Visitor
+    class Visitor < ::Prism::Visitor # rubocop:disable Metrics/ClassLength
       attr_reader :branches, :methods
 
       def initialize

--- a/spec/combine/branches_combiner_spec.rb
+++ b/spec/combine/branches_combiner_spec.rb
@@ -33,5 +33,24 @@ RSpec.describe SimpleCov::Combine::BranchesCombiner do
         }
       )
     end
+
+    it "does not double-count equivalent serialized branch keys from JSON resultsets" do
+      serialized_static = static_branch_coverage.to_h do |condition, branches|
+        [condition.inspect, branches.transform_keys(&:inspect)]
+      end
+      serialized_shifted = shifted_branch_coverage.to_h do |condition, branches|
+        [condition.inspect, branches.transform_keys(&:inspect)]
+      end
+
+      merged = described_class.combine(serialized_static, serialized_shifted)
+
+      expect(merged.size).to eq(1)
+      expect(merged).to eq(
+        "[:if, 9, 110, 12, 110, 34]" => {
+          "[:then, 10, 110, 12, 110, 16]" => 2,
+          "[:else, 11, 110, 12, 110, 34]" => 3
+        }
+      )
+    end
   end
 end

--- a/spec/combine/branches_combiner_spec.rb
+++ b/spec/combine/branches_combiner_spec.rb
@@ -13,23 +13,23 @@ RSpec.describe SimpleCov::Combine::BranchesCombiner do
       }
     end
 
-    let(:runtime_branch_coverage) do
+    let(:shifted_branch_coverage) do
       {
-        [:unless, 9, 110, 12, 110, 34] => {
-          [:else, 10, 110, 12, 110, 34] => 15,
-          [:then, 11, 110, 12, 110, 16] => 0
+        [:if, 12, 110, 12, 110, 34] => {
+          [:then, 13, 110, 12, 110, 16] => 2,
+          [:else, 14, 110, 12, 110, 34] => 3
         }
       }
     end
 
-    it "does not double-count the same branch when static and runtime condition types differ" do
-      merged = described_class.combine(static_branch_coverage, runtime_branch_coverage)
+    it "does not double-count the same branch when equivalent branch ids differ" do
+      merged = described_class.combine(static_branch_coverage, shifted_branch_coverage)
 
       expect(merged.size).to eq(1)
       expect(merged).to eq(
-        [:unless, 9, 110, 12, 110, 34] => {
-          [:then, 11, 110, 12, 110, 16] => 0,
-          [:else, 10, 110, 12, 110, 34] => 15
+        [:if, 9, 110, 12, 110, 34] => {
+          [:then, 10, 110, 12, 110, 16] => 2,
+          [:else, 11, 110, 12, 110, 34] => 3
         }
       )
     end

--- a/spec/combine/branches_combiner_spec.rb
+++ b/spec/combine/branches_combiner_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "helper"
+
+RSpec.describe SimpleCov::Combine::BranchesCombiner do
+  describe ".combine" do
+    let(:static_branch_coverage) do
+      {
+        [:if, 9, 110, 12, 110, 34] => {
+          [:then, 10, 110, 12, 110, 16] => 0,
+          [:else, 11, 110, 12, 110, 34] => 0
+        }
+      }
+    end
+
+    let(:runtime_branch_coverage) do
+      {
+        [:unless, 9, 110, 12, 110, 34] => {
+          [:else, 10, 110, 12, 110, 34] => 15,
+          [:then, 11, 110, 12, 110, 16] => 0
+        }
+      }
+    end
+
+    it "does not double-count the same branch when static and runtime condition types differ" do
+      merged = described_class.combine(static_branch_coverage, runtime_branch_coverage)
+
+      expect(merged.size).to eq(1)
+      expect(merged).to eq(
+        [:unless, 9, 110, 12, 110, 34] => {
+          [:then, 11, 110, 12, 110, 16] => 0,
+          [:else, 10, 110, 12, 110, 34] => 15
+        }
+      )
+    end
+  end
+end

--- a/spec/static_coverage_extractor_spec.rb
+++ b/spec/static_coverage_extractor_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe SimpleCov::StaticCoverageExtractor do
           expect(arms.keys.map(&:first)).to contain_exactly(:then, :else)
         end
 
+        it "matches Coverage for safe navigation" do
+          src = "x = Object.new\nx&.to_s\n"
+          static = static_branches(src)
+          expect(static.keys.first.first).to eq(:"&.")
+          arms = static.values.first
+          expect(arms.keys.map(&:first)).to contain_exactly(:then, :else)
+        end
+
         it "does NOT track `||=` (mirrors Coverage's documented behavior)" do
           src = "@x ||= 1\n"
           # Coverage doesn't emit a branch entry for `||=`, neither do we.

--- a/spec/static_coverage_extractor_spec.rb
+++ b/spec/static_coverage_extractor_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe SimpleCov::StaticCoverageExtractor do
         it "matches Coverage for `unless` block form" do
           src = "x = 1\nunless x > 0\n  :a\nelse\n  :b\nend\n"
           static = static_branches(src)
-          expect(static.keys.first.first).to eq(:if) # unless is normalized to :if in tuple type
+          expect(static.keys.first.first).to eq(:unless)
           arms = static.values.first
           expect(arms.keys.map(&:first)).to contain_exactly(:then, :else)
         end


### PR DESCRIPTION
## Summary

Fix branch tuple identity mismatches that can duplicate equivalent branches when static branch extraction, runtime branch coverage, and serialized resultsets are combined.

This PR:

- emits `:unless` static branch tuples for `Prism::UnlessNode`, matching Ruby Coverage
- emits static `:\"&.\"` branch tuples for safe-navigation calls, matching Ruby Coverage
- merges branch resultset tuples by branch type and source location instead of by the local sequential id
- restores serialized tuple keys through the existing Ruby data parser before comparing branch identity
- adds focused regression specs and a changelog entry

Closes #1206.

## Validation

- `bundle exec rubocop` passes.
- Focused specs: `bundle exec rspec spec/static_coverage_extractor_spec.rb spec/combine/branches_combiner_spec.rb` reports `29 examples, 0 failures, 2 pending`; the command exits `2` because SimpleCov's own dogfood coverage gate requires 100% whole-project coverage on partial spec runs.
- `bundle exec rake` passed RuboCop and the full RSpec suite with `1124 examples, 0 failures, 2 pending` and 100% dogfood line/branch/method coverage, then local Cucumber entered a long retry/failure loop before completion in my environment.

## Environment

- SimpleCov: `1.0.0.rc3`
- Ruby: `ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [x86_64-linux]`