### PR TITLE
fix: memoise key parsing in RubyDataParser to fix combiner performance regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Unreleased
 ## Bugfixes
 * `SimpleCov.formatter` and `SimpleCov.formatters` now accept formatter instances in addition to formatter classes, so constructor options can actually be passed — most notably `SimpleCov::Formatter::HTMLFormatter.new(silent: true)` to suppress the "Coverage report generated" status line. Previously SimpleCov unconditionally called `.new` on whatever was configured, so passing an instance crashed with `NoMethodError` at report time. See #1240.
 
+## Performance
+* Fix 5x performance regression on report combining (introduced in `1.0.0` as a result of using `Ripper#parse` in a hot path) by adding parsed key memoisation to `RubyDataParser.call`.
+
 1.0.2 (2026-07-18)
 ==================
 

--- a/lib/simplecov/source_file/ruby_data_parser.rb
+++ b/lib/simplecov/source_file/ruby_data_parser.rb
@@ -15,10 +15,28 @@ module SimpleCov
 
       # Tests use the real data structures (except for integration tests)
       # so no need to put them through here.
+      #
+      # String parses are memoized: `Combine::BranchesCombiner` and
+      # `Combine::MethodsCombiner` derive a merge identity from every key of
+      # both sides on every pairwise merge, so collating N resultsets parses
+      # each key string N-1 times — and Ripper dominates the wall time of a
+      # large collate.
+      # Key strings repeat across folds and within report building, while the
+      # set of unique keys is bounded by the project's branch and method
+      # count, so a permanent cache stays small. Cached arrays are frozen
+      # element-wise (String class names included, not just the tuple):
+      # every caller destructures without mutating, and sharing one array
+      # across callers must stay that way. The cache key needs no such
+      # care — `Hash#[]=` dups and freezes String keys on its own.
       def call(structure)
         return structure if structure.is_a?(Array)
 
-        parse_array_string(structure.to_s)
+        string = structure.to_s
+        parse_cache[string] ||= parse_array_string(string).each(&:freeze).freeze
+      end
+
+      def parse_cache
+        @parse_cache ||= {} #: Hash[String, untyped]
       end
 
       # Parse a string like '[:if, 0, 3, 4, 3, 21]' or

--- a/sig/internal/simplecov/source_file/ruby_data_parser.rbs
+++ b/sig/internal/simplecov/source_file/ruby_data_parser.rbs
@@ -7,9 +7,19 @@ module SimpleCov
     # #801). The grammar covers symbols, strings, integers, unary minus,
     # and constant paths — every shape Coverage ever emits.
     module RubyDataParser
+      # Memoizes string parses; see the implementation comment on `call`.
+      # Declared in both contexts deliberately: `module_function` also
+      # copies each method as a private instance method, and Steep
+      # type-checks `self?.` bodies in the instance context too, so
+      # dropping the instance-level declaration fails `steep check`.
+      self.@parse_cache: Hash[String, untyped]?
+      @parse_cache: Hash[String, untyped]?
+
       # Tests use the real data structures (except for integration tests)
       # so no need to put them through here.
       def self?.call: (untyped structure) -> untyped
+
+      def self?.parse_cache: () -> Hash[String, untyped]
 
       # Parse a string like '[:if, 0, 3, 4, 3, 21]' or
       # '["ClassName", :method1, 2, 2, 5, 5]' back into a Ruby array.

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -1316,6 +1316,34 @@ RSpec.describe SimpleCov::SourceFile do
         expect { described_class.parse_array_string("42") }.to raise_error(ArgumentError, /array literal/)
       end
     end
+
+    describe ".call" do
+      it "parses a stringified tuple into its array form" do
+        expect(described_class.call("[:if, 0, 3, 4, 3, 21]")).to eq([:if, 0, 3, 4, 3, 21])
+      end
+
+      it "returns arrays untouched and unfrozen" do
+        tuple = [:then, 4, 8, 6, 8, 12]
+
+        expect(described_class.call(tuple)).to be(tuple)
+        expect(tuple).not_to be_frozen
+      end
+
+      it "memoizes string parses, returning one frozen array for equal keys" do
+        first = described_class.call("[:while, 1, 5, 2, 7, 5]")
+        second = described_class.call(+"[:while, 1, 5, 2, 7, 5]")
+
+        expect(second).to be(first)
+        expect(first).to be_frozen
+      end
+
+      it "freezes the elements of a cached tuple, not just the tuple itself" do
+        tuple = described_class.call('["ClassName", :method1, 2, 2, 5, 5]')
+
+        expect(tuple).to eq(["ClassName", :method1, 2, 2, 5, 5])
+        expect(tuple).to all(be_frozen)
+      end
+    end
   end
 
   describe "method-coverage round-trip with a dynamic-symbol method name" do


### PR DESCRIPTION
Measured on a real 66-worker CI merge (~21k files, ~46k branches, branch coverage enabled): the collate step (which merged 66 reports) regressed from ~29s under `0.22` to ~145s (5x slower) under `1.0.0`.

A wall-clock stackprof attributes main time to `Ripper#parse` under `RubyDataParser.parse_array_string`.

Resultset JSON stores keys as stringified Ruby literals (`"[:if, 0, 14, 4, 14, 30]"`), and `RubyDataParser` walks them back into arrays with a Ripper parse. That parse sat on a hot path: `BranchesCombiner` and `MethodsCombiner` derive a merge identity from every key of *both* sides on *every* pairwise merge. Folding N resultsets therefore parsed each key string N-1 times.

This PR adds memoisation to `RubyDataParser.call` to avoid parsing strings that have already been parsed.

Notes:

- The set of unique keys is bounded by the project's branch and method count, so the cache stays reasonably small and needs no eviction.
- Cached arrays are frozen and shared. Every caller (both combiners, `BranchBuilder`, `MethodBuilder`, `SourceFile::Method`) destructures the parsed array without mutating it; freezing enforces that any future mutation surfaces as an error instead of silent cross-caller corruption.
- Array inputs still pass through untouched and unfrozen (in-process results never hit the cache, exactly as before).