### PR TITLE
Fix `NoMethodError` in `formatters=` for non-Array arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+==========
+
+## Bugfixes
+* Fixed `SimpleCov.formatters=` raising `NoMethodError` when given a single formatter instead of an Array — a regression from 0.22.x, where `MultiFormatter.new` normalized the value internally. This restores the long-documented `SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([...])` pattern, in which `MultiFormatter.new` returns a Class rather than an Array.
+
 1.0.0 (2026-07-12)
 ==================
 

--- a/lib/simplecov/configuration/formatting.rb
+++ b/lib/simplecov/configuration/formatting.rb
@@ -32,7 +32,10 @@ module SimpleCov
     end
 
     # Sets the configured formatters. Equivalent to `formatters [...]`.
+    # Accepts a single formatter as well as an Array, matching the pre-1.0 behavior
+    # where `MultiFormatter.new` normalized its input.
     def formatters=(formatters)
+      formatters = Array(formatters)
       @formatter = formatters.empty? ? nil : SimpleCov::Formatter::MultiFormatter.new(formatters)
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1379,6 +1379,29 @@ RSpec.describe SimpleCov::Configuration do
         expect(config.formatter).to be_nil
         expect(config.formatters).to eq([])
       end
+
+      it "accepts a single formatter that is not wrapped in an Array" do
+        config.formatters = SimpleCov::Formatter::SimpleFormatter
+        expect(config.formatter.new.formatters).to eq([SimpleCov::Formatter::SimpleFormatter])
+      end
+
+      # `SimpleCov.formatters = MultiFormatter.new([...])` is the pattern
+      # the README documented for years (and net-imap still uses).
+      # `MultiFormatter.new` returns a Class, not an Array, so the setter
+      # must normalize its input like the pre-1.0 implementation did.
+      it "accepts a MultiFormatter (a Class) and keeps its format chain working" do
+        formatter = Class.new { def format(_) = "ok" }
+        config.formatters = SimpleCov::Formatter::MultiFormatter.new([formatter])
+
+        result = instance_double(SimpleCov::Result)
+        expect(config.formatter.new.format(result).flatten).to eq(["ok"])
+      end
+
+      it "treats nil as an explicit opt-out" do
+        config.formatters = nil
+        expect(config.formatter).to be_nil
+        expect(config.formatters).to eq([])
+      end
     end
 
     describe "#at_exit" do


### PR DESCRIPTION
simplecov 1.0.0 broke a formatter configuration pattern the README documented for years:

```ruby
SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
  SimpleCov::Formatter::HTMLFormatter,
  SimpleCov::Formatter::JSONFormatter,
])
```

`MultiFormatter.new` returns a `Class`, not an `Array`, so the 1.0.0 setter raised `NoMethodError` on `formatters.empty?`. Up to 0.22.x the setter handed the value straight to `MultiFormatter.new`, whose internal `Array()` call normalized single formatters transparently.

This surfaced in ruby/ruby CI, where net-imap's test helper still uses the pattern above: https://github.com/ruby/ruby/actions/runs/29193505325/job/86652245625?pr=17830

Restore the 0.22.x tolerance by normalizing the setter input with `Array()`. As a side effect `formatters = nil` now opts out of formatting, consistent with the `formatter false` / `formatters []` opt-out semantics introduced in 1.0.0.