### PR TITLE
Explicitly write formatter's status message to STDERR

### DIFF
--- a/lib/simplecov/formatter/html_formatter.rb
+++ b/lib/simplecov/formatter/html_formatter.rb
@@ -32,7 +32,7 @@ module SimpleCov
         copy_static_assets
         # stderr, not stdout: this is a status message, not the program's
         # output. Keeps the line out of pipelines like `rspec -f json`.
-        warn output_message(result) unless @silent
+        $stderr.puts output_message(result) unless @silent # rubocop:disable Style/StderrPuts
       end
 
       # Generate HTML from a pre-existing coverage.json file without

--- a/lib/simplecov/formatter/json_formatter.rb
+++ b/lib/simplecov/formatter/json_formatter.rb
@@ -29,7 +29,7 @@ module SimpleCov
         File.write(path, JSON.pretty_generate(self.class.build_hash(result)))
         # stderr, not stdout: this is a status message, not the program's
         # output. Keeps the line out of pipelines like `rspec -f json`.
-        warn output_message(result) unless @silent
+        $stderr.puts output_message(result) unless @silent # rubocop:disable Style/StderrPuts
       end
 
     private


### PR DESCRIPTION
Using `Kernel.warn` seems it be an overkill here -- some setups track warnings during running test suite; these "warnings" are unaddressable and noisy.