### PR TITLE
Improve collate performance

### DIFF
--- a/benchmarks/collate.rb
+++ b/benchmarks/collate.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Phase-by-phase benchmark of `SimpleCov.collate` over a large parallel CI
+# run's worth of resultsets, for the configuration such a run uses:
+#
+#     SimpleCov.collate paths do
+#       enable_coverage :branch
+#       primary_coverage :branch
+#       formatter SimpleCov::Formatter::HTMLFormatter
+#       coverage(:line) { minimum_per_file 70 }
+#       coverage(:branch) { minimum_per_file 80 }
+#     end
+#
+# Input is synthetic: benchmarks/collate/shape.rb holds the statistics it
+# reproduces. Everything — resultsets, source tree, report output
+# and timings — lands under the repository's own tmp/collate-benchmark, which
+# is left in place between runs and printed at the end of each one.
+#
+# Usage:
+#
+#   ruby benchmarks/collate.rb baseline
+#   COUNT=8 ruby benchmarks/collate.rb faster --baseline baseline
+#
+# Environment:
+#   COUNT      merge only the first N resultsets — the knob for a fast
+#              iteration loop; merge cost grows with N (default: 160)
+#   SCALE      divide `Shape::FILES` by this (default: 4, giving ~1,836 files;
+#              SCALE=1 generates the full 7,345)
+#   SKIP       comma-separated trailing phases to skip, e.g. SKIP=format,store
+#   REBUILD    1 to regenerate the fixture from scratch
+#   BREAKDOWN  1 to also attribute the merge phase to the methods inside it
+#              (adds a few percent of overhead — don't use as a baseline)
+#
+# Timings go to tmp/collate-benchmark/timings/<label>.json, so a later run can
+# be compared against them with `--baseline <label>`.
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "simplecov"
+require_relative "collate/cli"
+
+CollateBenchmark::CLI.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/benchmarks/collate/artifact_writer.rb
+++ b/benchmarks/collate/artifact_writer.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require_relative "shape"
+
+module CollateBenchmark
+  # Writes the two artifacts a collate needs on disk: the source tree the
+  # report phase reads, and the resultset shards the merge phase folds.
+  class ArtifactWriter
+    def initialize(files:, project_dir:, result_files_dir:, seed:, progress:)
+      @files = files
+      @project_dir = project_dir
+      @result_files_dir = result_files_dir
+      @rng = Random.new(seed)
+      @progress = progress
+    end
+
+    # The report phase reads every file in the result, so the tree has to exist
+    # with matching line counts. Content only has to classify the same way the
+    # coverage data does and be of realistic width.
+    def write_sources
+      made = {}
+      @files.each_with_index do |file, index|
+        path = File.join(@project_dir, file.relative_path)
+        directory = File.dirname(path)
+        made[directory] ||= FileUtils.mkdir_p(directory) && true
+        File.write(path, source_body(file.lines))
+        @progress.call(index + 1, @files.size, "source files")
+      end
+    end
+
+    # Shards differ only in hit counts, so the structure is mutated in place,
+    # written, and reverted — no per-shard copy of six figures' worth of line
+    # entries.
+    def write_resultsets(count)
+      # One timestamp for the whole set: shards of a real run land seconds
+      # apart, and a single value keeps every shard's byte length identical.
+      timestamp = Time.now.to_i
+      count.times do |index|
+        drift = apply_drift
+        File.write(shard_path(index), resultset_json(timestamp))
+        revert_drift(drift)
+        @progress.call(index + 1, count, "resultsets")
+      end
+    end
+
+  private
+
+    def shard_path(index)
+      File.join(@result_files_dir, ".resultset-#{index}.json")
+    end
+
+    def source_body(lines)
+      lines.each_with_index.map do |hits, index|
+        if hits.nil?
+          "    # notes on why line #{index + 1} behaves the way it does"
+        else
+          "    value_#{index} = compute(record_#{index}, key: :option_#{index % 7})"
+        end
+      end.join("\n") << "\n"
+    end
+
+    def resultset_json(timestamp)
+      coverage = @files.to_h do |file|
+        [File.join(@project_dir, file.relative_path),
+         {"lines" => file.lines, "branches" => file.branches}]
+      end
+      # `JSON.pretty_generate` is what SimpleCov itself writes, and the
+      # resulting file width is a real input to the parse phase.
+      JSON.pretty_generate("RSpec" => {"coverage" => coverage, "timestamp" => timestamp})
+    end
+
+    # Returns undo records so the shared structure can be restored.
+    def apply_drift
+      drift_count.times.filter_map { drift_one_line }
+    end
+
+    def drift_count
+      total = @files.sum { |file| file.lines.size }
+      (total * Shape::SHARD_DRIFT_FRACTION).round
+    end
+
+    def drift_one_line
+      lines = @files[@rng.rand(@files.size)].lines
+      index = @rng.rand(lines.size)
+      previous = lines[index]
+      return nil if previous.nil?
+
+      lines[index] = previous.zero? ? @rng.rand(1..3) : previous + @rng.rand(1..4)
+      [lines, index, previous]
+    end
+
+    def revert_drift(drift)
+      drift.each { |lines, index, previous| lines[index] = previous }
+    end
+  end
+end

--- a/benchmarks/collate/breakdown.rb
+++ b/benchmarks/collate/breakdown.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module CollateBenchmark
+  # Opt-in attribution of the merge phase to the methods inside it, so a change
+  # can be aimed rather than guessed at.
+  #
+  # Each wrapper adds a couple of `clock_gettime` calls per invocation, which is
+  # a few percent on the merge phase — enough that an instrumented run makes a
+  # poor baseline, which is why `Report` records the flag alongside the timings.
+  module Breakdown
+  module_function
+
+    # Labelled as `[description, module, method]`. The modules are resolved
+    # lazily because this file is loaded before `simplecov` is.
+    TARGETS = [
+      ["ResultsetFile.parse (read + JSON)", %w[ResultMerger ResultsetFile], :parse],
+      ["LegacyFormatAdapter.call", %w[ResultMerger LegacyFormatAdapter], :call],
+      ["ResultsCombiner.combine_result_sets", %w[Combine ResultsCombiner], :combine_result_sets],
+      ["FilesCombiner.reconcile_synthesized", %w[Combine FilesCombiner], :reconcile_synthesized],
+      ["LinesCombiner.combine", %w[Combine LinesCombiner], :combine],
+      ["BranchesCombiner.combine", %w[Combine BranchesCombiner], :combine]
+    ].freeze
+
+    # `combine_result_sets` calls the three combiners, so its own row is
+    # reported net of them — otherwise the shares sum to well over 100%.
+    NESTED_IN_RESULTS_COMBINER = ["FilesCombiner.reconcile_synthesized", "LinesCombiner.combine",
+                                  "BranchesCombiner.combine"].freeze
+
+    Row = Struct.new(:label, :seconds, :calls, :share, keyword_init: true)
+
+    def totals
+      @totals ||= Hash.new(0.0)
+    end
+
+    def counts
+      @counts ||= Hash.new(0)
+    end
+
+    def install!
+      TARGETS.each { |label, path, method_name| wrap(label, path.reduce(SimpleCov, :const_get), method_name) }
+    end
+
+    def wrap(label, target, method_name)
+      original = target.method(method_name)
+      target.define_singleton_method(method_name) do |*args, **kwargs, &block|
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        original.call(*args, **kwargs, &block)
+      ensure
+        Breakdown.totals[label] += Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+        Breakdown.counts[label] += 1
+      end
+    end
+
+    def rows(wall)
+      net_totals.sort_by { |_, seconds| -seconds }.map do |label, seconds|
+        Row.new(label: label, seconds: seconds, calls: counts[label], share: seconds / wall * 100)
+      end
+    end
+
+    def net_totals
+      nested = totals.slice(*NESTED_IN_RESULTS_COMBINER).values.sum
+      totals.to_h do |label, seconds|
+        [label, label.start_with?("ResultsCombiner") ? seconds - nested : seconds]
+      end
+    end
+  end
+end

--- a/benchmarks/collate/cli.rb
+++ b/benchmarks/collate/cli.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "shape"
+require_relative "runner"
+
+module CollateBenchmark
+  # Turns `ARGV` and the environment into a `Runner`. See benchmarks/collate.rb
+  # for the documented set of knobs.
+  module CLI
+    DEFAULT_SCALE = 4
+
+    # `resultsets` rather than `count`, which would shadow `Struct#count`.
+    Options = Struct.new(:label, :resultsets, :scale, :skip, :rebuild, :baseline, :breakdown,
+                         keyword_init: true)
+
+    class << self
+      def run(argv)
+        Runner.new(options(argv)).call
+      end
+
+      def options(argv)
+        argv = argv.dup
+        Options.new(
+          label: label(argv),
+          baseline: flag_value(argv, "--baseline"),
+          resultsets: ENV.fetch("COUNT", Shape::RESULTSETS).to_i,
+          scale: ENV.fetch("SCALE", DEFAULT_SCALE).to_i,
+          skip: skip,
+          rebuild: ENV["REBUILD"] == "1",
+          breakdown: ENV["BREAKDOWN"] == "1"
+        )
+      end
+
+      def label(argv)
+        argv.first && !argv.first.start_with?("-") ? argv.shift : "run"
+      end
+
+      def flag_value(argv, flag)
+        index = argv.index(flag)
+        index && argv[index + 1]
+      end
+
+      def skip
+        requested = Set.new(ENV.fetch("SKIP", "").split(",").map(&:strip).reject(&:empty?))
+        unsupported = requested - Runner::SKIPPABLE_PHASES
+        return requested if unsupported.empty?
+
+        raise ArgumentError,
+              "can only SKIP #{Runner::SKIPPABLE_PHASES.join(', ')} (got #{unsupported.to_a.join(', ')})"
+      end
+    end
+  end
+end

--- a/benchmarks/collate/distribution.rb
+++ b/benchmarks/collate/distribution.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module CollateBenchmark
+  # Sampling helpers for turning the measured quantile curves in
+  # `Shape` back into concrete per-file numbers.
+  module Distribution
+  module_function
+
+    # Draw `count` values by walking the inverse CDF at evenly spaced
+    # quantiles — no PRNG, so the distribution is reproduced rather than
+    # sampled — then scale the result to sum to exactly `total`.
+    def samples(curve, count, total:, floor:)
+      raw = Array.new(count) { |index| interpolate(curve, (index + 0.5) / count) }
+      fit_total(raw, total, floor)
+    end
+
+    # Scales `values` to sum to `total`. Scaling preserves the shape of the
+    # distribution; the rounding residual is a handful of lines out of six
+    # figures.
+    def fit_total(values, total, floor)
+      factor = total.to_f / values.sum
+      scaled = values.map { |value| [(value * factor).round, floor].max }
+      absorb_residual(scaled, total - scaled.sum, floor)
+    end
+
+    # Walks the largest entries by ±1 until the total is exact, skipping any
+    # entry already at the floor so a downward correction can't produce a
+    # zero-line file.
+    def absorb_residual(scaled, residual, floor)
+      return scaled if residual.zero?
+
+      step = residual.positive? ? 1 : -1
+      largest_first(scaled).cycle do |index|
+        break if residual.zero?
+        next if step.negative? && scaled[index] <= floor
+
+        scaled[index] += step
+        residual -= step
+      end
+      scaled
+    end
+
+    def largest_first(values)
+      (0...values.size).sort_by { |index| -values[index] }
+    end
+
+    # Piecewise-linear inverse CDF over a {quantile => value} curve.
+    def interpolate(curve, quantile)
+      points = curve.to_a
+      index = points.index { |point_quantile, _| point_quantile >= quantile } || (points.size - 1)
+      return points[index].last if index.zero?
+
+      lerp(points[index - 1], points[index], quantile)
+    end
+
+    def lerp(low, high, quantile)
+      low_quantile, low_value = low
+      high_quantile, high_value = high
+      ratio = (quantile - low_quantile) / (high_quantile - low_quantile)
+      (low_value + ((high_value - low_value) * ratio)).round
+    end
+
+    # Picks a key from a {value => weight} Hash. Weights are the observed
+    # counts, so they need no normalizing.
+    def weighted_choice(weights, rng)
+      target = rng.rand * weights.values.sum
+      running = 0.0
+      weights.each do |value, weight|
+        running += weight
+        return value if running >= target
+      end
+      weights.keys.last
+    end
+  end
+end

--- a/benchmarks/collate/file_structure.rb
+++ b/benchmarks/collate/file_structure.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "distribution"
+require_relative "shape"
+
+module CollateBenchmark
+  # Builds the coverage structure every generated shard shares: the same file
+  # paths, the same line shapes, the same branch keys. That is what real
+  # shards of one suite look like — only their hit counts differ, and
+  # `ArtifactWriter` varies those per shard.
+  class FileStructure
+    # One generated file: its project-relative path, its `lines` array (`nil`
+    # for a non-relevant line) and its `branches` table, keyed by the
+    # stringified tuples Coverage emits once a resultset round-trips through
+    # JSON.
+    Entry = Struct.new(:relative_path, :lines, :branches, keyword_init: true)
+
+    TOP_LEVEL_DIRS = {
+      "app/models" => 22, "app/services" => 18, "app/controllers" => 12, "app/jobs" => 8,
+      "app/serializers" => 6, "app/policies" => 4, "lib" => 20, "config/initializers" => 4,
+      "app/helpers" => 3, "app/mailers" => 3
+    }.freeze
+
+    NOUNS = %w[account widget invoice session token report device policy alert channel
+               profile schedule payment contact endpoint record digest bundle roster
+               ledger transfer webhook receipt cursor snapshot boundary segment].freeze
+    QUALIFIERS = %w[legacy internal external primary shared cached pending archived
+                    inbound outbound derived nested scoped].freeze
+
+    def initialize(scale:, seed:)
+      @scale = scale
+      @rng = Random.new(seed)
+    end
+
+    def call
+      sizes = line_counts
+      conditions = condition_counts(sizes)
+
+      paths(sizes.size).each_with_index.map do |path, index|
+        lines = build_lines(sizes[index])
+        Entry.new(relative_path: path, lines: lines, branches: build_branches(lines, conditions[index]))
+      end
+    end
+
+  private
+
+    def line_counts
+      Distribution.samples(
+        Shape::LINES_PER_FILE, Shape.files(@scale),
+        total: Shape.lines(@scale), floor: 3
+      ).shuffle(random: @rng)
+    end
+
+    # Returns a per-file condition count, 0 for the third of files that carry
+    # no branches. Counts go to branchy files in size order, so the biggest
+    # files hold the most conditions — a stronger correlation than a source
+    # tree really shows, but it avoids handing a 3-line file 51 conditions.
+    def condition_counts(sizes)
+      branchy = branchy_indices(sizes.size)
+      counts = Distribution.samples(
+        Shape::CONDITIONS_PER_BRANCHY_FILE, branchy.size,
+        total: Shape.conditions(@scale), floor: 1
+      )
+
+      assigned = Array.new(sizes.size, 0)
+      branchy.sort_by { |index| sizes[index] }.each_with_index { |index, rank| assigned[index] = counts[rank] }
+      assigned
+    end
+
+    def branchy_indices(count)
+      (0...count).to_a.sample((count * Shape::BRANCHY_FILE_FRACTION).round, random: @rng)
+    end
+
+    # The tree gets a realistic spread of nesting depths — the report sorts and
+    # groups by path, so a flat directory would understate that work. The
+    # trailing index keeps every name unique without a retry loop.
+    def paths(count)
+      Array.new(count) do |index|
+        segments = [Distribution.weighted_choice(TOP_LEVEL_DIRS, @rng)]
+        segments << NOUNS.sample(random: @rng) if @rng.rand < 0.45
+        segments << QUALIFIERS.sample(random: @rng) if @rng.rand < 0.15
+        segments << "#{QUALIFIERS.sample(random: @rng)}_#{NOUNS.sample(random: @rng)}_#{index}.rb"
+        segments.join("/")
+      end
+    end
+
+    def build_lines(size)
+      Array.new(size) do
+        next nil if @rng.rand >= Shape::RELEVANT_LINE_FRACTION
+
+        @rng.rand < Shape::COVERED_RELEVANT_FRACTION ? hit_count : 0
+      end
+    end
+
+    def hit_count
+      ceiling = Distribution.weighted_choice(Shape::HIT_COUNT_TAIL, @rng)
+      ceiling == 1 ? 1 : @rng.rand(2..ceiling)
+    end
+
+    def build_branches(lines, conditions)
+      return {} if conditions.zero?
+
+      # Coverage numbers branch ids sequentially within a file.
+      ids = (0..).each
+      conditions.times.each_with_object({}) do |_, table|
+        add_condition(table, lines.size, ids)
+      end
+    end
+
+    def add_condition(table, max_line, ids)
+      arms = Distribution.weighted_choice(Shape::ARMS_PER_CONDITION, @rng)
+      condition_type, arm_types = classify_condition(arms)
+      start_line = @rng.rand(1..max_line)
+
+      table[tuple_key(condition_type, ids.next, start_line, max_line)] =
+        arm_types.to_h { |arm_type| [tuple_key(arm_type, ids.next, start_line, max_line), arm_hit_count] }
+    end
+
+    # Maps an arm count back to the construct that produces it, which is what
+    # keeps the generated condition- and arm-type tallies faithful: one arm is
+    # a loop body, two is a conditional (or a one-`when` `case`), and three or
+    # more is always a `case`.
+    def classify_condition(arms)
+      case arms
+      when 1 then [Distribution.weighted_choice(Shape::LOOP_CONDITION_TYPES, @rng), [:body]]
+      when 2 then two_arm_condition
+      else [:case, Array.new(arms - 1) { arm_type } << :else]
+      end
+    end
+
+    def two_arm_condition
+      type = Distribution.weighted_choice(Shape::TWO_ARM_CONDITION_TYPES, @rng)
+      [type, [type == :case ? arm_type : :then, :else]]
+    end
+
+    def arm_type
+      @rng.rand < Shape::PATTERN_MATCH_FRACTION ? :in : :when
+    end
+
+    def arm_hit_count
+      @rng.rand < Shape::ZERO_HIT_ARM_FRACTION ? 0 : hit_count
+    end
+
+    # Coverage keys are `[type, id, start_line, start_col, end_line, end_col]`.
+    # Once a resultset round-trips through JSON they arrive as the `inspect`
+    # form of that array, which is exactly what the combiners have to parse —
+    # so the fixture stores them that way, symbol quoting (`:"&."`) included.
+    def tuple_key(type, id, start_line, max_line)
+      end_line = [start_line + @rng.rand(0..3), max_line].min
+      start_col = @rng.rand(2..40)
+      [type, id, start_line, start_col, end_line, start_col + @rng.rand(4..60)].inspect
+    end
+  end
+end

--- a/benchmarks/collate/fixture.rb
+++ b/benchmarks/collate/fixture.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require_relative "artifact_writer"
+require_relative "file_structure"
+require_relative "shape"
+
+module CollateBenchmark
+  # Generates and caches the coverage artifacts a large parallel CI run leaves
+  # behind: N `.resultset-*.json` shards plus the source tree they reference.
+  # See `Shape` for the statistics they reproduce; a fixed seed makes
+  # every machine generate the same paths, line shapes, branch keys and hit
+  # counts (only the shared timestamp differs).
+  #
+  # Everything lands under the repository's own `tmp/`, which is already
+  # git-ignored and already excluded from RuboCop, and is deliberately left
+  # behind after a run so repeated runs and `--baseline` comparisons reuse it.
+  module Fixture
+  module_function
+
+    # Bumping this invalidates cached fixtures whose layout predates it.
+    GENERATOR_VERSION = 1
+    SEED = 20_240_517
+
+    DIR = File.expand_path("../../tmp/collate-benchmark", __dir__)
+    RESULT_FILES_DIR = File.join(DIR, "result_files")
+    PROJECT_DIR = File.join(DIR, "project")
+    COVERAGE_DIR = File.join(DIR, "coverage")
+    TIMINGS_DIR = File.join(DIR, "timings")
+    MANIFEST_PATH = File.join(DIR, "manifest.json")
+
+    Built = Struct.new(:root, :resultset_paths, :file_count, :line_count, :condition_count,
+                       keyword_init: true)
+
+    def dir
+      DIR
+    end
+
+    # @param scale [Integer] divide `Shape::FILES` by this
+    # @param resultsets [Integer] how many shards to make available
+    # @param force [Boolean] regenerate even if a matching fixture is cached
+    def prepare(scale:, resultsets:, force: false)
+      build(scale, resultsets) if force || !cached?(scale, resultsets)
+      built(resultsets)
+    end
+
+    # A cached fixture with *more* shards than we need is still usable — take
+    # the first N. That keeps `COUNT` a runtime knob for quick iteration rather
+    # than a full regeneration trigger. Scale, seed and generator version have
+    # to match exactly, since they change the data itself.
+    def cached?(scale, resultsets)
+      manifest = manifest_on_disk
+      return false unless manifest
+
+      manifest.values_at("generator_version", "seed", "scale") == [GENERATOR_VERSION, SEED, scale] &&
+        manifest["resultsets"].to_i >= resultsets
+    end
+
+    def manifest_on_disk
+      return nil unless File.exist?(MANIFEST_PATH)
+
+      JSON.parse(File.read(MANIFEST_PATH))
+    rescue JSON::ParserError
+      nil
+    end
+
+    def built(resultsets)
+      manifest = manifest_on_disk
+      Built.new(
+        root: PROJECT_DIR,
+        resultset_paths: resultset_paths.first(resultsets),
+        file_count: manifest["files"],
+        line_count: manifest["lines"],
+        condition_count: manifest["conditions"]
+      )
+    end
+
+    # Shards are dotfiles, matching what SimpleCov itself writes, so the glob
+    # has to opt into them. Sorted numerically so a `COUNT` slice is stable.
+    def resultset_paths
+      Dir.glob(File.join(RESULT_FILES_DIR, ".resultset-*.json"))
+         .sort_by { |path| path[/-(\d+)\.json\z/, 1].to_i }
+    end
+
+    def build(scale, resultsets)
+      FileUtils.rm_rf(DIR)
+      FileUtils.mkdir_p([RESULT_FILES_DIR, PROJECT_DIR])
+
+      files = FileStructure.new(scale: scale, seed: SEED).call
+      write_artifacts(files, resultsets)
+      write_manifest(files, scale, resultsets)
+    end
+
+    def write_artifacts(files, resultsets)
+      writer = ArtifactWriter.new(
+        files: files, project_dir: PROJECT_DIR, result_files_dir: RESULT_FILES_DIR,
+        seed: SEED + 1, progress: method(:progress)
+      )
+      writer.write_sources
+      writer.write_resultsets(resultsets)
+    end
+
+    def write_manifest(files, scale, resultsets)
+      manifest = {
+        "generator_version" => GENERATOR_VERSION, "seed" => SEED,
+        "scale" => scale, "resultsets" => resultsets,
+        "files" => files.size,
+        "lines" => files.sum { |file| file.lines.size },
+        "conditions" => files.sum { |file| file.branches.size }
+      }
+      File.write(MANIFEST_PATH, JSON.pretty_generate(manifest))
+    end
+
+    # Carriage-return progress is only readable on a terminal; piped into a log
+    # it would be one enormous line, so print just the final count there.
+    def progress(done, total, label)
+      if $stderr.tty?
+        return unless done == total || (done % 25).zero?
+
+        $stderr.print("\r[fixture] #{label}: #{done}/#{total}")
+        $stderr.puts if done == total
+      elsif done == total
+        warn("[fixture] #{label}: #{total}")
+      end
+    end
+  end
+end

--- a/benchmarks/collate/format.rb
+++ b/benchmarks/collate/format.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CollateBenchmark
+  # Number formatting for the report tables. Kept apart from `Report` so that
+  # class stays about the shape of the output rather than its units.
+  module Format
+  module_function
+
+    # A collate at full scale runs into minutes, so seconds alone stop being
+    # readable past the first phase.
+    def duration(seconds)
+      return format("%.2fs", seconds) if seconds < 60
+
+      format("%<minutes>dm%<seconds>04.1fs", minutes: seconds / 60, seconds: seconds % 60)
+    end
+
+    def delta(now, was)
+      return "-" if was.zero?
+
+      format("%+.1f%%", ((now - was) / was) * 100)
+    end
+
+    def bytes(count)
+      return "n/a" if count.zero?
+
+      format("%.2f GB", count / (1024.0**3))
+    end
+  end
+end

--- a/benchmarks/collate/report.rb
+++ b/benchmarks/collate/report.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require_relative "breakdown"
+require_relative "format"
+require_relative "fixture"
+
+module CollateBenchmark
+  # Prints a run's phase table (optionally against a saved baseline) and
+  # persists its timings so a later run can be compared against them.
+  class Report
+    PHASE_ROW = "%-16<phase>s %12<seconds>s %12<delta>s"
+    BREAKDOWN_ROW = "%-38<label>s %9<seconds>s %10<calls>s %6.1<share>f%%"
+
+    def initialize(run:, timings:, baseline_label:)
+      @run = run
+      @timings = timings
+      @baseline_label = baseline_label
+    end
+
+    def header(fixture)
+      puts
+      puts "SimpleCov collate benchmark — #{@run.label}"
+      puts "  resultsets:   #{fixture.resultset_paths.size}"
+      puts "  fixture:      #{fixture_summary(fixture)}"
+      puts "  skipping:     #{@run.skip.to_a.join(', ')}" if @run.skip.any?
+      puts
+    end
+
+    def fixture_summary(fixture)
+      "#{fixture.file_count} files, #{fixture.line_count} lines, " \
+        "#{fixture.condition_count} branch conditions (1/#{@run.scale} scale)"
+    end
+
+    def call(peak_rss:, files_reported:)
+      baseline = load_baseline
+      phase_table(baseline)
+      breakdown_table if @run.breakdown
+      footer(peak_rss, files_reported)
+      write(peak_rss, files_reported)
+    end
+
+  private
+
+    def phase_table(baseline)
+      puts
+      puts format(PHASE_ROW, phase: "phase", seconds: "seconds", delta: "vs baseline")
+      puts "-" * 41
+      Runner::PHASES.each { |name| phase_row(name, @timings[name], baseline&.dig("phases", name)) }
+      puts "-" * 41
+      phase_row("total", total, baseline&.fetch("total", nil))
+    end
+
+    def phase_row(name, seconds, was)
+      return unless seconds
+
+      puts format(PHASE_ROW, phase: name, seconds: Format.duration(seconds),
+                             delta: was ? Format.delta(seconds, was) : "-")
+    end
+
+    def breakdown_table
+      merge = @timings["merge"]
+      rows = Breakdown.rows(merge)
+
+      puts
+      puts "inside merge (#{Format.duration(merge)})"
+      puts "-" * 66
+      rows.each { |row| puts breakdown_row(row) }
+      puts breakdown_row(unattributed_row(rows, merge))
+    end
+
+    def unattributed_row(rows, merge)
+      seconds = merge - rows.sum(&:seconds)
+      Breakdown::Row.new(label: "unattributed", seconds: seconds, calls: "", share: seconds / merge * 100)
+    end
+
+    def breakdown_row(row)
+      format(BREAKDOWN_ROW, label: row.label, seconds: Format.duration(row.seconds),
+                            calls: row.calls, share: row.share)
+    end
+
+    def footer(peak_rss, files_reported)
+      puts
+      puts "  peak RSS:        #{Format.bytes(peak_rss)}"
+      puts "  files reported:  #{files_reported}" if files_reported
+      puts "  fixture dir:     #{Fixture.dir}"
+      puts "  timings:         #{path_for(@run.label)}"
+    end
+
+    def load_baseline
+      return nil unless @baseline_label
+
+      path = path_for(@baseline_label)
+      unless File.exist?(path)
+        warn "[collate] no baseline timings at #{path}"
+        return nil
+      end
+
+      JSON.parse(File.read(path)).tap { |baseline| warn_if_incomparable(baseline) }
+    end
+
+    def warn_if_incomparable(baseline)
+      return if baseline["resultsets"] == @run.resultsets_used && baseline["scale"] == @run.scale
+
+      warn "[collate] baseline '#{@baseline_label}' merged #{baseline['resultsets']} resultsets at " \
+           "1/#{baseline['scale']} scale, this run merged #{@run.resultsets_used} at 1/#{@run.scale} — " \
+           "the deltas below are not comparable"
+    end
+
+    def write(peak_rss, files_reported)
+      FileUtils.mkdir_p(Fixture::TIMINGS_DIR)
+      timings = {
+        "label" => @run.label, "scale" => @run.scale, "resultsets" => @run.resultsets_used,
+        "phases" => @timings, "total" => total, "peak_rss" => peak_rss,
+        "files_reported" => files_reported, "ruby" => RUBY_DESCRIPTION,
+        # Instrumented runs carry a few percent of wrapper overhead; flagged so
+        # a future comparison knows not to trust this as a baseline.
+        "instrumented" => @run.breakdown
+      }
+      File.write(path_for(@run.label), JSON.pretty_generate(timings))
+    end
+
+    def path_for(label)
+      File.join(Fixture::TIMINGS_DIR, "#{label}.json")
+    end
+
+    def total
+      @timings.values.sum
+    end
+  end
+end

--- a/benchmarks/collate/rss_sampler.rb
+++ b/benchmarks/collate/rss_sampler.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module CollateBenchmark
+  # Polls the process's resident set size on a background thread so a run can
+  # report its peak. Memory matters here: the merge fold rebuilds every hash
+  # and array it touches, so a change that trades allocations for speed (or the
+  # reverse) should be visible.
+  class RssSampler
+    INTERVAL = 0.25
+
+    def initialize
+      @peak = 0
+      @running = true
+      @thread = Thread.new { sample_until_stopped }
+    end
+
+    def peak
+      [@peak, RssSampler.current].max
+    end
+
+    def stop
+      @running = false
+      @thread.join
+      peak
+    end
+
+    # Resident set size in bytes. `ps` behaves the same on macOS and Linux, and
+    # at four samples a second the shell out is cheap next to a multi-minute
+    # collate.
+    def self.current
+      `ps -o rss= -p #{Process.pid}`.to_i * 1024
+    rescue StandardError
+      0
+    end
+
+  private
+
+    def sample_until_stopped
+      while @running
+        @peak = [@peak, RssSampler.current].max
+        sleep INTERVAL
+      end
+    end
+  end
+end

--- a/benchmarks/collate/runner.rb
+++ b/benchmarks/collate/runner.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative "breakdown"
+require_relative "fixture"
+require_relative "report"
+require_relative "rss_sampler"
+
+module CollateBenchmark
+  # Runs the steps `SimpleCov.collate` runs, in the same order, with a timer
+  # around each.
+  #
+  # `collate` itself isn't called because it ends in `Kernel.exit`, and because
+  # a single total wouldn't say which step a change moved. The phases are split
+  # exactly where `ResultMerger.merge_results` splits internally, so `merge`
+  # covers reading and folding the shards and `build_result` covers turning the
+  # folded coverage into `SimpleCov::SourceFile`s.
+  class Runner
+    PHASES = %w[merge build_result store format thresholds].freeze
+    # `merge` and `build_result` produce the inputs every later phase needs, so
+    # only the three trailing phases can be dropped from a run.
+    SKIPPABLE_PHASES = %w[store format thresholds].freeze
+
+    attr_reader :label, :scale, :skip, :breakdown, :resultsets_used
+
+    def initialize(options)
+      @label = options.label
+      @requested_resultsets = options.resultsets
+      @scale = options.scale
+      @skip = options.skip
+      @rebuild = options.rebuild
+      @baseline_label = options.baseline
+      @breakdown = options.breakdown
+      @timings = {}
+    end
+
+    def call
+      fixture = Fixture.prepare(scale: @scale, resultsets: @requested_resultsets, force: @rebuild)
+      @resultsets_used = fixture.resultset_paths.size
+      configure(fixture)
+      Breakdown.install! if @breakdown
+
+      report = Report.new(run: self, timings: @timings, baseline_label: @baseline_label)
+      report.header(fixture)
+      peak_rss = measure(fixture)
+      report.call(peak_rss: peak_rss, files_reported: @files_reported)
+    end
+
+  private
+
+    def measure(fixture)
+      sampler = RssSampler.new
+      run_phases(fixture)
+      sampler.stop
+    end
+
+    # Mirrors the `SimpleCov.collate` configuration block, plus the two things a
+    # real collate gets from its environment: the project root the resultset
+    # paths live under, and a coverage dir to write into.
+    #
+    # `print_errors` is left at its default on purpose — the threshold phase's
+    # work includes reporting each violation, and a warning about dropped source
+    # files is how we'd learn the fixture had gone stale.
+    def configure(fixture)
+      SimpleCov.root(fixture.root)
+      SimpleCov.coverage_dir(Fixture::COVERAGE_DIR)
+      SimpleCov.enable_coverage(:branch)
+      SimpleCov.primary_coverage(:branch)
+      SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+      SimpleCov.coverage(:line) { minimum_per_file 70 }
+      SimpleCov.coverage(:branch) { minimum_per_file 80 }
+    end
+
+    def run_phases(fixture)
+      merged = nil
+      result = nil
+
+      phase("merge") { merged = merge_coverage(fixture.resultset_paths) }
+      phase("build_result") { result = SimpleCov::ResultMerger.create_result(*merged) }
+      phase("store") { SimpleCov::ResultMerger.store_result(result) }
+      phase("format") { result.format! }
+      phase("thresholds") { SimpleCov.result_exit_status(result) }
+
+      @files_reported = result&.files&.size
+    end
+
+    # The read-and-fold loop out of `ResultMerger.merge_results`, stopping short
+    # of `create_result` so source-file building is timed separately.
+    def merge_coverage(paths)
+      remaining = paths.dup
+      initial = valid_results(remaining.shift)
+
+      remaining.each_with_index.reduce(initial) do |memo, (path, index)|
+        progress(index + 2, paths.size)
+        SimpleCov::ResultMerger.merge_coverage(memo, valid_results(path))
+      end
+    end
+
+    def valid_results(path)
+      SimpleCov::ResultMerger.valid_results(path, ignore_timeout: true)
+    end
+
+    def phase(name)
+      return if @skip.include?(name)
+
+      GC.start
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      @timings[name] = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      warn("\r[#{@label}] #{name}: #{format('%.2fs', @timings[name])}#{' ' * 20}")
+    end
+
+    def progress(done, total)
+      return unless $stderr.tty?
+
+      $stderr.print("\r[#{@label}] merge: #{done}/#{total} resultsets")
+    end
+  end
+end

--- a/benchmarks/collate/shape.rb
+++ b/benchmarks/collate/shape.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module CollateBenchmark
+  # The reference shape of a large parallel CI run's coverage artifacts, and
+  # the whole of what the fixture is built from. Every field is an aggregate —
+  # no filenames, no source, no coverage values.
+  #
+  # `scale` divides `FILES` only. Every other field is a per-file distribution
+  # or a ratio, so a scale of 4 yields a quarter of the lines, conditions and
+  # branch arms too, keeping the combiner hotspots in the same proportion as a
+  # full-size run.
+  module Shape
+    RESULTSETS = 160
+
+    FILES = 7345
+    # Headline totals. The sampled distributions are fitted to these so a
+    # fixture reports exactly `total / scale`, rather than whatever the
+    # trapezoidal approximation of a convex quantile curve happens to give
+    # (which ran 2-5% high).
+    LINES = 591_499
+    CONDITIONS = 32_820
+
+    # Lines-per-file quantiles (mean 80.5). Sampled through a
+    # piecewise-linear inverse CDF so the synthetic size distribution matches
+    # rather than clustering on the mean. The curve is dense through the upper
+    # tail on purpose: both this and the condition distribution are sharply
+    # convex above p90, and interpolating that stretch from p90 straight to
+    # the maximum overstates the totals by more than 20%.
+    LINES_PER_FILE = {0.0 => 3, 0.05 => 11, 0.10 => 15, 0.20 => 24, 0.30 => 32, 0.40 => 39,
+                      0.50 => 48, 0.60 => 61, 0.70 => 78, 0.80 => 107, 0.85 => 129,
+                      0.90 => 166, 0.94 => 222, 0.97 => 322, 0.99 => 554, 0.995 => 721,
+                      0.999 => 1300, 1.0 => 2615}.freeze
+
+    # Of all lines, the share Coverage reports a count for. The rest are
+    # `nil`: comments, blanks, `end` keywords.
+    RELEVANT_LINE_FRACTION = 0.4009
+    # Of those, the share with a non-zero count in a *single* shard.
+    COVERED_RELEVANT_FRACTION = 0.4232
+    # Non-zero counts are overwhelmingly 1 (p90 == 1, p99 == 8), with a long
+    # tail up to six figures for hot framework paths. The tail matters because
+    # it is what makes the JSON payload realistically wide.
+    HIT_COUNT_TAIL = {1 => 0.90, 8 => 0.09, 105_077 => 0.01}.freeze
+
+    BRANCHY_FILE_FRACTION = 0.659
+    # Conditions per file, counting only files that have any (mean 6.79).
+    CONDITIONS_PER_BRANCHY_FILE = {0.0 => 1, 0.05 => 1, 0.10 => 1, 0.20 => 1, 0.30 => 2,
+                                   0.40 => 3, 0.50 => 3, 0.60 => 5, 0.70 => 6, 0.80 => 9,
+                                   0.85 => 11, 0.90 => 15, 0.94 => 20, 0.97 => 31, 0.99 => 51,
+                                   0.995 => 77, 0.999 => 140, 1.0 => 246}.freeze
+
+    # Arms-per-condition tally, verbatim (sums to 32,820 conditions). Sampled
+    # by weight, which reproduces the mean of 2.059 without hand-tuning.
+    ARMS_PER_CONDITION = {1 => 70, 2 => 31_872, 3 => 406, 4 => 249, 5 => 97, 6 => 48,
+                          7 => 29, 8 => 14, 9 => 9, 10 => 5, 11 => 2, 12 => 3, 13 => 6,
+                          15 => 2, 16 => 1, 17 => 2, 18 => 2, 25 => 1, 27 => 2}.freeze
+
+    # A two-arm condition is an `if`/`unless`/`&.` (then + else) or, rarely, a
+    # `case` with a single `when`. These weights are the condition-type counts
+    # restricted to two-arm conditions, and they reproduce the full type tally
+    # exactly: `then` arms land at 31,737 (if + unless + `&.`) and `else` at
+    # 32,750 (one per non-loop condition).
+    TWO_ARM_CONDITION_TYPES = {if: 20_401, unless: 6123, "&.": 5213, case: 135}.freeze
+    LOOP_CONDITION_TYPES = {while: 56, until: 14}.freeze
+    # 33 of the 3,021 non-else `case` arms are pattern-matching `in` arms.
+    PATTERN_MATCH_FRACTION = 0.011
+    # Branch arms are almost never taken within a single shard.
+    ZERO_HIT_ARM_FRACTION = 0.9922
+
+    # Shards of the same suite share their file set, line shapes and branch
+    # keys exactly; they differ only in hit counts, and only barely — 3,866 of
+    # 591,499 lines between two adjacent shards.
+    SHARD_DRIFT_FRACTION = 0.0065
+
+    # Scaled headline targets the generated fixture is fitted to.
+    def self.files(scale)
+      (FILES / scale.to_f).round
+    end
+
+    def self.lines(scale)
+      (LINES / scale.to_f).round
+    end
+
+    def self.conditions(scale)
+      (CONDITIONS / scale.to_f).round
+    end
+  end
+end

--- a/lib/simplecov/combine/branches_combiner.rb
+++ b/lib/simplecov/combine/branches_combiner.rb
@@ -25,30 +25,43 @@ module SimpleCov
       #
       def combine(coverage_a, coverage_b)
         merged = {} #: Hash[untyped, [untyped, Hash[untyped, untyped]]]
-        combined = [coverage_a, coverage_b].each_with_object(merged) do |coverage, memo|
+        [coverage_a, coverage_b].each do |coverage|
           coverage.each do |condition, branches_inside|
-            condition_key = tuple_identity(condition)
-            condition_tuple, merged_branches = memo[condition_key] ||= [condition, {}]
-            merge_branches(merged_branches, branches_inside)
-            memo[condition_key] = [condition_tuple, merged_branches]
+            entry = merged[identities[condition]] ||= [condition, {}]
+            merge_branches(entry[1], branches_inside)
           end
         end
 
-        combined.values.to_h { |condition, branches| [condition, branches.values.to_h] }
+        merged.values.to_h { |condition, branches| [condition, branches.values.to_h] }
       end
 
+      # `target` and its pairs are always built by `combine` above, so updating
+      # them in place can't reach data a caller still holds.
       def merge_branches(target, source)
         source.each do |branch, count|
-          branch_key = tuple_identity(branch)
-          branch_tuple, existing_count = target[branch_key]
-          target[branch_key] = [branch_tuple || branch, existing_count ? existing_count + count : count]
+          branch_key = identities[branch]
+          existing = target[branch_key]
+          if existing
+            existing[1] += count
+          else
+            target[branch_key] = [branch, count]
+          end
         end
       end
 
+      # Derives an identity on first sight of a key and keeps it: the pairwise
+      # fold would otherwise re-derive the accumulator's identities on every one
+      # of its merges, always to the same answer. Bounded by the project's
+      # branch count, like `RubyDataParser`'s parse cache.
+      def identities
+        @identities ||= Hash.new { |cache, tuple| cache[tuple] = tuple_identity(tuple) }
+      end
+
+      # Branches match on source span, whatever ids the recording processes
+      # handed them (issue #1233).
       def tuple_identity(tuple)
-        tuple = SourceFile::RubyDataParser.call(tuple)
-        type, _id, start_line, start_column, end_line, end_column = tuple
-        [type, start_line, start_column, end_line, end_column]
+        type, _id, start_line, start_column, end_line, end_column = SourceFile::RubyDataParser.call(tuple)
+        [type, start_line, start_column, end_line, end_column].freeze
       end
     end
   end

--- a/lib/simplecov/combine/branches_combiner.rb
+++ b/lib/simplecov/combine/branches_combiner.rb
@@ -49,12 +49,24 @@ module SimpleCov
         end
       end
 
-      # Derives an identity on first sight of a key and keeps it: the pairwise
-      # fold would otherwise re-derive the accumulator's identities on every one
-      # of its merges, always to the same answer. Bounded by the project's
-      # branch count, like `RubyDataParser`'s parse cache.
+      # Maps a raw key to its interned identity on first sight and keeps it: the
+      # pairwise fold would otherwise re-derive the accumulator's identities on
+      # every one of its merges, always to the same answer. Bounded by the
+      # project's branch count, like `RubyDataParser`'s parse cache.
       def identities
-        @identities ||= Hash.new { |cache, tuple| cache[tuple] = tuple_identity(tuple) }
+        @identities ||= Hash.new do |cache, tuple|
+          identity = tuple_identity(tuple)
+          cache[tuple] = identity_ids[identity] ||= identity_ids.size
+        end
+      end
+
+      # Identities exist only to be `combine`'s hash keys, and `Array#hash` is
+      # not memoized, so keying on the tuple itself rehashed five elements for
+      # every key of both sides of every merge. An Integer hashes as an
+      # immediate. Two keys share an id exactly when their identities are equal,
+      # so the string and array forms of one key still merge together.
+      def identity_ids
+        @identity_ids ||= {} #: Hash[::Array[untyped], Integer]
       end
 
       # Branches match on source span, whatever ids the recording processes

--- a/lib/simplecov/combine/methods_combiner.rb
+++ b/lib/simplecov/combine/methods_combiner.rb
@@ -49,9 +49,16 @@ module SimpleCov
         end
       end
 
-      # Memoized like `BranchesCombiner.identities`.
+      # Memoized and interned like `BranchesCombiner.identities`.
       def identities
-        @identities ||= Hash.new { |cache, key| cache[key] = source_identity(key) }
+        @identities ||= Hash.new do |cache, key|
+          identity = source_identity(key)
+          cache[key] = identity_ids[identity] ||= identity_ids.size
+        end
+      end
+
+      def identity_ids
+        @identity_ids ||= {} #: Hash[::Array[untyped], Integer]
       end
 
       def source_identity(key)

--- a/lib/simplecov/combine/methods_combiner.rb
+++ b/lib/simplecov/combine/methods_combiner.rb
@@ -30,20 +30,33 @@ module SimpleCov
       #
       def combine(coverage_a, coverage_b)
         merged = {} #: Hash[untyped, [untyped, Integer]]
-        [coverage_a, coverage_b].each_with_object(merged) do |coverage, memo|
-          coverage.each do |key, count|
-            method_key = source_identity(key)
-            retained_key, existing = memo[method_key] || [key, 0]
-            memo[method_key] = [retained_key, existing + count]
-          end
-        end
+        [coverage_a, coverage_b].each { |coverage| merge_methods(merged, coverage) }
 
         merged.values.to_h
       end
 
+      # `target` and its pairs are always built by `combine` above, so updating
+      # them in place can't reach data a caller still holds.
+      def merge_methods(target, source)
+        source.each do |key, count|
+          method_key = identities[key]
+          entry = target[method_key]
+          if entry
+            entry[1] += count
+          else
+            target[method_key] = [key, count]
+          end
+        end
+      end
+
+      # Memoized like `BranchesCombiner.identities`.
+      def identities
+        @identities ||= Hash.new { |cache, key| cache[key] = source_identity(key) }
+      end
+
       def source_identity(key)
         _class_name, _method_name, *location = SourceFile::RubyDataParser.call(key)
-        location
+        location.freeze
       end
     end
   end

--- a/sig/internal/simplecov/combine/branches_combiner.rbs
+++ b/sig/internal/simplecov/combine/branches_combiner.rbs
@@ -7,8 +7,10 @@ module SimpleCov
     module BranchesCombiner
       # Memoizes branch identities. Declared in both contexts for the same
       # reason as `RubyDataParser`'s parse cache.
-      self.@identities: Hash[untyped, ::Array[untyped]]?
-      @identities: Hash[untyped, ::Array[untyped]]?
+      self.@identities: Hash[untyped, Integer]?
+      @identities: Hash[untyped, Integer]?
+      self.@identity_ids: Hash[::Array[untyped], Integer]?
+      @identity_ids: Hash[::Array[untyped], Integer]?
 
       #
       # Return merged branches or the existed branch if other is missing.
@@ -26,7 +28,9 @@ module SimpleCov
 
       def self?.merge_branches: (untyped target, untyped source) -> untyped
 
-      def self?.identities: () -> Hash[untyped, ::Array[untyped]]
+      def self?.identities: () -> Hash[untyped, Integer]
+
+      def self?.identity_ids: () -> Hash[::Array[untyped], Integer]
 
       def self?.tuple_identity: (untyped tuple) -> ::Array[untyped]
     end

--- a/sig/internal/simplecov/combine/branches_combiner.rbs
+++ b/sig/internal/simplecov/combine/branches_combiner.rbs
@@ -5,6 +5,11 @@ module SimpleCov
     #
     # Should be called through `SimpleCov.combine`.
     module BranchesCombiner
+      # Memoizes branch identities. Declared in both contexts for the same
+      # reason as `RubyDataParser`'s parse cache.
+      self.@identities: Hash[untyped, ::Array[untyped]]?
+      @identities: Hash[untyped, ::Array[untyped]]?
+
       #
       # Return merged branches or the existed branch if other is missing.
       #
@@ -20,6 +25,8 @@ module SimpleCov
       def self?.combine: (untyped coverage_a, untyped coverage_b) -> untyped
 
       def self?.merge_branches: (untyped target, untyped source) -> untyped
+
+      def self?.identities: () -> Hash[untyped, ::Array[untyped]]
 
       def self?.tuple_identity: (untyped tuple) -> ::Array[untyped]
     end

--- a/sig/internal/simplecov/combine/methods_combiner.rbs
+++ b/sig/internal/simplecov/combine/methods_combiner.rbs
@@ -7,8 +7,10 @@ module SimpleCov
     module MethodsCombiner
       # Memoizes method identities. Declared in both contexts for the same
       # reason as `RubyDataParser`'s parse cache.
-      self.@identities: Hash[untyped, ::Array[untyped]]?
-      @identities: Hash[untyped, ::Array[untyped]]?
+      self.@identities: Hash[untyped, Integer]?
+      @identities: Hash[untyped, Integer]?
+      self.@identity_ids: Hash[::Array[untyped], Integer]?
+      @identity_ids: Hash[::Array[untyped], Integer]?
 
       #
       # Return merged methods or the existing methods if other is missing.
@@ -25,7 +27,9 @@ module SimpleCov
 
       def self?.merge_methods: (untyped target, untyped source) -> untyped
 
-      def self?.identities: () -> Hash[untyped, ::Array[untyped]]
+      def self?.identities: () -> Hash[untyped, Integer]
+
+      def self?.identity_ids: () -> Hash[::Array[untyped], Integer]
 
       def self?.source_identity: (untyped key) -> Array[untyped]
     end

--- a/sig/internal/simplecov/combine/methods_combiner.rbs
+++ b/sig/internal/simplecov/combine/methods_combiner.rbs
@@ -5,6 +5,11 @@ module SimpleCov
     #
     # Should be called through `SimpleCov.combine`.
     module MethodsCombiner
+      # Memoizes method identities. Declared in both contexts for the same
+      # reason as `RubyDataParser`'s parse cache.
+      self.@identities: Hash[untyped, ::Array[untyped]]?
+      @identities: Hash[untyped, ::Array[untyped]]?
+
       #
       # Return merged methods or the existing methods if other is missing.
       #
@@ -17,6 +22,10 @@ module SimpleCov
       # @return [Hash]
       #
       def self?.combine: (untyped coverage_a, untyped coverage_b) -> untyped
+
+      def self?.merge_methods: (untyped target, untyped source) -> untyped
+
+      def self?.identities: () -> Hash[untyped, ::Array[untyped]]
 
       def self?.source_identity: (untyped key) -> Array[untyped]
     end


### PR DESCRIPTION
After upgrading from 0.22 to 1.0.2 our 231k line rails coverage step on CI, split across 160 files from 160 test nodes, increased significantly from ~90sec to nearly 10 minutes. To combat this we implemented parallel collate actions with `Process.fork` (subsequent PR if helpful), bring runtime down to 2m 16s as a workaround allowing us to merge the upgrade and gather real data.

Looking at the performance of `SimpleCov.collate` there are some easier performance wins.

This AI-assisted PR does 3 things broken out by commit:

1. It creates a benchmarking harness to measure `SimpleCov.collate` performance in runtime and memory consumption
2. Memoizes source file parsing which is helpful in large merges
3. Memoizes source file identity computation which is again helpful in large merges

```
5defb23  perf: intern merge identities to Integers
403c498  perf: memoise merge identities and reuse combiner tables

Cumulative, same fixture and machine throughout:

┌────────────┬────────┬────────┐
│            │ merge  │ total  │
├────────────┼────────┼────────┤
│ baseline   │ 8.44s  │ 9.21s  │
├────────────┼────────┼────────┤
│ after both │ 4.47s  │ 5.41s  │
├────────────┼────────┼────────┤
│            │ −47.0% │ −41.2% │
└────────────┴────────┴────────┘
```

Tests of these commits on our codebase reduces parallel collate from 2m 16s => 26s with identical outputs.

I'm happy to split these commits into separate PRs or add more metrics to test their impact.