### PR TITLE
Fix generic parallel adapter opt-out and result wait ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,8 @@ main
 ====
 
 ## Bugfixes
-* `SimpleCov.parallel_tests false` now disables the generic
-  `TEST_ENV_NUMBER` adapter as well as the `parallel_tests` gem adapter, so
-  projects that use those environment variables for a different coverage
-  collation flow can opt out consistently.
-* Parallel result coordination now stores the final worker's own resultset
-  before waiting for sibling resultsets, preventing an off-by-one timeout where
-  the final worker reported `N-1` of `N` workers and skipped threshold checks
-  immediately before producing a complete merged report.
+* `SimpleCov.parallel_tests false` now disables the generic `TEST_ENV_NUMBER` adapter as well as the `parallel_tests` gem adapter, so projects that use those environment variables for a different coverage collation flow can opt out consistently. #1209
+* Parallel result coordination now stores the final worker's own resultset before waiting for sibling resultsets, preventing an off-by-one timeout where the final worker reported `N-1` of `N` workers and skipped threshold checks immediately before producing a complete merged report. #1209
 * Static branch coverage now matches Ruby's runtime branch tuple identities for
   `unless` and safe-navigation calls, and resultset merges now combine
   serialized branch tuples by source location instead of by their local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ main
 ====
 
 ## Bugfixes
+* `SimpleCov.parallel_tests false` now disables the generic
+  `TEST_ENV_NUMBER` adapter as well as the `parallel_tests` gem adapter, so
+  projects that use those environment variables for a different coverage
+  collation flow can opt out consistently.
 * Static branch coverage now matches Ruby's runtime branch tuple identities for
   `unless` and safe-navigation calls, and resultset merges now combine
   serialized branch tuples by source location instead of by their local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,9 @@ main
 ====
 
 ## Bugfixes
-* `SimpleCov.parallel_tests false` now disables the generic `TEST_ENV_NUMBER` adapter as well as the `parallel_tests` gem adapter, so projects that use those environment variables for a different coverage collation flow can opt out consistently. #1209
-* Parallel result coordination now stores the final worker's own resultset before waiting for sibling resultsets, preventing an off-by-one timeout where the final worker reported `N-1` of `N` workers and skipped threshold checks immediately before producing a complete merged report. #1209
-* Static branch coverage now matches Ruby's runtime branch tuple identities for
-  `unless` and safe-navigation calls, and resultset merges now combine
-  serialized branch tuples by source location instead of by their local
-  sequential ids. This prevents equivalent branches from being duplicated when
-  static and runtime branch extraction assign different ids.
+* `SimpleCov.parallel_tests false` now disables the generic `TEST_ENV_NUMBER` adapter as well as the `parallel_tests` gem adapter, so projects that use those environment variables for a different coverage collation flow can opt out consistently. See #1209
+* Parallel result coordination now stores the final worker's own resultset before waiting for sibling resultsets, preventing an off-by-one timeout where the final worker reported `N-1` of `N` workers and skipped threshold checks immediately before producing a complete merged report. See #1209
+* Static branch coverage now matches Ruby's runtime branch tuple identities for `unless` and safe-navigation calls, and resultset merges now combine serialized branch tuples by source location instead of by their local sequential ids. This prevents equivalent branches from being duplicated when static and runtime branch extraction assign different ids. See #1207
 
 1.0.0.rc3 (2026-06-18)
 ======================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ main
   `TEST_ENV_NUMBER` adapter as well as the `parallel_tests` gem adapter, so
   projects that use those environment variables for a different coverage
   collation flow can opt out consistently.
+* Parallel result coordination now stores the final worker's own resultset
+  before waiting for sibling resultsets, preventing an off-by-one timeout where
+  the final worker reported `N-1` of `N` workers and skipped threshold checks
+  immediately before producing a complete merged report.
 * Static branch coverage now matches Ruby's runtime branch tuple identities for
   `unless` and safe-navigation calls, and resultset merges now combine
   serialized branch tuples by source location instead of by their local

--- a/lib/simplecov/parallel_adapters/generic.rb
+++ b/lib/simplecov/parallel_adapters/generic.rb
@@ -23,6 +23,8 @@ module SimpleCov
     class GenericAdapter < Base
       class << self
         def active?
+          return false if SimpleCov.parallel_tests == false
+
           ENV.key?("TEST_ENV_NUMBER")
         end
 

--- a/lib/simplecov/parallel_adapters/parallel_tests.rb
+++ b/lib/simplecov/parallel_adapters/parallel_tests.rb
@@ -14,6 +14,8 @@ module SimpleCov
     class ParallelTestsAdapter < Base
       class << self
         def active?
+          return false if SimpleCov.parallel_tests == false
+
           ensure_loaded
           # !! to coerce `defined?` (returns nil or "constant") to a proper bool.
           !!(defined?(::ParallelTests) && ENV.key?("TEST_ENV_NUMBER"))

--- a/lib/simplecov/result_processing.rb
+++ b/lib/simplecov/result_processing.rb
@@ -41,8 +41,8 @@ module SimpleCov
       # If we're using merging of results, store the current result
       # first (if there is one), then merge the results and return those
       if use_merging
-        wait_for_other_processes
         SimpleCov::ResultMerger.store_result(@result) if result?
+        wait_for_other_processes
         @result = SimpleCov::ResultMerger.merged_result
       end
 

--- a/spec/parallel_adapters_spec.rb
+++ b/spec/parallel_adapters_spec.rb
@@ -137,6 +137,16 @@ RSpec.describe SimpleCov::ParallelAdapters do
         ENV["TEST_ENV_NUMBER"] = ""
         expect(described_class.active?).to be true
       end
+
+      it "is false when SimpleCov.parallel_tests is false" do
+        previous = SimpleCov.parallel_tests
+        SimpleCov.parallel_tests false
+        ENV["TEST_ENV_NUMBER"] = "1"
+
+        expect(described_class.active?).to be false
+      ensure
+        SimpleCov.parallel_tests previous
+      end
     end
 
     describe ".first_worker?" do

--- a/spec/parallel_adapters_spec.rb
+++ b/spec/parallel_adapters_spec.rb
@@ -214,6 +214,17 @@ RSpec.describe SimpleCov::ParallelAdapters do
         allow(described_class).to receive(:ensure_loaded)
         expect(described_class.active?).to be false
       end
+
+      it "is false when SimpleCov.parallel_tests is false even if ParallelTests is already loaded" do
+        stub_const("ParallelTests", Class.new)
+        ENV["TEST_ENV_NUMBER"] = "1"
+        previous = SimpleCov.parallel_tests
+        SimpleCov.parallel_tests false
+
+        expect(described_class.active?).to be false
+      ensure
+        SimpleCov.parallel_tests previous
+      end
     end
 
     describe ".first_worker?" do

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -753,6 +753,20 @@ RSpec.describe SimpleCov do
           expect(SimpleCov::ResultMerger).to have_received(:store_result).once
         end
 
+        it "stores the current coverage before waiting for sibling processes" do
+          calls = []
+          allow(SimpleCov::ResultMerger).to receive(:store_result) { calls << :store }
+          allow(described_class).to receive(:wait_for_other_processes) { calls << :wait }
+          allow(SimpleCov::ResultMerger).to receive(:merged_result) do
+            calls << :merge
+            the_merged_result
+          end
+
+          described_class.result
+
+          expect(calls).to eq(%i[store wait merge])
+        end
+
         it "merges the result" do
           expect(described_class.result).to be(the_merged_result)
         end


### PR DESCRIPTION
## Summary

Fixes two parallel coordination issues found while using SimpleCov with an env-var-only parallel runner:

- `SimpleCov.parallel_tests false` now disables the generic `TEST_ENV_NUMBER` adapter as well as the `parallel_tests` gem adapter.
- The current worker's result is stored before waiting for sibling resultsets, so the final worker no longer times out at `N-1 of N` before producing a complete merged report.

Closes #1208.

## Why

The generic adapter honors the same `TEST_ENV_NUMBER` / `PARALLEL_TEST_GROUPS` environment shape as several parallel runners. If a project opts out with `SimpleCov.parallel_tests false`, SimpleCov should not re-enter parallel coordination through the generic adapter.

For result merging, the previous ordering waited for all expected resultset entries before storing the final worker's own result. That made `PARALLEL_TEST_GROUPS` impossible to satisfy in the final worker until after the wait had already timed out.

## Test

```sh
SIMPLECOV_NO_DOGFOOD=1 bundle exec rspec spec/simplecov_spec.rb spec/parallel_adapters_spec.rb
```
